### PR TITLE
show human readable error on semaphore group membership screen if you're not part of the group and other errors

### DIFF
--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -23,6 +23,8 @@ export function SemaphoreGroupProveScreen({
 }: {
   req: PCDGetRequest<typeof SemaphoreGroupPCDPackage>;
 }) {
+  const [error, setError] = useState<string | undefined>();
+
   // Load semaphore group
   const [group, setGroup] = useState<SerializedSemaphoreGroup>(null);
   useEffect(() => {
@@ -67,7 +69,14 @@ export function SemaphoreGroupProveScreen({
         )}`;
       }
     } catch (e) {
-      console.log(e);
+      if (
+        typeof e.message === "string" &&
+        e.message.indexOf("The identity is not part of the group") >= 0
+      ) {
+        setError("You are not part of this group.");
+      } else if (typeof e.message === "string") {
+        setError(e.message);
+      }
     }
   }, [
     group,
@@ -94,8 +103,10 @@ export function SemaphoreGroupProveScreen({
     );
   }
 
-  if (!proving) {
+  if (!proving && error === undefined) {
     lines.push(<Button onClick={onProve}>Prove</Button>);
+  } else if (error !== undefined) {
+    lines.push(<ErrorContainer>{error}</ErrorContainer>);
   } else {
     lines.push(<RippleLoader />);
   }
@@ -163,4 +174,15 @@ async function fillArgs(
 
 const LineWrap = styled.div`
   margin-bottom: 16px;
+`;
+
+const ErrorContainer = styled.div`
+  border: 2px solid var(--danger);
+  color: white;
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--bg-lite-primary);
 `;

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -177,12 +177,11 @@ const LineWrap = styled.div`
 `;
 
 const ErrorContainer = styled.div`
-  border: 2px solid var(--danger);
   color: white;
-  border-radius: 8px;
+  border-radius: 99px;
   padding: 16px;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: var(--bg-lite-primary);
+  background-color: var(--danger);
 `;


### PR DESCRIPTION
#### before
it would just hang in this state
<img width="360" alt="Screenshot 2023-04-17 at 12 42 29 PM" src="https://user-images.githubusercontent.com/2636237/232461808-a799de32-66eb-41a0-9d45-c836dcc0f2c3.png">

#### after
human-readable error
<img width="362" alt="Screenshot 2023-04-17 at 1 29 42 PM" src="https://user-images.githubusercontent.com/2636237/232471699-336c81d3-1e6f-452d-9d0e-407278226439.png">

