### PR TITLE
service worker

### DIFF
--- a/apps/passport-client/.gitignore
+++ b/apps/passport-client/.gitignore
@@ -2,3 +2,4 @@
 # Esbuild generated output
 public/js
 .env
+public/service-worker.js

--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -53,6 +53,12 @@ const serviceWorkerOpts: BuildOptions = {
   // workers are only able to be attached to the same scope as they
   // themselves are served from.
   outdir: "public/",
+  // Service workers are only updated when the binary contents of their
+  // files changes. The service worker for zupass.org uses this environment
+  // variable, which causes its contents to be changed every time `build.ts`
+  // is invoked, so that each new production deploy invalidates the previous
+  // service worker, which clears zupass.org application code (html, js, etc.),
+  // so that clients are not forever stuck on one version of the code.
   define: { ...define, "process.env.SW_ID": JSON.stringify(uuid()) },
 };
 

--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -2,6 +2,7 @@ import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfil
 import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 import * as dotenv from "dotenv";
 import { build, BuildOptions, context } from "esbuild";
+import { v4 as uuid } from "uuid";
 
 dotenv.config();
 
@@ -52,7 +53,7 @@ const serviceWorkerOpts: BuildOptions = {
   // workers are only able to be attached to the same scope as they
   // themselves are served from.
   outdir: "public/",
-  define,
+  define: { ...define, "process.env.SW_ID": JSON.stringify(uuid()) },
 };
 
 run(process.argv[2])

--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -2,13 +2,46 @@ import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfil
 import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 import * as dotenv from "dotenv";
 import { build, BuildOptions, context } from "esbuild";
+import http from "http";
 
 dotenv.config();
 
-const opts: BuildOptions = {
+const passportAppOpts: BuildOptions = {
   sourcemap: true,
   bundle: true,
-  entryPoints: ["pages/index.tsx", "src/service-worker.ts"],
+  entryPoints: ["pages/index.tsx"],
+  plugins: [
+    NodeModulesPolyfillPlugin(),
+    NodeGlobalsPolyfillPlugin({
+      process: true,
+      buffer: true,
+    }),
+  ],
+  loader: {
+    ".svg": "dataurl",
+  },
+  define: {
+    "process.env.PASSPORT_SERVER_URL": JSON.stringify(
+      process.env.PASSPORT_SERVER_URL || "http://localhost:3002"
+    ),
+    "process.env.NODE_ENV": JSON.stringify(
+      process.env.NODE_ENV || "development"
+    ),
+    ...(process.env.ROLLBAR_TOKEN !== undefined
+      ? {
+          "process.env.ROLLBAR_TOKEN": JSON.stringify(
+            process.env.ROLLBAR_TOKEN
+          ),
+        }
+      : {}),
+  },
+  outdir: "public/js",
+};
+
+const serviceWorkerOpts: BuildOptions = {
+  sourcemap: true,
+  bundle: true,
+  entryPoints: ["src/service-worker.ts"],
   plugins: [
     NodeModulesPolyfillPlugin(),
     NodeGlobalsPolyfillPlugin({
@@ -44,17 +77,56 @@ run(process.argv[2])
 async function run(command: string) {
   switch (command) {
     case "build":
-      const res = await build({ ...opts, minify: true });
-      console.error("Built", res);
+      const passportRes = await build({ ...passportAppOpts, minify: true });
+      console.error("Built", passportRes);
+      const serviceWorkerRes = await build({
+        ...serviceWorkerOpts,
+        minify: true,
+      });
+      console.error("Built", serviceWorkerRes);
       break;
     case "dev":
-      const ctx = await context(opts);
+      const serviceWorkerCtx = await context(serviceWorkerOpts);
+      await serviceWorkerCtx.watch();
+
+      const ctx = await context(passportAppOpts);
       await ctx.watch();
+
       const { host } = await ctx.serve({
         servedir: "public",
-        port: 3000,
+        port: 2999,
         host: "0.0.0.0",
       });
+
+      // Then start a proxy server on port 3000
+      console.log("starting server");
+      http
+        .createServer((req, res) => {
+          const options = {
+            hostname: host,
+            port: 2999,
+            path: req.url,
+            method: req.method,
+            headers: req.headers,
+          };
+
+          console.log(`${options.method} - ${options.path}`);
+
+          const proxyReq = http.request(options, (proxyRes) => {
+            if (options.path === "/js/service-worker.js") {
+              console.log("updating content type");
+              proxyRes.headers["content-type"] = "application/javascript";
+              proxyRes.headers["Service-Worker-Allowed"] = "/";
+            }
+
+            res.writeHead(proxyRes.statusCode, proxyRes.headers);
+            proxyRes.pipe(res, { end: true });
+          });
+
+          req.pipe(proxyReq, { end: true });
+        })
+        .listen(3000);
+
       console.log(`Serving passport client on ${host}`);
       break;
     default:

--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -39,6 +39,7 @@ const passportAppOpts: BuildOptions = {
 };
 
 const serviceWorkerOpts: BuildOptions = {
+  tsconfig: "./service-worker-tsconfig.json",
   sourcemap: true,
   bundle: true,
   entryPoints: ["src/service-worker.ts"],

--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -8,7 +8,7 @@ dotenv.config();
 const opts: BuildOptions = {
   sourcemap: true,
   bundle: true,
-  entryPoints: ["pages/index.tsx"],
+  entryPoints: ["pages/index.tsx", "src/service-worker.ts"],
   plugins: [
     NodeModulesPolyfillPlugin(),
     NodeGlobalsPolyfillPlugin({

--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -6,6 +6,18 @@ import http from "http";
 
 dotenv.config();
 
+const define = {
+  "process.env.PASSPORT_SERVER_URL": JSON.stringify(
+    process.env.PASSPORT_SERVER_URL || "http://localhost:3002"
+  ),
+  "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV || "development"),
+  ...(process.env.ROLLBAR_TOKEN !== undefined
+    ? {
+        "process.env.ROLLBAR_TOKEN": JSON.stringify(process.env.ROLLBAR_TOKEN),
+      }
+    : {}),
+};
+
 const passportAppOpts: BuildOptions = {
   sourcemap: true,
   bundle: true,
@@ -20,27 +32,12 @@ const passportAppOpts: BuildOptions = {
   loader: {
     ".svg": "dataurl",
   },
-  define: {
-    "process.env.PASSPORT_SERVER_URL": JSON.stringify(
-      process.env.PASSPORT_SERVER_URL || "http://localhost:3002"
-    ),
-    "process.env.NODE_ENV": JSON.stringify(
-      process.env.NODE_ENV || "development"
-    ),
-    ...(process.env.ROLLBAR_TOKEN !== undefined
-      ? {
-          "process.env.ROLLBAR_TOKEN": JSON.stringify(
-            process.env.ROLLBAR_TOKEN
-          ),
-        }
-      : {}),
-  },
   outdir: "public/js",
+  define,
 };
 
 const serviceWorkerOpts: BuildOptions = {
   tsconfig: "./service-worker-tsconfig.json",
-  sourcemap: true,
   bundle: true,
   entryPoints: ["src/service-worker.ts"],
   plugins: [
@@ -50,25 +47,13 @@ const serviceWorkerOpts: BuildOptions = {
       buffer: true,
     }),
   ],
-  loader: {
-    ".svg": "dataurl",
-  },
-  define: {
-    "process.env.PASSPORT_SERVER_URL": JSON.stringify(
-      process.env.PASSPORT_SERVER_URL || "http://localhost:3002"
-    ),
-    "process.env.NODE_ENV": JSON.stringify(
-      process.env.NODE_ENV || "development"
-    ),
-    ...(process.env.ROLLBAR_TOKEN !== undefined
-      ? {
-          "process.env.ROLLBAR_TOKEN": JSON.stringify(
-            process.env.ROLLBAR_TOKEN
-          ),
-        }
-      : {}),
-  },
-  outdir: "public/js",
+  // The output directory here needs to be `public/` rather than
+  // `public/js` in order for the service worker to be served from
+  // the root of the website, which is necessary because service
+  // workers are only able to be attached to the same scope as they
+  // themselves are served from.
+  outdir: "public/",
+  define,
 };
 
 run(process.argv[2])
@@ -116,7 +101,7 @@ async function run(command: string) {
           const proxyReq = http.request(options, (proxyRes) => {
             if (options.path === "/js/service-worker.js") {
               console.log("updating content type");
-              proxyRes.headers["content-type"] = "application/javascript";
+              // proxyRes.headers["content-type"] = "application/javascript";
               proxyRes.headers["Service-Worker-Allowed"] = "/";
             }
 

--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -2,7 +2,6 @@ import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfil
 import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 import * as dotenv from "dotenv";
 import { build, BuildOptions, context } from "esbuild";
-import http from "http";
 
 dotenv.config();
 
@@ -80,38 +79,9 @@ async function run(command: string) {
 
       const { host } = await ctx.serve({
         servedir: "public",
-        port: 2999,
+        port: 3000,
         host: "0.0.0.0",
       });
-
-      // Then start a proxy server on port 3000
-      console.log("starting server");
-      http
-        .createServer((req, res) => {
-          const options = {
-            hostname: host,
-            port: 2999,
-            path: req.url,
-            method: req.method,
-            headers: req.headers,
-          };
-
-          console.log(`${options.method} - ${options.path}`);
-
-          const proxyReq = http.request(options, (proxyRes) => {
-            if (options.path === "/js/service-worker.js") {
-              console.log("updating content type");
-              // proxyRes.headers["content-type"] = "application/javascript";
-              proxyRes.headers["Service-Worker-Allowed"] = "/";
-            }
-
-            res.writeHead(proxyRes.statusCode, proxyRes.headers);
-            proxyRes.pipe(res, { end: true });
-          });
-
-          req.pipe(proxyReq, { end: true });
-        })
-        .listen(3000);
 
       console.log(`Serving passport client on ${host}`);
       break;

--- a/apps/passport-client/components/shared/PCDCard.tsx
+++ b/apps/passport-client/components/shared/PCDCard.tsx
@@ -30,7 +30,7 @@ export function PCDCard({
     }
   }, [pcd, pcdPackage]);
   const header = isZuzaluIdentity
-    ? "VERIFIED ZUZALU PASSPORT 2"
+    ? "VERIFIED ZUZALU PASSPORT"
     : displayOptions?.header?.toUpperCase() ?? "PCD";
 
   if (expanded) {

--- a/apps/passport-client/components/shared/PCDCard.tsx
+++ b/apps/passport-client/components/shared/PCDCard.tsx
@@ -1,5 +1,4 @@
 import { PCD } from "@pcd/pcd-types";
-import * as React from "react";
 import { useCallback, useContext, useMemo } from "react";
 import styled from "styled-components";
 import { DispatchContext } from "../../src/dispatch";
@@ -31,7 +30,7 @@ export function PCDCard({
     }
   }, [pcd, pcdPackage]);
   const header = isZuzaluIdentity
-    ? "VERIFIED ZUZALU PASSPORT"
+    ? "VERIFIED ZUZALU PASSPORT 2"
     : displayOptions?.header?.toUpperCase() ?? "PCD";
 
   if (expanded) {

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -24,7 +24,7 @@ import {
   saveIdentity,
 } from "../src/localstorage";
 import { pollParticipant } from "../src/participant";
-import { registerServiceWorker } from "../src/serviceWorkerUtils";
+import { registerServiceWorker } from "../src/registerServiceWorker";
 import { ZuState } from "../src/state";
 
 class App extends React.Component<object, ZuState> {

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -24,6 +24,7 @@ import {
   saveIdentity,
 } from "../src/localstorage";
 import { pollParticipant } from "../src/participant";
+import { registerServiceWorker } from "../src/serviceWorkerUtils";
 import { ZuState } from "../src/state";
 
 class App extends React.Component<object, ZuState> {
@@ -145,6 +146,8 @@ async function loadInitialState(): Promise<ZuState> {
 if (!["zupass.org", "localhost"].includes(window.location.hostname)) {
   window.location.replace("https://zupass.org/" + window.location.hash);
 }
+
+registerServiceWorker();
 
 const root = createRoot(document.querySelector("#root"));
 root.render(

--- a/apps/passport-client/service-worker-tsconfig.json
+++ b/apps/passport-client/service-worker-tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2015", "DOM", "WebWorker"]
+  }
+}

--- a/apps/passport-client/src/pcdPackages.ts
+++ b/apps/passport-client/src/pcdPackages.ts
@@ -22,23 +22,23 @@ async function loadPackages(): Promise<PCDPackage[]> {
   const SERVER_STATIC_URL = config.passportServer + "/static/";
 
   await SemaphoreGroupPCDPackage.init({
-    wasmFilePath: SERVER_STATIC_URL + "/semaphore-artifacts/16.wasm",
-    zkeyFilePath: SERVER_STATIC_URL + "/semaphore-artifacts/16.zkey",
+    wasmFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.wasm",
+    zkeyFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.zkey",
   });
 
   await SemaphoreSignaturePCDPackage.init({
-    wasmFilePath: SERVER_STATIC_URL + "/semaphore-artifacts/16.wasm",
-    zkeyFilePath: SERVER_STATIC_URL + "/semaphore-artifacts/16.zkey",
+    wasmFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.wasm",
+    zkeyFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.zkey",
   });
 
   await EthereumOwnershipPCDPackage.init({
-    wasmFilePath: SERVER_STATIC_URL + "/semaphore-artifacts/16.wasm",
-    zkeyFilePath: SERVER_STATIC_URL + "/semaphore-artifacts/16.zkey",
+    wasmFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.wasm",
+    zkeyFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.zkey",
   });
 
   await RLNPCDPackage.init({
-    wasmFilePath: SERVER_STATIC_URL + "/rln-artifacts/16.wasm",
-    zkeyFilePath: SERVER_STATIC_URL + "/rln-artifacts/16.zkey",
+    wasmFilePath: SERVER_STATIC_URL + "rln-artifacts/16.wasm",
+    zkeyFilePath: SERVER_STATIC_URL + "rln-artifacts/16.zkey",
   });
 
   return [

--- a/apps/passport-client/src/pcdPackages.ts
+++ b/apps/passport-client/src/pcdPackages.ts
@@ -22,18 +22,18 @@ async function loadPackages(): Promise<PCDPackage[]> {
   const SERVER_STATIC_URL = config.passportServer + "/static/";
 
   await SemaphoreGroupPCDPackage.init({
-    wasmFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.wasm",
-    zkeyFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.zkey",
+    wasmFilePath: "/semaphore-artifacts/16.wasm",
+    zkeyFilePath: "/semaphore-artifacts/16.zkey",
   });
 
   await SemaphoreSignaturePCDPackage.init({
-    wasmFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.wasm",
-    zkeyFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.zkey",
+    wasmFilePath: "/semaphore-artifacts/16.wasm",
+    zkeyFilePath: "/semaphore-artifacts/16.zkey",
   });
 
   await EthereumOwnershipPCDPackage.init({
-    wasmFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.wasm",
-    zkeyFilePath: SERVER_STATIC_URL + "semaphore-artifacts/16.zkey",
+    wasmFilePath: "/semaphore-artifacts/16.wasm",
+    zkeyFilePath: "/semaphore-artifacts/16.zkey",
   });
 
   await RLNPCDPackage.init({

--- a/apps/passport-client/src/registerServiceWorker.ts
+++ b/apps/passport-client/src/registerServiceWorker.ts
@@ -11,6 +11,13 @@
  * iteration loops.
  */
 export async function registerServiceWorker() {
+  if (process.env.NODE_ENV === "development") {
+    console.log(
+      `[SERVICE_WORKER] not registering service worker in development mode`
+    );
+    return;
+  }
+
   const serviceWorkerPath = "/service-worker.js";
 
   console.log(`[SERVICE_WORKER] attempting to register ${serviceWorkerPath}`);

--- a/apps/passport-client/src/registerServiceWorker.ts
+++ b/apps/passport-client/src/registerServiceWorker.ts
@@ -1,3 +1,15 @@
+/**
+ * Installs a service worker which caches application code and
+ * various artifacts needed by the application, so that the website
+ * works offline, and so that it loads fast.
+ *
+ * The service worker is invalidated each time there is a production
+ * deploy.
+ *
+ * The service worker is not installed in development mode, so that
+ * its caching of application code does not interfere with quick
+ * iteration loops.
+ */
 export async function registerServiceWorker() {
   const serviceWorkerPath = "/service-worker.js";
 

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -1,7 +1,5 @@
 // this file is loaded as a service worker
 
-console.log("test");
-
 async function addResourcesToCache(resources: string[]): Promise<void> {
   const cache = await caches.open("v1");
   await cache.addAll(resources);

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -1,0 +1,3 @@
+// this file is loaded as a service worker
+
+console.log("service worker");

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -1,23 +1,13 @@
 // this file is loaded as a service worker
 
-const addResourcesToCache = async (resources: string[]) => {
+async function addResourcesToCache(resources: string[]): Promise<void> {
   const cache = await caches.open("v1");
   await cache.addAll(resources);
-};
-
-const cacheFirst = async (request) => {
-  const responseFromCache = await caches.match(request);
-  if (responseFromCache) {
-    return responseFromCache;
-  }
-  return fetch(request);
-};
-
-self.addEventListener("fetch", (event: any) => {
-  event.respondWith(cacheFirst(event.request));
-});
+}
 
 self.addEventListener("install", (event: any) => {
+  console.log("[SERVICE_WORKER] installing");
+
   event.waitUntil(
     addResourcesToCache([
       "/",
@@ -28,4 +18,26 @@ self.addEventListener("install", (event: any) => {
       "/semaphore-artifacts/16.zkey",
     ])
   );
+
+  console.log("[SERVICE_WORKER] installed");
+});
+
+async function cacheFirst(request): Promise<Response> {
+  const responseFromCache = await caches.match(request);
+
+  if (responseFromCache) {
+    console.log("[SERVICE_WORKER] cache hit ", request?.url);
+    return responseFromCache;
+  } else {
+    console.log("[SERVICE_WORKER] cache miss", request?.url);
+    return fetch(request);
+  }
+}
+
+self.addEventListener("fetch", (event: any) => {
+  event.respondWith(cacheFirst(event.request));
+});
+
+self.addEventListener("activate", () => {
+  console.log("[SERVICE_WORKER] activated");
 });

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -7,6 +7,7 @@ async function addResourcesToCache(resources: string[]): Promise<void> {
 
 self.addEventListener("install", (event: any) => {
   console.log("[SERVICE_WORKER] installing");
+  (self as any).skipWaiting();
 
   event.waitUntil(
     addResourcesToCache([

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -1,21 +1,23 @@
 // this file is loaded as a service worker
 
+const impermanentCache = ["/", "/index.html", "/global.css", "/js/index.js"];
+
 async function addResourcesToCache(resources: string[]): Promise<void> {
   const cache = await caches.open("v1");
+
+  await Promise.all(impermanentCache.map((item) => cache.delete(item)));
+
   await cache.addAll(resources);
 }
 
 self.addEventListener("install", (event: any) => {
-  console.log("[SERVICE_WORKER] installing");
+  console.log(`[SERVICE_WORKER] installing ${process.env.SW_ID}`);
   (self as any).skipWaiting();
 
   event.waitUntil(
     addResourcesToCache([
-      "/",
+      ...impermanentCache,
       "/favicon.ico",
-      "/index.html",
-      "/global.css",
-      "/js/index.js",
       "/semaphore-artifacts/16.wasm",
       "/semaphore-artifacts/16.zkey",
       "/fonts/IBMPlexSans-Regular.ttf",
@@ -24,7 +26,7 @@ self.addEventListener("install", (event: any) => {
     ])
   );
 
-  console.log("[SERVICE_WORKER] installed");
+  console.log(`[SERVICE_WORKER] installed ${process.env.SW_ID}`);
 });
 
 async function cacheFirst(request): Promise<Response> {
@@ -44,5 +46,5 @@ self.addEventListener("fetch", (event: any) => {
 });
 
 self.addEventListener("activate", () => {
-  console.log("[SERVICE_WORKER] activated");
+  console.log(`[SERVICE_WORKER] activated ${process.env.SW_ID}`);
 });

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -1,3 +1,18 @@
 // this file is loaded as a service worker
 
-console.log("service worker");
+const addResourcesToCache = async (resources: string[]) => {
+  const cache = await caches.open("v1");
+  await cache.addAll(resources);
+};
+
+self.addEventListener("install", (event: any) => {
+  event.waitUntil(
+    addResourcesToCache([
+      "/",
+      "/index.html",
+      "/global.css",
+      "/js/index.js",
+      "/image-list.js",
+    ])
+  );
+});

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -11,11 +11,15 @@ self.addEventListener("install", (event: any) => {
   event.waitUntil(
     addResourcesToCache([
       "/",
+      "/favicon.ico",
       "/index.html",
       "/global.css",
       "/js/index.js",
       "/semaphore-artifacts/16.wasm",
       "/semaphore-artifacts/16.zkey",
+      "/fonts/IBMPlexSans-Regular.ttf",
+      "/fonts/IBMPlexSans-Medium.ttf",
+      "/fonts/IBMPlexSans-Light.ttf",
     ])
   );
 

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -1,5 +1,11 @@
 // this file is loaded as a service worker
 
+/**
+ * These files are cleared from the cache every time a new version
+ * of the service worker is installed, because a new version of
+ * the service worker is triggered by a change in the service worker
+ * source code, which happens each time production deploys.
+ */
 const impermanentCache = ["/", "/index.html", "/global.css", "/js/index.js"];
 
 async function addResourcesToCache(resources: string[]): Promise<void> {

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -1,5 +1,7 @@
 // this file is loaded as a service worker
 
+console.log("test");
+
 async function addResourcesToCache(resources: string[]): Promise<void> {
   const cache = await caches.open("v1");
   await cache.addAll(resources);

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -5,6 +5,18 @@ const addResourcesToCache = async (resources: string[]) => {
   await cache.addAll(resources);
 };
 
+const cacheFirst = async (request) => {
+  const responseFromCache = await caches.match(request);
+  if (responseFromCache) {
+    return responseFromCache;
+  }
+  return fetch(request);
+};
+
+self.addEventListener("fetch", (event: any) => {
+  event.respondWith(cacheFirst(event.request));
+});
+
 self.addEventListener("install", (event: any) => {
   event.waitUntil(
     addResourcesToCache([

--- a/apps/passport-client/src/service-worker.ts
+++ b/apps/passport-client/src/service-worker.ts
@@ -12,7 +12,8 @@ self.addEventListener("install", (event: any) => {
       "/index.html",
       "/global.css",
       "/js/index.js",
-      "/image-list.js",
+      "/semaphore-artifacts/16.wasm",
+      "/semaphore-artifacts/16.zkey",
     ])
   );
 });

--- a/apps/passport-client/src/serviceWorkerUtils.ts
+++ b/apps/passport-client/src/serviceWorkerUtils.ts
@@ -1,12 +1,16 @@
 export async function registerServiceWorker() {
-  if (!("serviceworker" in navigator)) {
+  const serviceWorkerPath = "/js/service-worker.js";
+
+  console.log(`[SERVICE_WORKER] attempting to register ${serviceWorkerPath}`);
+
+  if (!("serviceWorker" in navigator)) {
+    console.log(`[SERVICE_WORKER] service workers not supported`);
     return;
   }
-  const serviceWorkerPath = "/js/src/service-worker.js";
 
   try {
     await navigator.serviceWorker.register(serviceWorkerPath, {
-      scope: "/*",
+      scope: "/",
     });
     console.log(`[SERVICE_WORKER] registered ${serviceWorkerPath}`);
   } catch (e) {

--- a/apps/passport-client/src/serviceWorkerUtils.ts
+++ b/apps/passport-client/src/serviceWorkerUtils.ts
@@ -12,6 +12,7 @@ export async function registerServiceWorker() {
     await navigator.serviceWorker.register(serviceWorkerPath, {
       scope: "/",
     });
+
     console.log(`[SERVICE_WORKER] registered ${serviceWorkerPath}`);
   } catch (e) {
     console.log(

--- a/apps/passport-client/src/serviceWorkerUtils.ts
+++ b/apps/passport-client/src/serviceWorkerUtils.ts
@@ -1,5 +1,5 @@
 export async function registerServiceWorker() {
-  const serviceWorkerPath = "/js/service-worker.js";
+  const serviceWorkerPath = "/service-worker.js";
 
   console.log(`[SERVICE_WORKER] attempting to register ${serviceWorkerPath}`);
 
@@ -9,12 +9,9 @@ export async function registerServiceWorker() {
   }
 
   try {
-    const registration = await navigator.serviceWorker.register(
-      serviceWorkerPath,
-      {
-        scope: "/",
-      }
-    );
+    await navigator.serviceWorker.register(serviceWorkerPath, {
+      scope: "/",
+    });
     console.log(`[SERVICE_WORKER] registered ${serviceWorkerPath}`);
   } catch (e) {
     console.log(

--- a/apps/passport-client/src/serviceWorkerUtils.ts
+++ b/apps/passport-client/src/serviceWorkerUtils.ts
@@ -1,0 +1,18 @@
+export async function registerServiceWorker() {
+  if (!("serviceworker" in navigator)) {
+    return;
+  }
+  const serviceWorkerPath = "/js/src/service-worker.js";
+
+  try {
+    await navigator.serviceWorker.register(serviceWorkerPath, {
+      scope: "/*",
+    });
+    console.log(`[SERVICE_WORKER] registered ${serviceWorkerPath}`);
+  } catch (e) {
+    console.log(
+      `[SERVICE_WORKER] error registering service worker ${serviceWorkerPath}`,
+      e
+    );
+  }
+}

--- a/apps/passport-client/src/serviceWorkerUtils.ts
+++ b/apps/passport-client/src/serviceWorkerUtils.ts
@@ -9,9 +9,12 @@ export async function registerServiceWorker() {
   }
 
   try {
-    await navigator.serviceWorker.register(serviceWorkerPath, {
-      scope: "/",
-    });
+    const registration = await navigator.serviceWorker.register(
+      serviceWorkerPath,
+      {
+        scope: "/",
+      }
+    );
     console.log(`[SERVICE_WORKER] registered ${serviceWorkerPath}`);
   } catch (e) {
     console.log(

--- a/apps/passport-client/tsconfig.json
+++ b/apps/passport-client/tsconfig.json
@@ -3,7 +3,7 @@
     "resolveJsonModule": true,
     "downlevelIteration": true,
     "jsx": "react-jsx",
-    "lib": ["ES2015", "dom"],
+    "lib": ["ES2015", "DOM"],
     "esModuleInterop": true
   },
   "include": ["**/*.ts", "**/*.tsx"],

--- a/turbo.json
+++ b/turbo.json
@@ -39,6 +39,7 @@
     "MAILGUN_API_KEY",
     "TIMING",
     "BYPASS_EMAIL_REGISTRATION",
-    "ROLLBAR_TOKEN"
+    "ROLLBAR_TOKEN",
+    "SW_ID"
   ]
 }


### PR DESCRIPTION
closes https://github.com/proofcarryingdata/zupass/issues/28
closes https://github.com/proofcarryingdata/zupass/issues/214

## Summary
- add a service worker which is installed on application load.
- the service worker caches heavy artifacts (eg. semaphore wasm and zkey), as well as zupass application code
- the contents of the service worker change with every production deploy, meaning it gets re-registered, which enables the relevant files (importantly `index.html` and `/js/index.js`, among others) to be refreshed.
- I tested this service worker locally. I killed the local `yarn dev`, reloaded the page, and the app worked properly.

#### service worker installs properly
<img width="521" alt="Screenshot 2023-04-29 at 6 14 55 PM" src="https://user-images.githubusercontent.com/2636237/235312869-c8d5ee83-fc8f-4db4-b2f1-cfbf052ad442.png">
<img width="750" alt="Screenshot 2023-04-29 at 6 14 59 PM" src="https://user-images.githubusercontent.com/2636237/235312874-076ab3b8-904b-470e-800c-c3d6253e3783.png">

#### Service worker caching works for relevant files
(see `(ServiceWorker)` under the `size` column)

<img width="1096" alt="Screenshot 2023-04-29 at 6 15 11 PM" src="https://user-images.githubusercontent.com/2636237/235312846-e236a0a4-1ad8-4c94-b315-efb2229da23a.png">
