### PR TITLE
show error if window fails to close

### DIFF
--- a/packages/passport-interface/src/PassportPopup.ts
+++ b/packages/passport-interface/src/PassportPopup.ts
@@ -59,6 +59,9 @@ export function usePassportPopupSetup() {
       // Later, the Passport redirects back with a proof. Send it to our parent.
       window.opener.postMessage({ encodedPCD: paramsProof }, "*");
       window.close();
+      setTimeout(() => {
+        setError("Finished. Please close this window.");
+      }, 1000 * 3);
     } else if (paramsEncodingPendingPCD != null) {
       // Later, the Passport redirects back with a encodedPendingPCD. Send it to our parent.
       window.opener.postMessage(
@@ -66,6 +69,9 @@ export function usePassportPopupSetup() {
         "*"
       );
       window.close();
+      setTimeout(() => {
+        setError("Finished. Please close this window.");
+      }, 1000 * 3);
     }
   }, []);
 


### PR DESCRIPTION
closes https://github.com/proofcarryingdata/zupass/issues/260, once all downstream applications update their `passport-interface` dependency.

<img width="379" alt="Screenshot 2023-05-05 at 11 40 54 AM" src="https://user-images.githubusercontent.com/2636237/236425552-a5675755-063c-4211-9437-6bf918b17def.png">
