### PR TITLE
Removed list of members from SemaphoreGroupPCD URL

### DIFF
--- a/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
@@ -36,7 +36,10 @@ export function ProveScreen() {
 
   if (request.options?.genericProveScreen) {
     return <GenericProveScreen req={request} />;
-  } else if (request.pcdType === SemaphoreGroupPCDPackage.name) {
+  } else if (
+    request.pcdType === SemaphoreGroupPCDPackage.name &&
+    request.args.group.remoteUrl !== undefined
+  ) {
     title = "Prove membership";
     body = <SemaphoreGroupProveScreen req={request} />;
   } else if (request.pcdType === SemaphoreSignaturePCDPackage.name) {

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -54,6 +54,12 @@ export function SemaphoreGroupProveScreen({
       } else {
         const { prove, serialize } = SemaphoreGroupPCDPackage;
         const pcd = await prove(args);
+
+        // We remove the group from the claim; we already loaded the
+        // group from a URL and can do it again on the consumer-client side to
+        // avoid sending a large group over
+        pcd.claim.group.members = [];
+
         const serializedPCD = await serialize(pcd);
         window.location.href = `${req.returnUrl}?proof=${JSON.stringify(
           serializedPCD

--- a/packages/passport-interface/src/SemaphoreGroupIntegration.ts
+++ b/packages/passport-interface/src/SemaphoreGroupIntegration.ts
@@ -1,6 +1,5 @@
 import { ArgumentTypeName } from "@pcd/pcd-types";
 import {
-  deserializeSemaphoreGroup,
   SemaphoreGroupPCD,
   SemaphoreGroupPCDPackage,
   SerializedSemaphoreGroup,
@@ -55,7 +54,8 @@ export function requestZuzaluMembershipUrl(
 
 /**
  * React hook which can be used on 3rd party application websites that
- * parses and verifies a PCD representing a Semaphore group membership proof.
+ * parses and verifies a PCD representing a Semaphore group membership proof from
+ * a specific semaphoreGroupUrl.
  */
 export function useSemaphorePassportProof(
   semaphoreGroupUrl: string,
@@ -102,11 +102,11 @@ async function verifyProof(
   serializedExpectedGroup: SerializedSemaphoreGroup
 ): Promise<boolean> {
   const { verify } = SemaphoreGroupPCDPackage;
+
+  // We add the group back to the claim; for client-side proofs the list of
+  // members is not sent to avoid long URL redirects from the passport
+  pcd.claim.group = serializedExpectedGroup;
+
   const verified = await verify(pcd);
-  if (!verified) return false;
-
-  const expectedGroup = deserializeSemaphoreGroup(serializedExpectedGroup);
-  const pcdGroup = deserializeSemaphoreGroup(pcd.claim.group);
-
-  return expectedGroup.root.toString() === pcdGroup.root.toString();
+  return verified;
 }


### PR DESCRIPTION
Resolves #150

SemaphoreGroupProveScreen already loads the group in via a URL by default, so this means the client page that is requesting this proof must also have access to the URL. Thus, it can load in the group on its own without having to send the entire list of members over the wire as part of SemaphoreGroupPCD's claim's SerializedSemaphoreGroup.

This should resolve any long URL errors that other sites are having, given they are using the functions in `SemaphoreGroupIntegration.ts` from `@pcd/passport-interface`