### PR TITLE
Added valid historic root checker

### DIFF
--- a/apps/passport-server/src/routing/routes/zuzaluRoutes.ts
+++ b/apps/passport-server/src/routing/routes/zuzaluRoutes.ts
@@ -200,6 +200,21 @@ export function initZuzaluRoutes(
   });
 
   app.get(
+    "/semaphore/valid-historic/:id/:root",
+    async (req: Request, res: Response) => {
+      const id = decodeString(req.params.id, "id");
+      const root = decodeString(req.params.root, "root");
+
+      const historicGroupValid =
+        await semaphoreService.getHistoricSemaphoreGroupValid(id, root);
+
+      res.json({
+        valid: historicGroupValid,
+      });
+    }
+  );
+
+  app.get(
     "/semaphore/historic/:id/:root",
     async (req: Request, res: Response) => {
       const id = decodeString(req.params.id, "id");

--- a/apps/passport-server/src/services/semaphore.ts
+++ b/apps/passport-server/src/services/semaphore.ts
@@ -126,6 +126,19 @@ export class SemaphoreService {
     return getGroupByRoot(this.dbPool, groupId, rootHash);
   }
 
+  async getHistoricSemaphoreGroupValid(
+    groupId: string,
+    rootHash: string
+  ): Promise<boolean> {
+    if (!this.dbPool) {
+      throw new Error("no database connection");
+    }
+
+    const group = await getGroupByRoot(this.dbPool, groupId, rootHash);
+
+    return group !== undefined;
+  }
+
   async getLatestSemaphoreGroups(): Promise<HistoricSemaphoreGroup[]> {
     if (!this.dbPool) {
       throw new Error("no database connection");


### PR DESCRIPTION
As per the investigation in https://0xparc.notion.site/2023-05-01-Vivek-Login-investigation-272d40a654f74a6ab82674bc55422465, it seems like a useful utility to have a route that just checks if a root is valid instead of retrieving the entire group.