### PR TITLE
set passport to invalid state if there's a commitment or uuid mismatch 

### DIFF
--- a/apps/passport-client/src/participant.ts
+++ b/apps/passport-client/src/participant.ts
@@ -22,18 +22,7 @@ export async function pollParticipant(
     }
 
     const participant = await response.json();
-
-    try {
-      await dispatch({ type: "set-self", self: participant });
-    } catch (e: any) {
-      console.log("failed to set self");
-      if (typeof e.message === "string") {
-        const msgString: string = e.message;
-        if (msgString.includes("mismatch")) {
-          dispatch({ type: "participant-invalid" });
-        }
-      }
-    }
+    await dispatch({ type: "set-self", self: participant });
   } catch (e) {
     console.error("[USER_POLL] Error polling participant", e);
   }

--- a/apps/passport-client/src/participant.ts
+++ b/apps/passport-client/src/participant.ts
@@ -20,8 +20,20 @@ export async function pollParticipant(
       console.log("[USER_POLL] Participant not found, skipping update");
       return;
     }
+
     const participant = await response.json();
-    dispatch({ type: "set-self", self: participant });
+
+    try {
+      await dispatch({ type: "set-self", self: participant });
+    } catch (e: any) {
+      console.log("failed to set self");
+      if (typeof e.message === "string") {
+        const msgString: string = e.message;
+        if (msgString.includes("mismatch")) {
+          dispatch({ type: "participant-invalid" });
+        }
+      }
+    }
   } catch (e) {
     console.error("[USER_POLL] Error polling participant", e);
   }


### PR DESCRIPTION
... upon loading the participant from the server - i.e. if the user logged in on another device and overwrote their old commitment

closes https://github.com/proofcarryingdata/zupass/issues/226