### PR TITLE
fix eth-pcd and rln-pcd browser compatibility issue

### DIFF
--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -4,6 +4,7 @@ import {
   ProveRequest,
 } from "@pcd/passport-interface";
 import { ArgsOf, PCDOf, PCDPackage, SerializedPCD } from "@pcd/pcd-types";
+import { useRollbar } from "@rollbar/react";
 import { useCallback, useContext, useState } from "react";
 import styled from "styled-components";
 import { requestPendingPCD } from "../../../src/api/requestPendingPCD";
@@ -32,6 +33,7 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
     pendingPCD: PendingPCD | undefined
   ) => void;
 }) {
+  const rollbar = useRollbar();
   const [state] = useContext(DispatchContext);
   const [args, setArgs] = useState(JSON.parse(JSON.stringify(initialArgs)));
   const [error, setError] = useState<Error | undefined>();
@@ -59,10 +61,12 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
         onProve(pcd as any, serialized, undefined);
       }
     } catch (e) {
+      console.log(e);
+      rollbar.error(e);
       setError(e);
       setProving(false);
     }
-  }, [options?.proveOnServer, pcdType, args, onProve, pcdPackage]);
+  }, [options?.proveOnServer, pcdType, args, onProve, pcdPackage, rollbar]);
 
   const pageTitle = options?.title ?? "Prove " + pcdType;
 

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -62,7 +62,7 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
       }
     } catch (e) {
       console.log(e);
-      rollbar.error(e);
+      rollbar?.error(e);
       setError(e);
       setProving(false);
     }

--- a/packages/ethereum-ownership-pcd/package.json
+++ b/packages/ethereum-ownership-pcd/package.json
@@ -2,7 +2,7 @@
   "name": "@pcd/ethereum-ownership-pcd",
   "version": "0.5.3",
   "license": "GPL-3.0-or-later",
-  "main": "./dist/index.js",
+  "main": "./dist/node/index.js",
   "types": "./src/index.ts",
   "files": [
     "./artifacts/*",
@@ -10,9 +10,19 @@
     "./dist/*",
     "./README.md"
   ],
+  "exports": {
+    ".": {
+      "node": {
+        "default": "./dist/node/index.js"
+      },
+      "browser": {
+        "default": "./dist/browser/index.js"
+      }
+    }
+  },
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup --platform=browser src/index.ts",
+    "build": "tsup --platform=browser src/index.ts --out-dir ./dist/browser && tsup --platform=node src/index.ts --out-dir ./dist/node",
     "dev": "tsup --platform=browser src/index.ts --watch",
     "typecheck": "yarn tsc --noEmit",
     "test": "ts-mocha --exit test/**/*.spec.ts",

--- a/packages/ethereum-ownership-pcd/package.json
+++ b/packages/ethereum-ownership-pcd/package.json
@@ -12,8 +12,8 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts",
-    "dev": "tsup src/index.ts --watch",
+    "build": "tsup --platform=browser src/index.ts",
+    "dev": "tsup --platform=browser src/index.ts --watch",
     "typecheck": "yarn tsc --noEmit",
     "test": "ts-mocha --exit test/**/*.spec.ts",
     "prepublishOnly": "yarn build"

--- a/packages/rln-pcd/package.json
+++ b/packages/rln-pcd/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
     "test": "ts-mocha --exit test/**/*.spec.ts",
-    "build": "tsup src/index.ts",
-    "dev": "tsup src/index.ts --watch",
+    "build": "tsup --platform=browser src/index.ts",
+    "dev": "tsup --platform=browser src/index.ts --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build"
   },

--- a/packages/rln-pcd/package.json
+++ b/packages/rln-pcd/package.json
@@ -2,7 +2,7 @@
   "name": "@pcd/rln-pcd",
   "version": "0.4.2",
   "license": "GPL-3.0-or-later",
-  "main": "./dist/index.js",
+  "main": "./dist/node/index.js",
   "types": "./src/index.ts",
   "files": [
     "./artifacts/*",

--- a/packages/rln-pcd/package.json
+++ b/packages/rln-pcd/package.json
@@ -10,10 +10,20 @@
     "./dist/*",
     "./README.md"
   ],
+  "exports": {
+    ".": {
+      "node": {
+        "default": "./dist/node/index.js"
+      },
+      "browser": {
+        "default": "./dist/browser/index.js"
+      }
+    }
+  },
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
     "test": "ts-mocha --exit test/**/*.spec.ts",
-    "build": "tsup --platform=browser src/index.ts",
+    "build": "tsup --platform=browser src/index.ts --out-dir ./dist/browser && tsup --platform=node src/index.ts --out-dir ./dist/node",
     "dev": "tsup --platform=browser src/index.ts --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build"


### PR DESCRIPTION
closes #276 

## Summary
Another day another encounter with some esoteric package management configuration option. Turns out the `uuid` package we depend on defines different entrypoints based on which environment it runs in. In the `node` environment it depends on the `crypto` package (which is not available in browsers), and in the `browser` environment it depends on something else. By default, `tsup` specifies the `node` environment, which breaks importing the `uuid` package. I am not certain why the only packages that are affected are the `eth` and `rln` pcds. I am not super interested in finding out at this point.

## Evidence
I got the eth pcd to work locally, after confirming that it is broken.
<img width="1114" alt="Screenshot 2023-05-16 at 1 56 03 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/c62a4a0b-f602-42d0-9eb7-b0d19f8d75d9">
<img width="946" alt="Screenshot 2023-05-16 at 1 56 24 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/4ca63ca3-fea3-47da-8be9-c9b9ba48e346">
