### PR TITLE
Never regenerate the identity

### DIFF
--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -18,6 +18,7 @@ import {
   loadIdentity,
   loadPCDs,
   loadSelf,
+  saveIdentity,
 } from "../src/localstorage";
 import { ZuState } from "../src/state";
 
@@ -85,12 +86,16 @@ function Router() {
 }
 
 async function loadInitialState(): Promise<ZuState> {
+  let identity = loadIdentity();
+  if (identity == null) {
+    console.log("Generating a new Semaphore identity...");
+    identity = new Identity();
+    saveIdentity(identity);
+  }
+
   const self = loadSelf();
   const pcds = await loadPCDs();
   const encryptionKey = await loadEncryptionKey();
-
-  const identityStr = loadIdentity();
-  const identity = identityStr ? new Identity(identityStr) : undefined;
 
   const bgColor = self ? "gray" : "primary";
 

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -61,7 +61,7 @@ export async function dispatch(
 
   switch (action.type) {
     case "new-passport":
-      return genPassport(action.email, update);
+      return genPassport(state.identity, action.email, update);
     case "save-self":
       return doSaveSelf(action.participant, state, update);
     case "error":
@@ -77,16 +77,14 @@ export async function dispatch(
   }
 }
 
-async function genPassport(email: string, update: ZuUpdate) {
-  // Generate a semaphore identity, save it to the local store, generate an
-  // email magic link. In prod, send email, in dev, display the link.
-
-  // Generate a fresh identity, save in local storage.
-  const identity = new Identity();
-  console.log("Created identity", identity.toString());
-  saveIdentity(identity);
-
-  update({ identity, pendingAction: { type: "new-passport", email } });
+async function genPassport(
+  identity: Identity,
+  email: string,
+  update: ZuUpdate
+) {
+  // Show the NewPassportScreen.
+  // This will save the sema identity & request email verification.
+  update({ pendingAction: { type: "new-passport", email } });
   window.location.hash = "#/new-passport";
 
   const identityPCD = await SemaphoreIdentityPCDPackage.prove({ identity });

--- a/apps/passport-client/src/localstorage.ts
+++ b/apps/passport-client/src/localstorage.ts
@@ -54,8 +54,9 @@ export function saveSelf(self: ZuParticipant): void {
   window.localStorage["self"] = JSON.stringify(self);
 }
 
-export function loadIdentity(): string {
-  return window.localStorage["identity"];
+export function loadIdentity(): Identity | null {
+  const str = window.localStorage["identity"];
+  return str ? new Identity(str) : null;
 }
 
 export function saveIdentity(identity: Identity): void {

--- a/apps/passport-client/src/state.ts
+++ b/apps/passport-client/src/state.ts
@@ -6,7 +6,7 @@ export type PendingAction = { type: "new-passport"; email: string };
 
 export interface ZuState {
   // Zuzalu semaphore identity.
-  identity?: Identity;
+  identity: Identity;
   pcds: PCDCollection;
   pendingAction?: PendingAction;
   encryptionKey?: string;


### PR DESCRIPTION
@gubsheep this lets people finish creating their passport from the spot you were stuck in earlier.

Will reduce the situations in which we have to manually delete a commitment from the DB.


### Summary

Passport app generates a Semaphore identity on first load, saving it in localStorage.

That will be that passport's identity unless
1. The user syncs over another passport
2. The user clears their browser storage

Previously, a new identity was generated every time the user clicks "Generate Passport".

