### PR TITLE
Cleaning up SemaphoreGroupPCD prove screen + related interfaces

### DIFF
--- a/apps/consumer-client/package.json
+++ b/apps/consumer-client/package.json
@@ -11,27 +11,27 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@semaphore-protocol/group": "^3.2.3",
-    "@semaphore-protocol/identity": "^3.2.3",
-    "next": "^13.1.1",
     "@pcd/passport-interface": "0.3.0",
     "@pcd/pcd-types": "0.3.0",
     "@pcd/semaphore-group-pcd": "0.3.0",
     "@pcd/semaphore-identity-pcd": "0.3.0",
+    "@semaphore-protocol/group": "^3.2.3",
+    "@semaphore-protocol/identity": "^3.2.3",
+    "next": "^13.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "styled-components": "^5.3.6"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "@pcd/eslint-config-custom": "0.3.0",
+    "@pcd/tsconfig": "0.3.0",
     "@types/expect": "^24.3.0",
     "@types/node": "^17.0.12",
     "@types/react": "^18.0.22",
     "@types/react-dom": "^18.0.7",
     "@types/styled-components": "^5.1.26",
     "eslint": "7.32.0",
-    "@pcd/eslint-config-custom": "0.3.0",
-    "@pcd/tsconfig": "0.3.0",
     "typescript": "^4.5.3"
   }
 }

--- a/apps/consumer-client/pages/examples/group-proof.tsx
+++ b/apps/consumer-client/pages/examples/group-proof.tsx
@@ -4,7 +4,7 @@ import {
   usePassportPopupMessages,
   usePCDMultiplexer,
   usePendingPCD,
-  useSemaphorePassportProof,
+  useSemaphoreGroupProof,
 } from "@pcd/passport-interface";
 import { ArgumentTypeName } from "@pcd/pcd-types";
 import { SemaphoreGroupPCDPackage } from "@pcd/semaphore-group-pcd";
@@ -30,7 +30,7 @@ export default function Page() {
     PASSPORT_SERVER_URL
   );
   const pcdStr = usePCDMultiplexer(passportPCDStr, serverPCDStr);
-  const { proof, group, valid } = useSemaphorePassportProof(
+  const { proof, group, valid } = useSemaphoreGroupProof(
     SEMAPHORE_GROUP_URL,
     pcdStr
   );

--- a/apps/consumer-client/pages/examples/group-proof.tsx
+++ b/apps/consumer-client/pages/examples/group-proof.tsx
@@ -7,7 +7,10 @@ import {
   useSemaphoreGroupProof,
 } from "@pcd/passport-interface";
 import { ArgumentTypeName } from "@pcd/pcd-types";
-import { SemaphoreGroupPCDPackage } from "@pcd/semaphore-group-pcd";
+import {
+  generateMessageHash,
+  SemaphoreGroupPCDPackage,
+} from "@pcd/semaphore-group-pcd";
 import { useState } from "react";
 import { CodeLink, CollapsableCode, HomeLink } from "../../components/Core";
 import { ExampleContainer } from "../../components/ExamplePage";
@@ -31,8 +34,9 @@ export default function Page() {
   );
   const pcdStr = usePCDMultiplexer(passportPCDStr, serverPCDStr);
   const { proof, group, valid } = useSemaphoreGroupProof(
+    pcdStr,
     SEMAPHORE_GROUP_URL,
-    pcdStr
+    "consumer-client"
   );
 
   const [debugChecked, setDebugChecked] = useState(false);
@@ -67,7 +71,13 @@ export default function Page() {
       </p>
       <ExampleContainer>
         <button
-          onClick={() => requestMembershipProof(debugChecked, serverProving)}
+          onClick={() =>
+            requestMembershipProof(
+              debugChecked,
+              serverProving,
+              "consumer-client"
+            )
+          }
           disabled={valid}
         >
           Request Group Membership Proof
@@ -117,7 +127,11 @@ export default function Page() {
 }
 
 // Show the Passport popup, ask the user to show anonymous membership.
-function requestMembershipProof(debug: boolean, proveOnServer: boolean) {
+function requestMembershipProof(
+  debug: boolean,
+  proveOnServer: boolean,
+  originalSiteName: string
+) {
   const popupUrl = window.location.origin + "/popup";
   const proofUrl = constructPassportPcdGetRequestUrl<
     typeof SemaphoreGroupPCDPackage
@@ -129,7 +143,7 @@ function requestMembershipProof(debug: boolean, proveOnServer: boolean) {
       externalNullifier: {
         argumentType: ArgumentTypeName.BigInt,
         userProvided: true,
-        value: "1",
+        value: generateMessageHash(originalSiteName).toString(),
         description:
           "You can choose a nullifier to prevent this signed message from being used across domains.",
       },

--- a/apps/consumer-client/pages/index.tsx
+++ b/apps/consumer-client/pages/index.tsx
@@ -31,17 +31,17 @@ export default function Page() {
         <ol>
           <li>
             <a href="/zuzalu-examples/group-proof">
-              Semaphore Group Membership Proof
+              Zuzalu Group Membership Proof
+            </a>
+          </li>
+          <li>
+            <a href="/zuzalu-examples/uuid-proof">
+              Zuzalu Identity-Revealing Proof
             </a>
           </li>
           <li>
             <a href="/zuzalu-examples/signature-proof">
               Semaphore Signature Proof
-            </a>
-          </li>
-          <li>
-            <a href="/zuzalu-examples/uuid-proof">
-              Semaphore Identity-Revealing Proof
             </a>
           </li>
         </ol>

--- a/apps/consumer-client/pages/zuzalu-examples/group-proof.tsx
+++ b/apps/consumer-client/pages/zuzalu-examples/group-proof.tsx
@@ -15,8 +15,9 @@ export default function Page() {
   // Populate PCD from either client-side or server-side proving using passport popup
   const [pcdStr, _passportPendingPCDStr] = usePassportPopupMessages();
   const { proof, group, valid } = useSemaphoreGroupProof(
+    pcdStr,
     SEMAPHORE_GROUP_URL,
-    pcdStr
+    "consumer-client"
   );
 
   return (

--- a/apps/consumer-client/pages/zuzalu-examples/group-proof.tsx
+++ b/apps/consumer-client/pages/zuzalu-examples/group-proof.tsx
@@ -1,19 +1,11 @@
 import {
   openZuzaluMembershipPopup,
   usePassportPopupMessages,
-  usePCDMultiplexer,
-  usePendingPCD,
   useSemaphorePassportProof,
 } from "@pcd/passport-interface";
-import { useState } from "react";
 import { CodeLink, CollapsableCode, HomeLink } from "../../components/Core";
 import { ExampleContainer } from "../../components/ExamplePage";
-import { PendingPCDStatusDisplay } from "../../components/PendingPCDStatusDisplay";
-import {
-  PASSPORT_SERVER_URL,
-  PASSPORT_URL,
-  SEMAPHORE_GROUP_URL,
-} from "../../src/constants";
+import { PASSPORT_URL, SEMAPHORE_GROUP_URL } from "../../src/constants";
 
 /**
  * Example page which shows how to use a Zuzalu-specific prove screen to
@@ -21,18 +13,11 @@ import {
  */
 export default function Page() {
   // Populate PCD from either client-side or server-side proving using passport popup
-  const [passportPCDStr, passportPendingPCDStr] = usePassportPopupMessages();
-  const [pendingPCDStatus, pendingPCDError, serverPCDStr] = usePendingPCD(
-    passportPendingPCDStr,
-    PASSPORT_SERVER_URL
-  );
-  const pcdStr = usePCDMultiplexer(passportPCDStr, serverPCDStr);
+  const [pcdStr, _passportPendingPCDStr] = usePassportPopupMessages();
   const { proof, group, valid } = useSemaphorePassportProof(
     SEMAPHORE_GROUP_URL,
     pcdStr
   );
-
-  const [serverProving, setServerProving] = useState(false);
 
   return (
     <>
@@ -70,33 +55,13 @@ export default function Page() {
               PASSPORT_URL,
               window.location.origin + "/popup",
               SEMAPHORE_GROUP_URL,
-              "1337",
-              "12345",
-              serverProving
+              "consumer-client"
             )
           }
           disabled={valid}
         >
           Request Zuzalu Membership Proof
         </button>
-        <label>
-          <input
-            type="checkbox"
-            checked={serverProving}
-            onChange={() => {
-              setServerProving((checked: boolean) => !checked);
-            }}
-          />
-          server-side proof
-        </label>
-        {passportPendingPCDStr && (
-          <>
-            <PendingPCDStatusDisplay
-              status={pendingPCDStatus}
-              pendingPCDError={pendingPCDError}
-            />
-          </>
-        )}
         {proof != null && (
           <>
             <p>Got Zuzalu Membership Proof from Passport</p>

--- a/apps/consumer-client/pages/zuzalu-examples/group-proof.tsx
+++ b/apps/consumer-client/pages/zuzalu-examples/group-proof.tsx
@@ -1,7 +1,7 @@
 import {
   openZuzaluMembershipPopup,
   usePassportPopupMessages,
-  useSemaphorePassportProof,
+  useSemaphoreGroupProof,
 } from "@pcd/passport-interface";
 import { CodeLink, CollapsableCode, HomeLink } from "../../components/Core";
 import { ExampleContainer } from "../../components/ExamplePage";
@@ -14,7 +14,7 @@ import { PASSPORT_URL, SEMAPHORE_GROUP_URL } from "../../src/constants";
 export default function Page() {
   // Populate PCD from either client-side or server-side proving using passport popup
   const [pcdStr, _passportPendingPCDStr] = usePassportPopupMessages();
-  const { proof, group, valid } = useSemaphorePassportProof(
+  const { proof, group, valid } = useSemaphoreGroupProof(
     SEMAPHORE_GROUP_URL,
     pcdStr
   );

--- a/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
@@ -37,7 +37,11 @@ export function ProveScreen() {
   if (request.options?.genericProveScreen) {
     return <GenericProveScreen req={request} />;
   } else if (request.pcdType === SemaphoreGroupPCDPackage.name) {
-    title = "Prove membership";
+    if (request.options?.title !== undefined) {
+      title = request.options?.title;
+    } else {
+      title = "Prove membership";
+    }
     body = <SemaphoreGroupProveScreen req={request} />;
   } else if (request.pcdType === SemaphoreSignaturePCDPackage.name) {
     if (request.options?.title !== undefined) {

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -78,11 +78,19 @@ export function SemaphoreGroupProveScreen({
   ]);
 
   const lines: ReactNode[] = [];
-  lines.push(<p>Loading {req.args.group.remoteUrl}</p>);
-  if (group != null) {
-    lines.push(<p>Loaded {group.name}</p>);
+  if (group === null) {
+    lines.push(<p>Loading the group...</p>);
+  } else {
+    const websiteName =
+      req.options?.description !== undefined
+        ? req.options?.description
+        : "This website";
+
     lines.push(
-      <p>You're proving that you're one of {group.members.length} members</p>
+      <p>
+        <b>{websiteName}</b> is requesting a proof that you're one of{" "}
+        {group.members.length} members of {group.name}.
+      </p>
     );
   }
 

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
@@ -64,6 +64,7 @@ export function SemaphoreSignatureProveScreen({
   const lines: ReactNode[] = [];
 
   if (req.args.signedMessage.value === undefined) {
+    // Website is asking for a signature of the Zuzalu UUID for auth
     const websiteName =
       req.options?.description !== undefined
         ? req.options?.description
@@ -75,20 +76,24 @@ export function SemaphoreSignatureProveScreen({
       </p>
     );
     lines.push("Make sure you trust this website!");
-    lines.push(<Button onClick={onProve}>Continue</Button>);
+
+    if (!proving) {
+      lines.push(<Button onClick={onProve}>Continue</Button>);
+    } else {
+      lines.push(<RippleLoader />);
+    }
   } else {
+    // Website is asking for a signature of a custom message
     lines.push(
       <p>
         Signing message: <b>{req.args.signedMessage.value}</b>
       </p>
     );
-    lines.push(<Button onClick={onProve}>Prove</Button>);
-  }
-
-  if (!proving) {
-    lines.push(<Button onClick={onProve}>Prove</Button>);
-  } else {
-    lines.push(<RippleLoader />);
+    if (!proving) {
+      lines.push(<Button onClick={onProve}>Prove</Button>);
+    } else {
+      lines.push(<RippleLoader />);
+    }
   }
 
   return (

--- a/packages/passport-interface/src/SemaphoreGroupIntegration.ts
+++ b/packages/passport-interface/src/SemaphoreGroupIntegration.ts
@@ -66,7 +66,7 @@ export function openZuzaluMembershipPopup(
  * React hook which can be used on 3rd party application websites that
  * parses and verifies a PCD representing a Semaphore group membership proof.
  */
-export function useSemaphorePassportProof(
+export function useSemaphoreGroupProof(
   semaphoreGroupUrl: string,
   pcdStr: string
 ) {

--- a/packages/passport-interface/src/SemaphoreGroupIntegration.ts
+++ b/packages/passport-interface/src/SemaphoreGroupIntegration.ts
@@ -1,6 +1,7 @@
 import { ArgumentTypeName } from "@pcd/pcd-types";
 import {
   deserializeSemaphoreGroup,
+  generateMessageHash,
   SemaphoreGroupPCD,
   SemaphoreGroupPCDPackage,
   SerializedSemaphoreGroup,
@@ -13,15 +14,15 @@ import { useSerializedPCD } from "./SerializedPCDIntegration";
 /**
  * Opens a passport popup to generate a Zuzalu membership proof.
  *
- * popUrl must be the route where the usePassportPopupSetup hook is being served from.
+ * popupUrl must be the route where the usePassportPopupSetup hook is being served from.
  */
 export function openZuzaluMembershipPopup(
   urlToPassportWebsite: string,
   popupUrl: string,
   urlToSemaphoreGroup: string,
-  externalNullifier?: string,
+  originalSiteName: string,
   signal?: string,
-  proveOnServer?: boolean
+  uniqueProofId?: string
 ) {
   const proofUrl = constructPassportPcdGetRequestUrl<
     typeof SemaphoreGroupPCDPackage
@@ -33,7 +34,8 @@ export function openZuzaluMembershipPopup(
       externalNullifier: {
         argumentType: ArgumentTypeName.BigInt,
         userProvided: false,
-        value: externalNullifier ?? "1",
+        value:
+          uniqueProofId ?? generateMessageHash(originalSiteName).toString(),
       },
       group: {
         argumentType: ArgumentTypeName.Object,
@@ -52,7 +54,8 @@ export function openZuzaluMembershipPopup(
       },
     },
     {
-      proveOnServer: proveOnServer,
+      title: "Zuzalu Anon Auth",
+      description: originalSiteName,
     }
   );
 

--- a/packages/passport-interface/src/SemaphoreGroupIntegration.ts
+++ b/packages/passport-interface/src/SemaphoreGroupIntegration.ts
@@ -14,7 +14,12 @@ import { useSerializedPCD } from "./SerializedPCDIntegration";
 /**
  * Opens a passport popup to generate a Zuzalu membership proof.
  *
- * popupUrl must be the route where the usePassportPopupSetup hook is being served from.
+ * @param urlToPassportWebsite URL of passport website
+ * @param popupUrl Route where the usePassportPopupSetup hook is being served from
+ * @param urlToSemaphoreGroup URL where Zuzalu semaphore group is being served from
+ * @param originalSiteName Name of site requesting proof
+ * @param signal Optional signal that user is anonymously attesting to
+ * @param externalNullifier Optional unique identifier for this SemaphoreGroupPCD
  */
 export function openZuzaluMembershipPopup(
   urlToPassportWebsite: string,
@@ -22,7 +27,7 @@ export function openZuzaluMembershipPopup(
   urlToSemaphoreGroup: string,
   originalSiteName: string,
   signal?: string,
-  uniqueProofId?: string
+  externalNullifier?: string
 ) {
   const proofUrl = constructPassportPcdGetRequestUrl<
     typeof SemaphoreGroupPCDPackage
@@ -35,7 +40,7 @@ export function openZuzaluMembershipPopup(
         argumentType: ArgumentTypeName.BigInt,
         userProvided: false,
         value:
-          uniqueProofId ?? generateMessageHash(originalSiteName).toString(),
+          externalNullifier ?? generateMessageHash(originalSiteName).toString(),
       },
       group: {
         argumentType: ArgumentTypeName.Object,
@@ -65,10 +70,13 @@ export function openZuzaluMembershipPopup(
 /**
  * React hook which can be used on 3rd party application websites that
  * parses and verifies a PCD representing a Semaphore group membership proof.
+ * Params match those used in openZuzaluMembershipPopup.
  */
 export function useSemaphoreGroupProof(
+  pcdStr: string,
   semaphoreGroupUrl: string,
-  pcdStr: string
+  originalSiteName: string,
+  externalNullifier?: string
 ) {
   const [error, setError] = useState<Error | undefined>();
   const semaphoreGroupPCD = useSerializedPCD(SemaphoreGroupPCDPackage, pcdStr);
@@ -94,9 +102,22 @@ export function useSemaphoreGroupProof(
   const [semaphoreProofValid, setValid] = useState<boolean | undefined>();
   useEffect(() => {
     if (semaphoreGroupPCD && semaphoreGroup) {
-      verifyProof(semaphoreGroupPCD, semaphoreGroup).then(setValid);
+      const proofExternalNullifier =
+        externalNullifier ?? generateMessageHash(originalSiteName).toString();
+
+      verifyProof(
+        semaphoreGroupPCD,
+        semaphoreGroup,
+        proofExternalNullifier
+      ).then(setValid);
     }
-  }, [semaphoreGroupPCD, semaphoreGroup, setValid]);
+  }, [
+    semaphoreGroupPCD,
+    semaphoreGroup,
+    externalNullifier,
+    originalSiteName,
+    setValid,
+  ]);
 
   return {
     proof: semaphoreGroupPCD,
@@ -108,13 +129,19 @@ export function useSemaphoreGroupProof(
 
 async function verifyProof(
   pcd: SemaphoreGroupPCD,
-  serializedExpectedGroup: SerializedSemaphoreGroup
+  serializedExpectedGroup: SerializedSemaphoreGroup,
+  externalNullifier: string
 ): Promise<boolean> {
   const { verify } = SemaphoreGroupPCDPackage;
   const verified = await verify(pcd);
   if (!verified) return false;
 
-  const expectedGroup = deserializeSemaphoreGroup(serializedExpectedGroup);
+  // verify the claim is for the correct externalNullifier and group
+  const sameExternalNullifier =
+    pcd.claim.externalNullifier === externalNullifier;
 
-  return expectedGroup.root.toString() === pcd.claim.merkleRoot;
+  const expectedGroup = deserializeSemaphoreGroup(serializedExpectedGroup);
+  const sameRoot = expectedGroup.root.toString() === pcd.claim.merkleRoot;
+
+  return sameExternalNullifier && sameRoot;
 }

--- a/packages/passport-interface/src/SemaphoreSignatureIntegration.ts
+++ b/packages/passport-interface/src/SemaphoreSignatureIntegration.ts
@@ -8,7 +8,10 @@ import { useSerializedPCD } from "./SerializedPCDIntegration";
 /**
  * Opens a passport popup to generate a Semaphore signature proof.
  *
- * popupUrl must be the route where the usePassportPopupSetup hook is being served from.
+ * @param urlToPassportWebsite URL of passport website
+ * @param popupUrl Route where the usePassportPopupSetup hook is being served from
+ * @param messageToSign Message being attested to
+ * @param proveOnServer Boolean indicating whether proof should be generated on server
  */
 export function openSemaphoreSignaturePopup(
   urlToPassportWebsite: string,
@@ -47,8 +50,9 @@ export function openSemaphoreSignaturePopup(
  * Zuzalu DB uuid, which can then be used to fetch user details from the passport
  * server. Built specifically for Zuzalu apps.
  *
- * popupUrl must be the route where the usePassportPopupSetup hook is being served from.
- * originalSiteName should be the name of your service, to be displayed on the popup.
+ * @param urlToPassportWebsite URL of passport website
+ * @param popupUrl Route where the usePassportPopupSetup hook is being served from
+ * @param originalSiteName Name of site requesting proof
  */
 export function openSignedZuzaluUUIDPopup(
   urlToPassportWebsite: string,

--- a/packages/passport-interface/src/SemaphoreSignatureIntegration.ts
+++ b/packages/passport-interface/src/SemaphoreSignatureIntegration.ts
@@ -8,7 +8,7 @@ import { useSerializedPCD } from "./SerializedPCDIntegration";
 /**
  * Opens a passport popup to generate a Semaphore signature proof.
  *
- * popUrl must be the route where the usePassportPopupSetup hook is being served from.
+ * popupUrl must be the route where the usePassportPopupSetup hook is being served from.
  */
 export function openSemaphoreSignaturePopup(
   urlToPassportWebsite: string,
@@ -47,7 +47,7 @@ export function openSemaphoreSignaturePopup(
  * Zuzalu DB uuid, which can then be used to fetch user details from the passport
  * server. Built specifically for Zuzalu apps.
  *
- * popUrl must be the route where the usePassportPopupSetup hook is being served from.
+ * popupUrl must be the route where the usePassportPopupSetup hook is being served from.
  * originalSiteName should be the name of your service, to be displayed on the popup.
  */
 export function openSignedZuzaluUUIDPopup(

--- a/packages/semaphore-group-pcd/package.json
+++ b/packages/semaphore-group-pcd/package.json
@@ -24,6 +24,7 @@
     "@types/json-bigint": "^1.0.1",
     "@types/mocha": "^10.0.1",
     "@types/uuid": "^9.0.0",
+    "js-sha256": "^0.9.0",
     "json-bigint": "^1.0.0",
     "typescript": "^4.9.5",
     "uuid": "^9.0.0"

--- a/packages/semaphore-group-pcd/src/SemaphoreGroupPCD.ts
+++ b/packages/semaphore-group-pcd/src/SemaphoreGroupPCD.ts
@@ -17,6 +17,7 @@ import {
   Proof,
   verifyProof,
 } from "@semaphore-protocol/proof";
+import { sha256 } from "js-sha256";
 import JSONBig from "json-bigint";
 import { v4 as uuid } from "uuid";
 import {
@@ -27,6 +28,17 @@ import {
 let initArgs: SempahoreGroupPCDInitArgs | undefined = undefined;
 
 export const SemaphoreGroupPCDTypeName = "semaphore-group-signal";
+
+/**
+ * Hashes a message to be signed with sha256 and fits it into a baby jub jub field element.
+ * @param signal The initial message.
+ * @returns The outputted hash, fed in as a signal to the Semaphore proof.
+ */
+export function generateMessageHash(signal: string): bigint {
+  // right shift to fit into a field element, which is 254 bits long
+  // shift by 8 ensures we have a 253 bit element
+  return BigInt("0x" + sha256(signal)) >> BigInt(8);
+}
 
 export interface SempahoreGroupPCDInitArgs {
   // TODO: how do we distribute these in-package, so that consumers

--- a/packages/semaphore-signature-pcd/src/SemaphoreSignaturePCD.ts
+++ b/packages/semaphore-signature-pcd/src/SemaphoreSignaturePCD.ts
@@ -30,7 +30,7 @@ export const STATIC_SIGNATURE_PCD_NULLIFIER = generateMessageHash(
 );
 
 /**
- * Hashes a message to be signed with Keccak and fits it into a baby jub jub field element.
+ * Hashes a message to be signed with sha256 and fits it into a baby jub jub field element.
  * @param signal The initial message.
  * @returns The outputted hash, fed in as a signal to the Semaphore proof.
  */


### PR DESCRIPTION
In setting up the new hooks with zuzalu-confessions, I realized the SemaphoreGroupPCD prove screens and interfaces were quite confusing. The prove screen was clunky, and using `openZuzaluMembershipPopup` required understanding of externalNullifier and signals, which felt unnecessary for the workshop and for most use cases of the anonymous auth provided by SemaphoreGroupPCD. 

Thus, I simplified that interface and cleaned up the SemaphoreGroupProveScreen so its ability to provide anonymous auth was more easily usable. I also removed the server-side proving option from `openZuzaluMembershipPopup` and `zuzalu-examples/group-proof.tsx` in consumer-client for further simplicity.

Finally, I added #163 to eventually incorporate `generateMessageHash` into the SemaphoreGroupPCD claim à la SemaphoreSignaturePCD, but that isn't necessary for the auth workshop. It will be helpful to make the polling app more understandable (in particular, people can see what poll option they are agreeing to on the SemaphoreGroupProveScreen if we use `signedMessage` and not arbitrary `signal`).