### PR TITLE
spartan-ecdsa-eth-pcd

### DIFF
--- a/packages/spartan-ecdsa-eth-pcd/test/ETHPubkeyGroupPCD.spec.ts
+++ b/packages/spartan-ecdsa-eth-pcd/test/ETHPubkeyGroupPCD.spec.ts
@@ -71,6 +71,17 @@ describe("ETH pubkey group membership check should work", function () {
     assert.equal(verified, true);
   });
 
+  it("should not verify a broken proof", async function () {
+    const { prove, verify } = ETHPubkeyGroupPCDPackage;
+    const pcd = await prove(args);
+
+    // change merkle root
+    pcd.claim.publicInput.circuitPubInput.merkleRoot = BigInt("0");
+
+    const verified = await verify(pcd);
+    assert.equal(verified, false);
+  });
+
   it("serializing and then deserializing a PCD should result in equal PCDs", async function () {
     const { prove, serialize, deserialize } = ETHPubkeyGroupPCDPackage;
     const pcd = await prove(args);


### PR DESCRIPTION
This PR adds in spartan-ecdsa proving as a new PCD type. @ichub don't accept this yet; I would like this PR to go through a draft of our review process as I develop the guidelines/expectations there.