### PR TITLE
Adding targeted postMessage calls to improve perfomance.

### DIFF
--- a/apps/consumer-client/pages/examples/group-proof.tsx
+++ b/apps/consumer-client/pages/examples/group-proof.tsx
@@ -26,8 +26,9 @@ import {
  * request a Semaphore Group Membership PCD as a third party developer.
  */
 export default function Page() {
+  const popupSrcId = "generic-group-proof";
   // Populate PCD from either client-side or server-side proving using passport popup
-  const [passportPCDStr, passportPendingPCDStr] = usePassportPopupMessages();
+  const [passportPCDStr, passportPendingPCDStr] = usePassportPopupMessages(popupSrcId);
   const [pendingPCDStatus, pendingPCDError, serverPCDStr] = usePendingPCD(
     passportPendingPCDStr,
     PASSPORT_SERVER_URL
@@ -78,6 +79,7 @@ export default function Page() {
         <button
           onClick={() =>
             requestMembershipProof(
+              popupSrcId,
               debugChecked,
               serverProving,
               "consumer-client"
@@ -133,6 +135,7 @@ export default function Page() {
 
 // Show the Passport popup, ask the user to show anonymous membership.
 function requestMembershipProof(
+  popupSrcId: string,
   debug: boolean,
   proveOnServer: boolean,
   originalSiteName: string
@@ -142,6 +145,7 @@ function requestMembershipProof(
     typeof SemaphoreGroupPCDPackage
   >(
     PASSPORT_URL,
+    popupSrcId,
     popupUrl,
     SemaphoreGroupPCDPackage.name,
     {

--- a/apps/consumer-client/pages/examples/signature-proof.tsx
+++ b/apps/consumer-client/pages/examples/signature-proof.tsx
@@ -19,8 +19,9 @@ import { PASSPORT_SERVER_URL, PASSPORT_URL } from "../../src/constants";
  * request a Semaphore Signature PCD as a third party developer.
  */
 export default function Page() {
+  const popupSrcId = "generic-signature-proof";
   // Populate PCD from either client-side or server-side proving using passport popup
-  const [passportPCDStr, passportPendingPCDStr] = usePassportPopupMessages();
+  const [passportPCDStr, passportPendingPCDStr] = usePassportPopupMessages(popupSrcId);
   const [pendingPCDStatus, pendingPCDError, serverPCDStr] = usePendingPCD(
     passportPendingPCDStr,
     PASSPORT_SERVER_URL
@@ -52,7 +53,7 @@ export default function Page() {
         <button
           disabled={signatureProofValid}
           onClick={useCallback(
-            () => requestSemaphoreSignature(serverProving),
+            () => requestSemaphoreSignature(popupSrcId, serverProving),
             [serverProving]
           )}
         >
@@ -95,12 +96,13 @@ export default function Page() {
   );
 }
 
-function requestSemaphoreSignature(proveOnServer: boolean) {
+function requestSemaphoreSignature(popupSrcId: string, proveOnServer: boolean) {
   const popupUrl = window.location.origin + "/popup";
   const proofUrl = constructPassportPcdGetRequestUrl<
     typeof SemaphoreSignaturePCDPackage
   >(
     PASSPORT_URL,
+    popupSrcId,
     popupUrl,
     SemaphoreSignaturePCDPackage.name,
     {

--- a/apps/consumer-client/pages/zuzalu-examples/group-proof.tsx
+++ b/apps/consumer-client/pages/zuzalu-examples/group-proof.tsx
@@ -13,8 +13,9 @@ import { useState } from "react";
  * request a Semaphore Group Membership PCD as a third party developer.
  */
 export default function Page() {
+  const popupSrcId = "zuzalu-group-proof";
   // Populate PCD from either client-side or server-side proving using passport popup
-  const [pcdStr, _passportPendingPCDStr] = usePassportPopupMessages();
+  const [pcdStr, _passportPendingPCDStr] = usePassportPopupMessages(popupSrcId);
 
   const [valid, setValid] = useState<boolean | undefined>();
   const onVerified = (valid: boolean) => {
@@ -62,6 +63,7 @@ export default function Page() {
           onClick={() =>
             openZuzaluMembershipPopup(
               PASSPORT_URL,
+              popupSrcId,
               window.location.origin + "/popup",
               SEMAPHORE_GROUP_URL,
               "consumer-client"

--- a/apps/consumer-client/pages/zuzalu-examples/signature-proof.tsx
+++ b/apps/consumer-client/pages/zuzalu-examples/signature-proof.tsx
@@ -16,8 +16,9 @@ import { PASSPORT_SERVER_URL, PASSPORT_URL } from "../../src/constants";
  * request a Semaphore Signature PCD as a third party developer.
  */
 export default function Page() {
+  const popupSrcId = "zuzalu-signature-proof";
   // Populate PCD from either client-side or server-side proving using passport popup
-  const [passportPCDStr, passportPendingPCDStr] = usePassportPopupMessages();
+  const [passportPCDStr, passportPendingPCDStr] = usePassportPopupMessages(popupSrcId);
   const [pendingPCDStatus, pendingPCDError, serverPCDStr] = usePendingPCD(
     passportPendingPCDStr,
     PASSPORT_SERVER_URL
@@ -62,6 +63,7 @@ export default function Page() {
             () =>
               openSemaphoreSignaturePopup(
                 PASSPORT_URL,
+                popupSrcId,
                 window.location.origin + "/popup",
                 messageToSign,
                 serverProving

--- a/apps/consumer-client/pages/zuzalu-examples/uuid-proof.tsx
+++ b/apps/consumer-client/pages/zuzalu-examples/uuid-proof.tsx
@@ -15,9 +15,10 @@ import { PASSPORT_SERVER_URL, PASSPORT_URL } from "../../src/constants";
  * party developer.
  */
 export default function Page() {
+  const popupSrcId = "zuzalu-uuid-proof";
   // We only do client-side proofs for Zuzalu UUID proofs, which means we can
   // ignore any PendingPCDs that would result from server-side proving
-  const [pcdStr, _passportPendingPCDStr] = usePassportPopupMessages();
+  const [pcdStr, _passportPendingPCDStr] = usePassportPopupMessages(popupSrcId);
   
   const [signatureProofValid, setSignatureProofValid] = useState<boolean | undefined>();
   const onProofVerified = (valid: boolean) => {
@@ -56,6 +57,7 @@ export default function Page() {
           onClick={() =>
             openSignedZuzaluUUIDPopup(
               PASSPORT_URL,
+              popupSrcId,
               window.location.origin + "/popup",
               "consumer-client"
             )

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
@@ -43,13 +43,12 @@ export function GenericProveScreen({ req }: { req: PCDGetRequest }) {
           args: args,
         };
         const pendingPCD = await requestPendingPCD(serverReq);
-        window.location.href = `${
-          req.returnUrl
-        }?encodedPendingPCD=${JSON.stringify(pendingPCD)}`;
+        window.location.href = `${req.returnUrl
+          }?srcId=${req.srcId}&encodedPendingPCD=${JSON.stringify(pendingPCD)}`;
       } else {
         const pcd = await pcdPackage.prove(args);
         const serialized = await pcdPackage.serialize(pcd);
-        window.location.href = `${req.returnUrl}?proof=${JSON.stringify(
+        window.location.href = `${req.returnUrl}?srcId=${req.srcId}&proof=${JSON.stringify(
           serialized
         )}`;
       }
@@ -61,6 +60,7 @@ export function GenericProveScreen({ req }: { req: PCDGetRequest }) {
     args,
     pcdPackage,
     req.returnUrl,
+    req.srcId,
     req.options?.proveOnServer,
     req.pcdType,
   ]);

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -59,12 +59,12 @@ export function SemaphoreGroupProveScreen({
         const pendingPCD = await requestPendingPCD(serverReq);
         window.location.href = `${
           req.returnUrl
-        }?encodedPendingPCD=${JSON.stringify(pendingPCD)}`;
+        }?srcId=${req.srcId}&encodedPendingPCD=${JSON.stringify(pendingPCD)}`;
       } else {
         const { prove, serialize } = SemaphoreGroupPCDPackage;
         const pcd = await prove(args);
         const serializedPCD = await serialize(pcd);
-        window.location.href = `${req.returnUrl}?proof=${JSON.stringify(
+        window.location.href = `${req.returnUrl}?srcId=${req.srcId}&proof=${JSON.stringify(
           serializedPCD
         )}`;
       }
@@ -81,6 +81,7 @@ export function SemaphoreGroupProveScreen({
   }, [
     group,
     req.returnUrl,
+    req.srcId,
     state.identity,
     req.args,
     req.options?.proveOnServer,

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
@@ -47,12 +47,12 @@ export function SemaphoreSignatureProveScreen({
         const pendingPCD = await requestPendingPCD(serverReq);
         window.location.href = `${
           req.returnUrl
-        }?encodedPendingPCD=${JSON.stringify(pendingPCD)}`;
+        }?srcId=${req.srcId}&encodedPendingPCD=${JSON.stringify(pendingPCD)}`;
       } else {
         const { prove, serialize } = SemaphoreSignaturePCDPackage;
         const pcd = await prove(args);
         const serializedPCD = await serialize(pcd);
-        window.location.href = `${req.returnUrl}?proof=${JSON.stringify(
+        window.location.href = `${req.returnUrl}?srcId=${req.srcId}&proof=${JSON.stringify(
           serializedPCD
         )}`;
       }

--- a/packages/passport-interface/src/PassportInterface.ts
+++ b/packages/passport-interface/src/PassportInterface.ts
@@ -6,6 +6,7 @@ export enum PCDRequestType {
 }
 
 export interface PCDRequest {
+  srcId: string;
   returnUrl: string;
   type: PCDRequestType;
 }
@@ -33,6 +34,7 @@ export interface PCDAddRequest extends PCDRequest {
 
 export function constructPassportPcdGetRequestUrl<T extends PCDPackage>(
   passportOrigin: string,
+  srcId: string,
   returnUrl: string,
   pcdType: T["name"],
   args: ArgsOf<T>,
@@ -40,6 +42,7 @@ export function constructPassportPcdGetRequestUrl<T extends PCDPackage>(
 ) {
   const req: PCDGetRequest<T> = {
     type: PCDRequestType.Get,
+    srcId: srcId,
     returnUrl: returnUrl,
     args: args,
     pcdType,
@@ -51,11 +54,13 @@ export function constructPassportPcdGetRequestUrl<T extends PCDPackage>(
 
 export function constructPassportPcdAddRequestUrl(
   passportOrigin: string,
+  srcId: string,
   returnUrl: string,
   pcd: PCD
 ) {
   const req: PCDAddRequest = {
     type: PCDRequestType.Add,
+    srcId: srcId,
     returnUrl: returnUrl,
     pcd,
   };

--- a/packages/passport-interface/src/SemaphoreGroupIntegration.ts
+++ b/packages/passport-interface/src/SemaphoreGroupIntegration.ts
@@ -23,6 +23,7 @@ import { useSerializedPCD } from "./SerializedPCDIntegration";
  */
 export function openZuzaluMembershipPopup(
   urlToPassportWebsite: string,
+  srcId: string,
   popupUrl: string,
   urlToSemaphoreGroup: string,
   originalSiteName: string,
@@ -33,6 +34,7 @@ export function openZuzaluMembershipPopup(
     typeof SemaphoreGroupPCDPackage
   >(
     urlToPassportWebsite,
+    srcId,
     popupUrl,
     SemaphoreGroupPCDPackage.name,
     {

--- a/packages/passport-interface/src/SemaphoreSignatureIntegration.ts
+++ b/packages/passport-interface/src/SemaphoreSignatureIntegration.ts
@@ -15,6 +15,7 @@ import { useSerializedPCD } from "./SerializedPCDIntegration";
  */
 export function openSemaphoreSignaturePopup(
   urlToPassportWebsite: string,
+  srcId: string,
   popupUrl: string,
   messageToSign: string,
   proveOnServer?: boolean
@@ -23,6 +24,7 @@ export function openSemaphoreSignaturePopup(
     typeof SemaphoreSignaturePCDPackage
   >(
     urlToPassportWebsite,
+    srcId,
     popupUrl,
     SemaphoreSignaturePCDPackage.name,
     {
@@ -56,6 +58,7 @@ export function openSemaphoreSignaturePopup(
  */
 export function openSignedZuzaluUUIDPopup(
   urlToPassportWebsite: string,
+  srcId: string,
   popupUrl: string,
   originalSiteName: string
 ) {
@@ -63,6 +66,7 @@ export function openSignedZuzaluUUIDPopup(
     typeof SemaphoreSignaturePCDPackage
   >(
     urlToPassportWebsite,
+    srcId,
     popupUrl,
     SemaphoreSignaturePCDPackage.name,
     {


### PR DESCRIPTION
Currently, the response from one popup updates the pcdStr's in all the usePassportPopup hooks, which ends up trriggering the verification of the proof. To fix his, we're added a ID field which can be specified by each component which uses the passport hooks.

When the popup returns a pcdStr from a generate proof, only the specific component which requested the proof will have it's pcdStr updated.

Tested on all the current consumer-client apps, but further testing may be required.