### PR TITLE
Adding `signedMessage` to SemaphoreGroupPCD claim + improving prove screen

### DIFF
--- a/apps/consumer-client/pages/examples/group-proof.tsx
+++ b/apps/consumer-client/pages/examples/group-proof.tsx
@@ -165,8 +165,8 @@ function requestMembershipProof(
         description:
           "The Semaphore Identity which you are signing the message on behalf of.",
       },
-      signal: {
-        argumentType: ArgumentTypeName.BigInt,
+      signedMessage: {
+        argumentType: ArgumentTypeName.String,
         userProvided: true,
         value: "1",
         description:

--- a/apps/consumer-client/pages/zuzalu-examples/group-proof.tsx
+++ b/apps/consumer-client/pages/zuzalu-examples/group-proof.tsx
@@ -3,10 +3,10 @@ import {
   usePassportPopupMessages,
   useSemaphoreGroupProof,
 } from "@pcd/passport-interface";
+import { useState } from "react";
 import { CodeLink, CollapsableCode, HomeLink } from "../../components/Core";
 import { ExampleContainer } from "../../components/ExamplePage";
 import { PASSPORT_URL, SEMAPHORE_GROUP_URL } from "../../src/constants";
-import { useState } from "react";
 
 /**
  * Example page which shows how to use a Zuzalu-specific prove screen to
@@ -15,6 +15,10 @@ import { useState } from "react";
 export default function Page() {
   // Populate PCD from either client-side or server-side proving using passport popup
   const [pcdStr, _passportPendingPCDStr] = usePassportPopupMessages();
+
+  const [messageToSign, setMessageToSign] = useState<string | undefined>(
+    undefined
+  );
 
   const [valid, setValid] = useState<boolean | undefined>();
   const onVerified = (valid: boolean) => {
@@ -26,6 +30,7 @@ export default function Page() {
     SEMAPHORE_GROUP_URL,
     "consumer-client",
     onVerified,
+    messageToSign
   );
 
   return (
@@ -58,13 +63,22 @@ export default function Page() {
         .
       </p>
       <ExampleContainer>
+        <input
+          style={{ marginBottom: "8px" }}
+          placeholder="Message to group sign"
+          type="text"
+          value={messageToSign}
+          onChange={(e) => setMessageToSign(e.target.value)}
+        />
+        <br />
         <button
           onClick={() =>
             openZuzaluMembershipPopup(
               PASSPORT_URL,
               window.location.origin + "/popup",
               SEMAPHORE_GROUP_URL,
-              "consumer-client"
+              "consumer-client",
+              messageToSign
             )
           }
           disabled={valid}

--- a/apps/consumer-client/pages/zuzalu-examples/signature-proof.tsx
+++ b/apps/consumer-client/pages/zuzalu-examples/signature-proof.tsx
@@ -24,13 +24,17 @@ export default function Page() {
   );
   const pcdStr = usePCDMultiplexer(passportPCDStr, serverPCDStr);
 
-  const [signatureProofValid, setSignatureProofValid] = useState<boolean | undefined>();
+  const [signatureProofValid, setSignatureProofValid] = useState<
+    boolean | undefined
+  >();
   const onProofVerified = (valid: boolean) => {
     setSignatureProofValid(valid);
   };
 
-  const { signatureProof } =
-    useSemaphoreSignatureProof(pcdStr, onProofVerified);
+  const { signatureProof } = useSemaphoreSignatureProof(
+    pcdStr,
+    onProofVerified
+  );
 
   const [messageToSign, setMessageToSign] = useState<string>("");
   const [serverProving, setServerProving] = useState(false);

--- a/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
@@ -55,7 +55,7 @@ export function ProveScreen() {
 
   return (
     <AppContainer bg="gray">
-      <Spacer h={24} />
+      <Spacer h={48} />
       <H2>{title.toUpperCase()}</H2>
       <Spacer h={24} />
       <CenterColumn w={280}>{body}</CenterColumn>

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -90,15 +90,21 @@ export function SemaphoreGroupProveScreen({
   if (group === null) {
     lines.push(<p>Loading the group...</p>);
   } else {
+    console.log(req.options);
     const websiteName =
-      req.options?.description !== undefined
-        ? req.options?.description
+      req.options?.originalSiteName !== undefined
+        ? req.options?.originalSiteName
         : "This website";
+
+    const attestedMessage =
+      req.args.signedMessage.value !== "1"
+        ? `, and that you are signing "${req.args.signedMessage.value}".`
+        : ".";
 
     lines.push(
       <p>
         <b>{websiteName}</b> is requesting a proof that you're one of{" "}
-        {group.members.length} members of {group.name}.
+        {group.members.length} members of {group.name + attestedMessage}
       </p>
     );
   }

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -133,11 +133,11 @@ async function fillArgs(
   let args: SemaphoreGroupPCDArgs = {
     externalNullifier: {
       argumentType: ArgumentTypeName.BigInt,
-      value: 23 + "",
+      value: "1",
     },
-    signal: {
-      argumentType: ArgumentTypeName.BigInt,
-      value: 34 + "",
+    signedMessage: {
+      argumentType: ArgumentTypeName.String,
+      value: "1",
     },
     group: {
       argumentType: ArgumentTypeName.Object,
@@ -160,8 +160,8 @@ async function fillArgs(
     };
   }
   // same, but for signal
-  if (reqArgs.signal.value !== undefined) {
-    args = { ...args, signal: reqArgs.signal };
+  if (reqArgs.signedMessage.value !== undefined) {
+    args = { ...args, signedMessage: reqArgs.signedMessage };
   }
 
   console.log("Proving semaphore membership", args);

--- a/packages/passport-interface/src/PassportInterface.ts
+++ b/packages/passport-interface/src/PassportInterface.ts
@@ -16,6 +16,7 @@ export interface GetRequestOptions {
   description?: string;
   debug?: boolean;
   proveOnServer?: boolean;
+  originalSiteName?: string;
 }
 
 export interface PCDGetRequest<T extends PCDPackage = PCDPackage>

--- a/packages/passport-interface/src/SemaphoreGroupIntegration.ts
+++ b/packages/passport-interface/src/SemaphoreGroupIntegration.ts
@@ -18,7 +18,7 @@ import { useSerializedPCD } from "./SerializedPCDIntegration";
  * @param popupUrl Route where the usePassportPopupSetup hook is being served from
  * @param urlToSemaphoreGroup URL where Zuzalu semaphore group is being served from
  * @param originalSiteName Name of site requesting proof
- * @param signal Optional signal that user is anonymously attesting to
+ * @param signedMessage Optional signedMessage that user is anonymously attesting to
  * @param externalNullifier Optional unique identifier for this SemaphoreGroupPCD
  */
 export function openZuzaluMembershipPopup(
@@ -26,7 +26,7 @@ export function openZuzaluMembershipPopup(
   popupUrl: string,
   urlToSemaphoreGroup: string,
   originalSiteName: string,
-  signal?: string,
+  signedMessage?: string,
   externalNullifier?: string
 ) {
   const proofUrl = constructPassportPcdGetRequestUrl<
@@ -52,10 +52,10 @@ export function openZuzaluMembershipPopup(
         value: undefined,
         userProvided: true,
       },
-      signal: {
-        argumentType: ArgumentTypeName.BigInt,
+      signedMessage: {
+        argumentType: ArgumentTypeName.String,
         userProvided: false,
-        value: signal ?? "1",
+        value: signedMessage ?? "1",
       },
     },
     {

--- a/packages/semaphore-group-pcd/test/SemaphoreGroupPCD.spec.ts
+++ b/packages/semaphore-group-pcd/test/SemaphoreGroupPCD.spec.ts
@@ -29,7 +29,7 @@ describe("semaphore group identity should work", function () {
     const group = new Group(1, 16);
     group.addMember(identity.commitment);
     const externalNullifier = group.root;
-    const signal = 1;
+    const signedMessage = "Test message";
 
     const identityPCD = await SemaphoreIdentityPCDPackage.serialize(
       await SemaphoreIdentityPCDPackage.prove({ identity })
@@ -40,9 +40,9 @@ describe("semaphore group identity should work", function () {
         argumentType: ArgumentTypeName.BigInt,
         value: externalNullifier + "",
       },
-      signal: {
-        argumentType: ArgumentTypeName.BigInt,
-        value: signal + "",
+      signedMessage: {
+        argumentType: ArgumentTypeName.String,
+        value: signedMessage,
       },
       group: {
         argumentType: ArgumentTypeName.Object,
@@ -67,7 +67,7 @@ describe("semaphore group identity should work", function () {
 
     const pcd = await prove(args);
     // make the pcd invalid by changing its claim
-    pcd.claim.signal = pcd.claim.signal + "1";
+    pcd.claim.signedMessage = pcd.claim.signedMessage + "1";
 
     const verified = await verify(pcd);
     assert.equal(verified, false);

--- a/packages/semaphore-signature-pcd/src/SemaphoreSignaturePCD.ts
+++ b/packages/semaphore-signature-pcd/src/SemaphoreSignaturePCD.ts
@@ -65,7 +65,7 @@ export interface SemaphoreSignaturePCDArgs {
 
 export interface SemaphoreSignaturePCDClaim {
   /**
-   * Pre-hashed message.
+   * Pre-hashed message being attested to.
    */
   signedMessage: string;
 


### PR DESCRIPTION
Previously, we only kept the signal in the SemaphoreGroupPCD claim. This meant displaying the actual message users were signing would have to be sent over in options + the PCD itself wasn't interpretable outside of the context of the issuing website. This PR adds this and improves the prove screen, which shouldn't break any deployments in production.