### PR TITLE
Logging server-side proving routes to debug /pcds requests hanging

### DIFF
--- a/apps/passport-server/src/routing/routes/pcdRoutes.ts
+++ b/apps/passport-server/src/routing/routes/pcdRoutes.ts
@@ -19,10 +19,12 @@ export async function initPCDRoutes(
 ): Promise<void> {
   await initPackages();
 
+  console.log("initPCDRoutes setting up /pcds/prove");
   app.post(
     "/pcds/prove",
     async (req: Request, res: Response, next: NextFunction) => {
       try {
+        console.log("/pcds/prove received:", req.body);
         const request: ProveRequest = req.body;
         const pending: PendingPCD = await enqueueProofRequest(request);
         res.status(200).json(pending);
@@ -32,6 +34,7 @@ export async function initPCDRoutes(
     }
   );
 
+  console.log("initPCDRoutes setting up /pcds/supported");
   app.get(
     "/pcds/supported",
     async (req: Request, res: Response, next: NextFunction) => {
@@ -43,10 +46,12 @@ export async function initPCDRoutes(
     }
   );
 
+  console.log("initPCDRoutes setting up /pcds/status");
   app.post(
     "/pcds/status",
     async (req: Request, res: Response, next: NextFunction) => {
       try {
+        console.log("/pcds/status received:", req.body);
         const statusRequest: StatusRequest = req.body;
         const statusResponse: StatusResponse = getPendingPCDStatus(
           statusRequest.hash

--- a/apps/passport-server/src/routing/server.ts
+++ b/apps/passport-server/src/routing/server.ts
@@ -28,7 +28,10 @@ export async function startServer(
     app.use(express.json());
     app.use(cors());
 
-    routes.forEach((r) => r(app, context));
+    routes.forEach((r) => {
+      console.log("startServer initializing:", r);
+      r(app, context);
+    });
 
     app.use(
       cors({

--- a/apps/passport-server/src/services/proving.ts
+++ b/apps/passport-server/src/services/proving.ts
@@ -36,16 +36,24 @@ const packages: PCDPackage[] = [
 
 export async function initPackages() {
   const fullPath = path.join(__dirname, "../../public/semaphore-artifacts");
+  console.log("initPackages __dirname:", __dirname);
+  console.log("initPackages current working directory:", process.cwd());
+  console.log("initPackages fullPath:", fullPath);
+  console.log("initPackages fullPath with zkey: ", fullPath + "/16.zkey");
 
-  await SemaphoreGroupPCDPackage.init!({
-    wasmFilePath: fullPath + "/16.wasm",
-    zkeyFilePath: fullPath + "/16.zkey",
-  });
+  try {
+    await SemaphoreGroupPCDPackage.init!({
+      wasmFilePath: fullPath + "/16.wasm",
+      zkeyFilePath: fullPath + "/16.zkey",
+    });
 
-  await SemaphoreSignaturePCDPackage.init!({
-    wasmFilePath: fullPath + "/16.wasm",
-    zkeyFilePath: fullPath + "/16.zkey",
-  });
+    await SemaphoreSignaturePCDPackage.init!({
+      wasmFilePath: fullPath + "/16.wasm",
+      zkeyFilePath: fullPath + "/16.zkey",
+    });
+  } catch (e) {
+    console.error("initPackages error during init:", e);
+  }
 }
 
 function getPackage(name: string) {


### PR DESCRIPTION
Added the following logs to see if we can figure out why /pcds requests are hanging. It seems like they are not even being initialized, and likely due to the PCDPackages not being properly initialized with the right artifacts.

- initPCDs
    - log the directory name
    - log the cwd
    - try to initialize and see what errors we get
- Initializing routes
    - Check that all routes are being initialized in startServer
- Log initializing the various API endpoints
    - See if they're even getting initialized