### PR TITLE
fix npe on passport reset

### DIFF
--- a/apps/passport-client/src/api/endToEndEncryptionApi.ts
+++ b/apps/passport-client/src/api/endToEndEncryptionApi.ts
@@ -8,7 +8,7 @@ import { config } from "../config";
 
 export async function downloadEncryptedStorage(
   blobKey: string
-): Promise<EncryptedPacket> {
+): Promise<EncryptedPacket | null> {
   const request: LoadE2EERequest = {
     blobKey,
   };
@@ -23,6 +23,11 @@ export async function downloadEncryptedStorage(
       Accept: "application/json",
     },
   });
+
+  if (response.status === 404) {
+    return null;
+  }
+
   if (!response.ok) {
     throw new Error(await response.text());
   }

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -341,13 +341,29 @@ async function sync(state: ZuState, update: ZuUpdate) {
     update({
       downloadingPCDs: true,
     });
-    const pcds = await downloadStorage();
-    update({
-      downloadedPCDs: true,
-      downloadingPCDs: false,
-      pcds: pcds,
-      uploadedUploadId: state.pcds.getUploadId(),
-    });
+    try {
+      const pcds = await downloadStorage();
+      update({
+        downloadedPCDs: true,
+        downloadingPCDs: false,
+        pcds: pcds,
+        uploadedUploadId: state.pcds.getUploadId(),
+      });
+    } catch (e) {
+      if (typeof e.message === "string") {
+        if (e.message.includes("can't load e2ee: never saved")) {
+          console.log(
+            `[SYNC] E2EE has never been uploaded, skipping download in favor` +
+              ` of writing the storage for the first time`
+          );
+          update({
+            downloadedPCDs: true,
+            downloadingPCDs: false,
+          });
+        }
+      }
+    }
+
     return;
   }
 

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -341,27 +341,24 @@ async function sync(state: ZuState, update: ZuUpdate) {
     update({
       downloadingPCDs: true,
     });
-    try {
-      const pcds = await downloadStorage();
+
+    const pcds = await downloadStorage();
+
+    if (pcds != null) {
       update({
         downloadedPCDs: true,
         downloadingPCDs: false,
         pcds: pcds,
         uploadedUploadId: pcds.getUploadId(),
       });
-    } catch (e) {
-      if (typeof e.message === "string") {
-        if (e.message.includes("can't load e2ee: never saved")) {
-          console.log(
-            `[SYNC] E2EE has never been uploaded, skipping download in favor` +
-              ` of writing the storage for the first time`
-          );
-          update({
-            downloadedPCDs: true,
-            downloadingPCDs: false,
-          });
-        }
-      }
+    } else {
+      console.log(
+        `[SYNC] skipping download in favor of writing the storage for the first time`
+      );
+      update({
+        downloadedPCDs: true,
+        downloadingPCDs: false,
+      });
     }
 
     return;

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -14,6 +14,7 @@ import { Identity } from "@semaphore-protocol/identity";
 import { createContext } from "react";
 import { config } from "./config";
 import {
+  loadEncryptionKey,
   saveEncryptionKey,
   saveIdentity,
   saveParticipantInvalid,
@@ -329,6 +330,11 @@ function participantInvalid(update: ZuUpdate) {
  */
 async function sync(state: ZuState, update: ZuUpdate) {
   console.log("[SYNC] calculating correct sync action");
+
+  if ((await loadEncryptionKey()) == null) {
+    console.log("[SYNC] no encryption key, can't sync");
+    return;
+  }
 
   if (!state.downloadedPCDs && !state.downloadingPCDs) {
     console.log("[SYNC] sync action: download");

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -347,7 +347,7 @@ async function sync(state: ZuState, update: ZuUpdate) {
         downloadedPCDs: true,
         downloadingPCDs: false,
         pcds: pcds,
-        uploadedUploadId: state.pcds.getUploadId(),
+        uploadedUploadId: pcds.getUploadId(),
       });
     } catch (e) {
       if (typeof e.message === "string") {

--- a/apps/passport-client/src/useSyncE2EEStorage.tsx
+++ b/apps/passport-client/src/useSyncE2EEStorage.tsx
@@ -48,12 +48,16 @@ export async function uploadStorage(): Promise<void> {
  * Given the encryption key in local storage, downloads the e2ee
  * encrypted storage from the server.
  */
-export async function downloadStorage(): Promise<PCDCollection> {
+export async function downloadStorage(): Promise<PCDCollection | null> {
   console.log("[SYNC] downloading e2ee storage");
-
   const encryptionKey = await loadEncryptionKey();
   const blobHash = await getHash(encryptionKey);
   const storage = await downloadEncryptedStorage(blobHash);
+
+  if (storage == null) {
+    return null;
+  }
+
   const decrypted = await passportDecrypt(storage, encryptionKey);
   const pcds = new PCDCollection(await getPackages(), []);
   await pcds.deserializeAllAndAdd(decrypted.pcds);

--- a/apps/passport-server/src/routing/routes/zuzaluRoutes.ts
+++ b/apps/passport-server/src/routing/routes/zuzaluRoutes.ts
@@ -241,6 +241,7 @@ export function initZuzaluRoutes(
       if (request.blobKey === undefined) {
         throw new Error("Can't load e2ee: missing blobKey");
       }
+
       console.log(`[E2EE] Loading ${request.blobKey}`);
 
       try {
@@ -250,7 +251,11 @@ export function initZuzaluRoutes(
         );
 
         if (!storageModel) {
-          throw new Error("can't load e2ee: never saved");
+          console.log(
+            `can't load e2ee: never saved sync key ${request.blobKey}`
+          );
+          res.sendStatus(404);
+          return;
         }
 
         const result: LoadE2EEResponse = {


### PR DESCRIPTION
### summary

This PR fixes two issues that I observed in rollbar. Neither of them causes user-visible errors.


#### issue number one
rollbar links: 
- https://app.rollbar.com/a/0xparc/fix/item/zupass/52
- https://app.rollbar.com/a/0xparc/fix/item/zupass/53

in some cases, the user does not have a sync key saved in local storage. i have only been able to reproduce this by clearing the passport using the 'clear passport' button, but I suspect there are some other cases where there is no sync key.

the fix for this issue is the first commit of this pr

#### issue number two
rollbar links (i'm not sure how to merge issues in rollbar)
- https://app.rollbar.com/a/0xparc/fix/item/zupass/54
- https://app.rollbar.com/a/0xparc/fix/item/zupass/55
- https://app.rollbar.com/a/0xparc/fix/item/zupass/56
- https://app.rollbar.com/a/0xparc/fix/item/zupass/57


in some cases, the user has a valid passport without having uploaded their passport data to e2ee for some reason. i think I made it less likely for a user to end up in this state in my previous sync pr by making the passport to save e2ee before redirecting the user to the home page with all their pcds only after their pcds have been uploaded to e2ee.

however, i think it is still possible for someone to end up in this state if they refresh the page after signing up, but before the upload to e2ee has completed.

so, that takes me to commit number two, which ensures that the sync goes through even in the case that there hasn't been a valid e2ee upload before, by catching the exception, and setting some local state that allows the sync to proceed.

I was able to reproduce this issue locally by deleting e2ee storage from the database. the error only appeared in the console, and did not break user-facing functionality, except for sync.