### PR TITLE
Initial server-side proving setup

### DIFF
--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -1,4 +1,8 @@
-import { PCDGetRequest, ProveRequest } from "@pcd/passport-interface";
+import {
+  PCDGetRequest,
+  PendingStamp,
+  ProveRequest,
+} from "@pcd/passport-interface";
 import { ArgumentTypeName } from "@pcd/pcd-types";
 import {
   SemaphoreGroupPCDArgs,
@@ -68,12 +72,13 @@ export function SemaphoreGroupProveScreen({
       },
     });
 
-    const proofResponse = JSON.parse(await response.text());
-    const serializedPCD = proofResponse.serializedPCD;
-    console.log("Proof complete", serializedPCD);
+    const pendingStamp = (await response.json()) as PendingStamp;
+    console.log("Pending stamp received", pendingStamp);
 
     // Redirect back to requester
-    window.location.href = `${req.returnUrl}?proof=${serializedPCD}`;
+    window.location.href = `${req.returnUrl}?stamp=${JSON.stringify(
+      pendingStamp
+    )}`;
   }, [group]);
 
   const lines: ReactNode[] = [];

--- a/apps/passport-server/src/application.ts
+++ b/apps/passport-server/src/application.ts
@@ -1,4 +1,8 @@
-import { ProveRequest, StampStatus } from "@pcd/passport-interface";
+import {
+  ProveRequest,
+  ProveResponse,
+  StampStatus,
+} from "@pcd/passport-interface";
 import { getHoneycombAPI } from "./apis/honeycombAPI";
 import { getDBClient } from "./database/postgresClient";
 import { startServer } from "./routing/server";
@@ -22,12 +26,14 @@ export async function startApplication() {
   const honeyClient = getHoneycombAPI();
   const queue: Array<ProveRequest> = [];
   const stampStatus: Map<string, StampStatus> = new Map();
+  const stampResult: Map<string, ProveResponse> = new Map();
 
   const context: ApplicationContext = {
     dbClient,
     honeyClient,
     queue,
     stampStatus,
+    stampResult,
   };
 
   // Run all services concurrently.

--- a/apps/passport-server/src/routing/routes/pcdRoutes.ts
+++ b/apps/passport-server/src/routing/routes/pcdRoutes.ts
@@ -1,4 +1,10 @@
-import { ProveRequest, VerifyRequest } from "@pcd/passport-interface";
+import {
+  hashRequest,
+  PendingStamp,
+  ProveRequest,
+  StampStatus,
+  VerifyRequest,
+} from "@pcd/passport-interface";
 import express, { NextFunction, Request, Response } from "express";
 import {
   getSupportedPCDTypes,
@@ -19,8 +25,21 @@ export function initPCDRoutes(
     async (req: Request, res: Response, next: NextFunction) => {
       try {
         const proveRequest: ProveRequest = req.body;
-        const response = await prove(proveRequest);
-        res.status(200).json(response);
+        const hash = hashRequest(proveRequest);
+        context.queue.push(proveRequest);
+        if (context.queue.length == 1) {
+          context.stampStatus.set(hash, StampStatus.IN_PROGRESS);
+          prove(proveRequest, context);
+        } else {
+          context.stampStatus.set(hash, StampStatus.IN_QUEUE);
+        }
+
+        const pending: PendingStamp = {
+          pcdType: proveRequest.pcdType,
+          hash: hash,
+          status: context.stampStatus.get(hash)!,
+        };
+        res.status(200).json(pending);
       } catch (e) {
         next(e);
       }
@@ -52,9 +71,16 @@ export function initPCDRoutes(
   );
 
   app.get(
-    "/pcds/status/:id",
+    "/pcds/status/:hash",
     async (req: Request, res: Response, next: NextFunction) => {
       try {
+        const hash = req.params.hash;
+        const status = context.stampStatus.get(hash);
+        if (status === StampStatus.COMPLETE) {
+          res.status(200).json(context.stampResult.get(hash));
+        } else {
+          res.status(400).send(status);
+        }
       } catch (e) {
         next(e);
       }

--- a/apps/passport-server/src/types.ts
+++ b/apps/passport-server/src/types.ts
@@ -1,4 +1,8 @@
-import { ProveRequest, StampStatus } from "@pcd/passport-interface";
+import {
+  ProveRequest,
+  ProveResponse,
+  StampStatus,
+} from "@pcd/passport-interface";
 import Libhoney from "libhoney";
 import { Client } from "pg";
 
@@ -7,4 +11,5 @@ export interface ApplicationContext {
   honeyClient: Libhoney | null;
   queue: Array<ProveRequest>;
   stampStatus: Map<string, StampStatus>;
+  stampResult: Map<string, ProveResponse>;
 }

--- a/packages/passport-interface/src/StampUtils.ts
+++ b/packages/passport-interface/src/StampUtils.ts
@@ -1,9 +1,9 @@
-import { createHash } from "crypto";
+import { sha256 } from "js-sha256";
 import { ProveRequest } from "./RequestTypes";
 
 export function hashRequest(req: ProveRequest): string {
   const reqString = JSON.stringify(req);
-  return createHash("sha256").update(reqString).digest("hex");
+  return sha256(reqString);
 }
 
 export interface PendingStamp {
@@ -14,7 +14,6 @@ export interface PendingStamp {
 
 export enum StampStatus {
   IN_QUEUE = "in queue",
-  NEXT_UP = "next up",
   IN_PROGRESS = "in progress",
   COMPLETE = "complete",
 }


### PR DESCRIPTION
Still need to integrate the `PendingStamp` fully with consumer-client, @dcposch where is the code for message passing instead of URL passing set up exactly? I can't quite hunt down where that logic is stored

We are starting with a slightly jank in-memory queue, but will move to a Postgres based solution to avoid concurrency problems and be able to have the queue survive any server restarts / redeploys.