### PR TITLE
Add instant feedback on ProveScreens after user requests proof

### DIFF
--- a/apps/passport-client/components/core/RippleLoader.tsx
+++ b/apps/passport-client/components/core/RippleLoader.tsx
@@ -1,0 +1,61 @@
+import styled, { keyframes } from "styled-components";
+
+/**
+ * Source: https://loading.io/css/
+ *
+ * Usage:
+ *  <RippleContainer>
+ *    <Ripple />
+ *    <Ripple />
+ *  </RippleContainer>
+ */
+
+const ripple = keyframes`
+  0% {
+    top: 36px;
+    left: 36px;
+    width: 0;
+    height: 0;
+    opacity: 0;
+  }
+  4.9% {
+    top: 36px;
+    left: 36px;
+    width: 0;
+    height: 0;
+    opacity: 0;
+  }
+  5% {
+    top: 36px;
+    left: 36px;
+    width: 0;
+    height: 0;
+    opacity: 1;
+  }
+  100% {
+    top: 0px;
+    left: 0px;
+    width: 72px;
+    height: 72px;
+    opacity: 0;
+  }
+`;
+
+export const RippleContainer = styled.div`
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+`;
+
+export const Ripple = styled.div`
+  position: absolute;
+  border: 4px solid #fff;
+  opacity: 1;
+  border-radius: 50%;
+  animation: ${ripple} 1s cubic-bezier(0, 0.2, 0.8, 1) infinite;
+
+  &:nth-child(2) {
+    animation-delay: -0.5s;
+  }
+`;

--- a/apps/passport-client/components/core/RippleLoader.tsx
+++ b/apps/passport-client/components/core/RippleLoader.tsx
@@ -1,61 +1,80 @@
+import React from "react";
 import styled, { keyframes } from "styled-components";
 
 /**
  * Source: https://loading.io/css/
  *
  * Usage:
- *  <RippleContainer>
- *    <Ripple />
- *    <Ripple />
- *  </RippleContainer>
+ * <RippleLoaderWrapper>
+ *  <RippleLoader>
+ *     <div></div>
+ *     <div></div>
+ *  </RippleLoader>
+ * <RippleLoaderWrapper/>
  */
 
 const ripple = keyframes`
-  0% {
-    top: 36px;
-    left: 36px;
-    width: 0;
-    height: 0;
-    opacity: 0;
-  }
-  4.9% {
-    top: 36px;
-    left: 36px;
-    width: 0;
-    height: 0;
-    opacity: 0;
-  }
-  5% {
-    top: 36px;
-    left: 36px;
-    width: 0;
-    height: 0;
-    opacity: 1;
-  }
-  100% {
-    top: 0px;
-    left: 0px;
-    width: 72px;
-    height: 72px;
-    opacity: 0;
-  }
+ 0% {
+   top: 36px;
+   left: 36px;
+   width: 0;
+   height: 0;
+   opacity: 0;
+ }
+ 4.9% {
+   top: 36px;
+   left: 36px;
+   width: 0;
+   height: 0;
+   opacity: 0;
+ }
+ 5% {
+   top: 36px;
+   left: 36px;
+   width: 0;
+   height: 0;
+   opacity: 1;
+ }
+ 100% {
+   top: 0px;
+   left: 0px;
+   width: 72px;
+   height: 72px;
+   opacity: 0;
+ }
 `;
 
-export const RippleContainer = styled.div`
+export const RippleLoaderWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;
+
+export const RippleLoaderInner = styled.div`
   display: inline-block;
   position: relative;
   width: 80px;
   height: 80px;
-`;
-
-export const Ripple = styled.div`
-  position: absolute;
-  border: 4px solid #fff;
-  opacity: 1;
-  border-radius: 50%;
-  animation: ${ripple} 1s cubic-bezier(0, 0.2, 0.8, 1) infinite;
-
-  &:nth-child(2) {
+  & > div {
+    position: absolute;
+    border: 4px solid var(--accent-dark);
+    opacity: 1;
+    border-radius: 50%;
+    animation: ${ripple} 1s cubic-bezier(0, 0.2, 0.8, 1) infinite;
+  }
+  & > div:nth-child(2) {
     animation-delay: -0.5s;
   }
 `;
+
+export const RippleLoader = () => {
+  return (
+    <RippleLoaderWrapper>
+      <RippleLoaderInner>
+        <div></div>
+        <div></div>
+      </RippleLoaderInner>
+    </RippleLoaderWrapper>
+  );
+};

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
@@ -10,6 +10,7 @@ import { requestPendingPCD } from "../../../src/api/requestPendingPCD";
 import { DispatchContext } from "../../../src/dispatch";
 import { err } from "../../../src/util";
 import { Button, H1, Spacer } from "../../core";
+import { RippleLoader } from "../../core/RippleLoader";
 import { AppHeader } from "../../shared/AppHeader";
 import { PCDArgs } from "../../shared/PCDArgs";
 
@@ -25,11 +26,13 @@ export function GenericProveScreen({ req }: { req: PCDGetRequest }) {
   const [state, dispatch] = useContext(DispatchContext);
   const [args, setArgs] = useState(JSON.parse(JSON.stringify(req.args)));
   const [error, setError] = useState<Error | undefined>();
+  const [proving, setProving] = useState(false);
 
   const pcdPackage = state.pcds.getPackage(req.pcdType);
 
   const onProveClick = useCallback(async () => {
     try {
+      setProving(true);
       if (req.options?.proveOnServer === true) {
         const serverReq: ProveRequest = {
           pcdType: req.pcdType,
@@ -48,6 +51,7 @@ export function GenericProveScreen({ req }: { req: PCDGetRequest }) {
       }
     } catch (e) {
       setError(e);
+      setProving(false);
     }
   }, [
     args,
@@ -87,7 +91,11 @@ export function GenericProveScreen({ req }: { req: PCDGetRequest }) {
           <Spacer h={16} />
         </>
       )}
-      <Button onClick={onProveClick}>PROVE</Button>
+      {proving ? (
+        <RippleLoader />
+      ) : (
+        <Button onClick={onProveClick}>Prove</Button>
+      )}
       <Spacer h={64} />
     </Container>
   );

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
@@ -8,7 +8,7 @@ import { useCallback, useContext, useState } from "react";
 import styled from "styled-components";
 import { requestPendingPCD } from "../../../src/api/requestPendingPCD";
 import { DispatchContext } from "../../../src/dispatch";
-import { err } from "../../../src/util";
+import { err, sleep } from "../../../src/util";
 import { Button, H1, Spacer } from "../../core";
 import { RippleLoader } from "../../core/RippleLoader";
 import { AppHeader } from "../../shared/AppHeader";
@@ -33,6 +33,11 @@ export function GenericProveScreen({ req }: { req: PCDGetRequest }) {
   const onProveClick = useCallback(async () => {
     try {
       setProving(true);
+
+      // Give the UI has a chance to update to the 'loading' state before the
+      // potentially blocking proving operation kicks off
+      sleep(200);
+
       if (req.options?.proveOnServer === true) {
         const serverReq: ProveRequest = {
           pcdType: req.pcdType,

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -15,6 +15,7 @@ import styled from "styled-components";
 import { requestPendingPCD } from "../../../src/api/requestPendingPCD";
 import { DispatchContext } from "../../../src/dispatch";
 import { Button } from "../../core";
+import { RippleLoader } from "../../core/RippleLoader";
 
 export function SemaphoreGroupProveScreen({
   req,
@@ -77,10 +78,12 @@ export function SemaphoreGroupProveScreen({
     lines.push(
       <p>You're proving that you're one of {group.members.length} members</p>
     );
-    lines.push(<Button onClick={onProve}>Prove</Button>);
   }
-  if (proving) {
-    lines.push(<p>Proving...</p>);
+
+  if (!proving) {
+    lines.push(<Button onClick={onProve}>Prove</Button>);
+  } else {
+    lines.push(<RippleLoader />);
   }
 
   return (

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -14,6 +14,7 @@ import { ReactNode, useCallback, useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 import { requestPendingPCD } from "../../../src/api/requestPendingPCD";
 import { DispatchContext } from "../../../src/dispatch";
+import { sleep } from "../../../src/util";
 import { Button } from "../../core";
 import { RippleLoader } from "../../core/RippleLoader";
 
@@ -41,6 +42,11 @@ export function SemaphoreGroupProveScreen({
   const onProve = useCallback(async () => {
     try {
       setProving(true);
+
+      // Give the UI has a chance to update to the 'loading' state before the
+      // potentially blocking proving operation kicks off
+      sleep(200);
+
       const args = await fillArgs(state.identity, group, req.args);
 
       if (req.options?.proveOnServer === true) {

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
@@ -12,6 +12,7 @@ import { ReactNode, useCallback, useContext, useState } from "react";
 import styled from "styled-components";
 import { requestPendingPCD } from "../../../src/api/requestPendingPCD";
 import { DispatchContext } from "../../../src/dispatch";
+import { sleep } from "../../../src/util";
 import { Button, Spacer } from "../../core";
 import { RippleLoader } from "../../core/RippleLoader";
 
@@ -26,6 +27,11 @@ export function SemaphoreSignatureProveScreen({
   const onProve = useCallback(async () => {
     try {
       setProving(true);
+
+      // Give the UI has a chance to update to the 'loading' state before the
+      // potentially blocking proving operation kicks off
+      sleep(200);
+
       const modifiedArgs = cloneDeep(req.args);
       const args = await fillArgs(
         state.identity,

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
@@ -13,6 +13,7 @@ import styled from "styled-components";
 import { requestPendingPCD } from "../../../src/api/requestPendingPCD";
 import { DispatchContext } from "../../../src/dispatch";
 import { Button, Spacer } from "../../core";
+import { RippleLoader } from "../../core/RippleLoader";
 
 export function SemaphoreSignatureProveScreen({
   req,
@@ -75,10 +76,10 @@ export function SemaphoreSignatureProveScreen({
     );
   }
 
-  lines.push(<Button onClick={onProve}>Prove</Button>);
-
-  if (proving) {
-    lines.push(<p>Proving...</p>);
+  if (!proving) {
+    lines.push(<Button onClick={onProve}>Prove</Button>);
+  } else {
+    lines.push(<RippleLoader />);
   }
 
   return (

--- a/apps/passport-client/src/util.ts
+++ b/apps/passport-client/src/util.ts
@@ -1,6 +1,14 @@
 import { v4 as uuid } from "uuid";
 import { Dispatcher } from "./dispatch";
 
+export async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}
+
 export function err(dispatch: Dispatcher, title: string, message: string) {
   dispatch({
     type: "error",


### PR DESCRIPTION
Resolves #149 

I really liked the ripple loading symbol from https://loading.io/css. Something about the pulsing made it feel like the passport was slowly trying to mine this proof that the user requested. There's a lot of other fun loading bars there, I'm down to get one of the vanity ones from https://loading.io/spinner/ (the fidget spinner one is GAS) and/or rotate between a few. I think making the proving experience feel fresh and new will make the UX much more delightful, and I would love to get more ownership over making that happen.