### PR TITLE
group proof screen improvements

### DIFF
--- a/apps/passport-client/components/core/Button.tsx
+++ b/apps/passport-client/components/core/Button.tsx
@@ -8,16 +8,18 @@ export function Button({
   style,
   type,
   size,
+  disabled,
 }: {
   children: React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   style?: "primary" | "danger";
   size?: "large" | "small";
   type?: "submit" | "button" | "reset";
+  disabled: boolean;
 }) {
   const Btn = style === "danger" ? BtnDanger : BtnBase;
   return (
-    <Btn type={type} size={size} onClick={onClick}>
+    <Btn type={type} size={size} disabled={disabled} onClick={onClick}>
       {children}
     </Btn>
   );
@@ -43,8 +45,9 @@ const buttonStyle = `
   }
 `;
 
-const BtnBase = styled.button<{ size?: "large" | "small" }>`
+const BtnBase = styled.button<{ size?: "large" | "small"; disabled?: boolean }>`
   ${buttonStyle}
+
   ${({ size }: { size?: "large" | "small" }) =>
     size === undefined || size === "large"
       ? css``

--- a/apps/passport-client/components/core/Button.tsx
+++ b/apps/passport-client/components/core/Button.tsx
@@ -15,11 +15,11 @@ export function Button({
   style?: "primary" | "danger";
   size?: "large" | "small";
   type?: "submit" | "button" | "reset";
-  disabled: boolean;
+  disabled?: boolean;
 }) {
   const Btn = style === "danger" ? BtnDanger : BtnBase;
   return (
-    <Btn type={type} size={size} disabled={disabled} onClick={onClick}>
+    <Btn type={type} size={size} onClick={onClick} disabled={disabled}>
       {children}
     </Btn>
   );
@@ -45,7 +45,7 @@ const buttonStyle = `
   }
 `;
 
-const BtnBase = styled.button<{ size?: "large" | "small"; disabled?: boolean }>`
+const BtnBase = styled.button<{ size?: "large" | "small" }>`
   ${buttonStyle}
 
   ${({ size }: { size?: "large" | "small" }) =>

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -44,7 +44,7 @@ export function SemaphoreGroupProveScreen({
 
       // Give the UI has a chance to update to the 'loading' state before the
       // potentially blocking proving operation kicks off
-      sleep(200);
+      await sleep(200);
 
       const args = await fillArgs(state.identity, group, req.args);
 

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -4,12 +4,9 @@ import {
   SemaphoreGroupPCDArgs,
   SemaphoreGroupPCDPackage,
   SerializedSemaphoreGroup,
-  serializeSemaphoreGroup,
 } from "@pcd/semaphore-group-pcd";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
-import { Group } from "@semaphore-protocol/group";
 import { Identity } from "@semaphore-protocol/identity";
-import * as React from "react";
 import { ReactNode, useCallback, useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 import { requestPendingPCD } from "../../../src/api/requestPendingPCD";
@@ -120,11 +117,6 @@ async function fillArgs(
   semaphoreGroup: SerializedSemaphoreGroup,
   reqArgs: SemaphoreGroupPCDArgs
 ): Promise<SemaphoreGroupPCDArgs> {
-  const group = new Group(BigInt(semaphoreGroup.id), semaphoreGroup.depth);
-  for (const member of semaphoreGroup.members) {
-    group.addMember(BigInt(member));
-  }
-
   let args: SemaphoreGroupPCDArgs = {
     externalNullifier: {
       argumentType: ArgumentTypeName.BigInt,
@@ -136,7 +128,7 @@ async function fillArgs(
     },
     group: {
       argumentType: ArgumentTypeName.Object,
-      value: serializeSemaphoreGroup(group, "Zuzalu Attendees"),
+      value: semaphoreGroup,
     },
     identity: {
       argumentType: ArgumentTypeName.PCD,
@@ -159,11 +151,6 @@ async function fillArgs(
   if (reqArgs.signal.value !== undefined) {
     args = { ...args, signal: reqArgs.signal };
   }
-
-  console.log("Proving semaphore membership", args);
-  console.log("Group root", group.root.toString());
-  console.log("Group first member", group.members[0]);
-  console.log("Identity", identity.commitment.toString());
 
   return args;
 }

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -21,9 +21,11 @@ export function SemaphoreGroupProveScreen({
   req: PCDGetRequest<typeof SemaphoreGroupPCDPackage>;
 }) {
   const [error, setError] = useState<string | undefined>();
+  const [group, setGroup] = useState<SerializedSemaphoreGroup | null>(null);
+  const [state] = useContext(DispatchContext);
+  const [proving, setProving] = useState(false);
+  const isLoading = group === null;
 
-  // Load semaphore group
-  const [group, setGroup] = useState<SerializedSemaphoreGroup>(null);
   useEffect(() => {
     const fetchGroup = async () => {
       const res = await fetch(req.args.group.remoteUrl);
@@ -33,10 +35,6 @@ export function SemaphoreGroupProveScreen({
     };
     fetchGroup().catch(console.error);
   }, [req.args.group.remoteUrl]);
-
-  // Once that's done & user clicks Prove, create a zero-knowledge proof
-  const [state] = useContext(DispatchContext);
-  const [proving, setProving] = useState(false);
 
   const onProve = useCallback(async () => {
     try {
@@ -96,7 +94,11 @@ export function SemaphoreGroupProveScreen({
   }
 
   if (!proving && error === undefined) {
-    lines.push(<Button onClick={onProve}>Prove</Button>);
+    lines.push(
+      <Button disabled={isLoading} onClick={onProve}>
+        {isLoading ? "Loading..." : "Prove"}
+      </Button>
+    );
   } else if (error !== undefined) {
     lines.push(<ErrorContainer>{error}</ErrorContainer>);
   } else {

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
@@ -7,7 +7,6 @@ import {
 } from "@pcd/semaphore-signature-pcd";
 import { Identity } from "@semaphore-protocol/identity";
 import { cloneDeep } from "lodash";
-import * as React from "react";
 import { ReactNode, useCallback, useContext, useState } from "react";
 import styled from "styled-components";
 import { requestPendingPCD } from "../../../src/api/requestPendingPCD";
@@ -30,7 +29,7 @@ export function SemaphoreSignatureProveScreen({
 
       // Give the UI has a chance to update to the 'loading' state before the
       // potentially blocking proving operation kicks off
-      sleep(200);
+      await sleep(200);
 
       const modifiedArgs = cloneDeep(req.args);
       const args = await fillArgs(


### PR DESCRIPTION
closes https://github.com/proofcarryingdata/zupass/issues/197
closes https://github.com/proofcarryingdata/zupass/issues/216

Also halves the amount of time it takes to generate a group membership proof by only deserializing the group once rather than twice. I've confirmed that the prod merkle tree (300-400 members) takes 3-4 seconds to generate.

<img width="373" alt="Screenshot 2023-04-20 at 7 46 07 PM" src="https://user-images.githubusercontent.com/2636237/233457750-2550606f-d36e-4f5c-89db-20a334d13c13.png">

#### group proof screen loading state
https://user-images.githubusercontent.com/2636237/233457292-bc0ae351-bb57-4f74-a46b-bf114a1dba00.mov
