### PR TITLE
disambiguate between expired and upcoming visitors

### DIFF
--- a/apps/passport-client/components/screens/VerifyScreen.tsx
+++ b/apps/passport-client/components/screens/VerifyScreen.tsx
@@ -8,7 +8,7 @@ import { useLocation } from "react-router-dom";
 import { config } from "../../src/config";
 import { ZuzaluQRPayload } from "../../src/createZuzaluQRProof";
 import { DispatchContext } from "../../src/dispatch";
-import { getVisitorStatus } from "../../src/participant";
+import { getVisitorStatus, VisitorStatus } from "../../src/participant";
 import { decodeQRPayload } from "../../src/qr";
 import { bigintToUuid } from "../../src/util";
 import {
@@ -184,7 +184,7 @@ async function deserializeAndVerify(pcdStr: string): Promise<VerifyResult> {
   if (
     visitorStatus !== undefined &&
     visitorStatus.isVisitor &&
-    !visitorStatus.isDateRangeValid
+    visitorStatus.status !== VisitorStatus.Current
   ) {
     return {
       valid: false,

--- a/apps/passport-client/components/shared/PCDCard.tsx
+++ b/apps/passport-client/components/shared/PCDCard.tsx
@@ -2,7 +2,7 @@ import { PCD } from "@pcd/pcd-types";
 import { useCallback, useContext, useMemo } from "react";
 import styled from "styled-components";
 import { DispatchContext } from "../../src/dispatch";
-import { getVisitorStatus } from "../../src/participant";
+import { getVisitorStatus, VisitorStatus } from "../../src/participant";
 import { usePackage } from "../../src/usePackage";
 import { Button, H4, Spacer, TextCenter } from "../core";
 import { ZuzaluCardBody } from "./ZuzaluCard";
@@ -33,10 +33,6 @@ export function PCDCard({
   }, [pcd, pcdPackage]);
 
   const visitorStatus = getVisitorStatus(state.self);
-  const visitorExpired =
-    visitorStatus !== undefined &&
-    !visitorStatus.isDateRangeValid &&
-    visitorStatus.isVisitor;
 
   let header = displayOptions?.header?.toUpperCase() ?? "PCD";
 
@@ -44,17 +40,30 @@ export function PCDCard({
     header = "VERIFIED ZUZALU PASSPORT";
   }
 
-  if (visitorExpired) {
+  if (
+    visitorStatus.isVisitor &&
+    visitorStatus.status === VisitorStatus.Expired
+  ) {
     header = "EXPIRED";
+  } else if (
+    visitorStatus.isVisitor &&
+    visitorStatus.status === VisitorStatus.Upcoming
+  ) {
+    header = "UPCOMING";
   }
+
+  const notCurrentVisitor =
+    visitorStatus.isVisitor && visitorStatus.status !== VisitorStatus.Current;
 
   if (expanded) {
     return (
       <CardContainerExpanded>
         <CardOutlineExpanded>
           <CardHeader
-            col={visitorExpired ? "" : "var(--accent-lite)"}
-            style={{ backgroundColor: visitorExpired ? "var(--danger)" : "" }}
+            col={notCurrentVisitor ? "" : "var(--accent-lite)"}
+            style={{
+              backgroundColor: notCurrentVisitor ? "var(--danger)" : "",
+            }}
           >
             {header}
           </CardHeader>

--- a/apps/passport-client/components/shared/ZuzaluCard.tsx
+++ b/apps/passport-client/components/shared/ZuzaluCard.tsx
@@ -9,7 +9,7 @@ import styled from "styled-components";
 import { config } from "../../src/config";
 import { createZuzaluQRProof } from "../../src/createZuzaluQRProof";
 import { DispatchContext } from "../../src/dispatch";
-import { getVisitorStatus } from "../../src/participant";
+import { getVisitorStatus, VisitorStatus } from "../../src/participant";
 import { encodeQRPayload, makeEncodedVerifyLink } from "../../src/qr";
 import { H3, InfoLine, Spacer, TextCenter } from "../core";
 import { icons } from "../icons";
@@ -26,19 +26,19 @@ export function ZuzaluCardBody({
   const actualParticipant = participant ?? state.self;
   const { role, name, email, residence } = actualParticipant;
   const visitorStatus = getVisitorStatus(actualParticipant);
-  const visitorExpired =
-    visitorStatus !== undefined &&
-    !visitorStatus.isDateRangeValid &&
-    visitorStatus.isVisitor;
 
   return (
     <CardBody>
-      {showQrCode && !visitorExpired && (
-        <>
-          <Spacer h={32} />
-          <ZuzaluQR />
-        </>
-      )}
+      {showQrCode &&
+        !(
+          visitorStatus.isVisitor &&
+          visitorStatus.status !== VisitorStatus.Current
+        ) && (
+          <>
+            <Spacer h={32} />
+            <ZuzaluQR />
+          </>
+        )}
       <Spacer h={24} />
       <TextCenter>
         <H3 col="var(--primary-dark)">{name}</H3>
@@ -47,7 +47,13 @@ export function ZuzaluCardBody({
         <VisitorDateSection participant={actualParticipant} />
       </TextCenter>
       <Spacer h={24} />
-      <Footer role={role} expired={visitorExpired}>
+      <Footer
+        role={role}
+        notCurrent={
+          visitorStatus.isVisitor &&
+          visitorStatus.status !== VisitorStatus.Current
+        }
+      >
         ZUZALU {role.toUpperCase()}
       </Footer>
     </CardBody>
@@ -88,11 +94,11 @@ const CardBody = styled.div`
   border-radius: 0 0 12px 12px;
 `;
 
-const Footer = styled.div<{ role: string; expired: boolean }>`
+const Footer = styled.div<{ role: string; notCurrent: boolean }>`
   font-size: 20px;
   letter-spacing: 1px;
   background: ${(p) => {
-    if (p.expired) {
+    if (p.notCurrent) {
       return "var(--danger)";
     }
 


### PR DESCRIPTION
## Summary

closes https://github.com/proofcarryingdata/zupass/issues/256

Some visitors have visitor passes for future dates. Previously, they were displayed as 'Expired', and this PR changes the invalid visitor pass behavior to show 'Upcoming', for visitors who are not in a valid date range, but do have a date for which they are permissioned in the future.

<img width="477" alt="Screenshot 2023-05-03 at 1 55 09 PM" src="https://user-images.githubusercontent.com/2636237/235908979-26262624-0368-4386-be0e-2109a5ab9095.png">

<img width="519" alt="Screenshot 2023-05-03 at 1 53 18 PM" src="https://user-images.githubusercontent.com/2636237/235909061-1064bb22-96e3-47b0-b69c-78fbb05667f7.png">

<img width="486" alt="Screenshot 2023-05-03 at 1 50 38 PM" src="https://user-images.githubusercontent.com/2636237/235909079-6a9f9da3-56a5-416e-b300-bf5875c85159.png">
