### PR TITLE
pretix error handling

### DIFF
--- a/apps/passport-server/src/apis/pretixAPI.ts
+++ b/apps/passport-server/src/apis/pretixAPI.ts
@@ -30,8 +30,9 @@ export class PretixAPI implements IPretixAPI {
           headers: { Authorization: `Token ${this.config.token}` },
         });
         if (!res.ok) {
-          logger(`Error fetching ${url}: ${res.status} ${res.statusText}`);
-          break;
+          throw new Error(
+            `[PRETIX] Error fetching ${url}: ${res.status} ${res.statusText}`
+          );
         }
         const page = await res.json();
         orders.push(...page.results);
@@ -55,8 +56,9 @@ export class PretixAPI implements IPretixAPI {
           headers: { Authorization: `Token ${this.config.token}` },
         });
         if (!res.ok) {
-          logger(`Error fetching ${url}: ${res.status} ${res.statusText}`);
-          break;
+          throw new Error(
+            `[PRETIX] Error fetching ${url}: ${res.status} ${res.statusText}`
+          );
         }
         const page = await res.json();
         orders.push(...page.results);

--- a/apps/passport-server/src/services/pretixSyncService.ts
+++ b/apps/passport-server/src/services/pretixSyncService.ts
@@ -63,21 +63,30 @@ export class PretixSyncService {
 
   public startSyncLoop(): void {
     const trySync = async (): Promise<void> => {
-      await this.trySync();
+      const success = await this.trySync();
+
+      if (success) {
+        logger(`[PRETIX] success`);
+      } else {
+        logger(`[PRETIX] failed to sync`);
+      }
+
       this.timeout = setTimeout(() => trySync(), 1000 * 60);
     };
 
     trySync();
   }
 
-  public async trySync(): Promise<void> {
+  public async trySync(): Promise<boolean> {
     try {
       await this.sync();
       await this.semaphoreService.reload();
       this._hasCompletedSyncSinceStarting = true;
+      return true;
     } catch (e) {
       this.rollbarService?.reportError(e);
       logger(e);
+      return false;
     }
   }
 

--- a/apps/passport-server/test/pretix/mockPretixApi.ts
+++ b/apps/passport-server/test/pretix/mockPretixApi.ts
@@ -23,13 +23,22 @@ export function newMockZuzaluPretixAPI(): IPretixAPI | null {
   return getMockPretixAPI(mockData);
 }
 
-export function getMockPretixAPI(mockData: IMockPretixData): IPretixAPI {
+export function getMockPretixAPI(
+  mockData: IMockPretixData,
+  options?: {
+    throwOnFetchOrders?: boolean;
+    throwOnFetchSubevents?: boolean;
+  }
+): IPretixAPI {
   logger("[MOCK] instantiating mock zuzalu pretix api");
 
   return {
     config: mockData.config,
     fetchOrders: async (eventID: string): Promise<PretixOrder[]> => {
       const result = mockData.ordersByEventId.get(eventID) ?? [];
+      if (options?.throwOnFetchOrders) {
+        throw new Error(`[MOCK] throwing for 'fetchOrders'`);
+      }
       logger(
         `[MOCK] fetchOrders('${eventID}') =>`,
         JSON.stringify(result, null, 2)
@@ -38,6 +47,9 @@ export function getMockPretixAPI(mockData: IMockPretixData): IPretixAPI {
     },
     fetchSubevents: async (parentId: string): Promise<PretixSubevent[]> => {
       const result = mockData.subEventsByParentEventId.get(parentId) ?? [];
+      if (options?.throwOnFetchSubevents) {
+        throw new Error(`[MOCK] throwing for 'fetchSubevents'`);
+      }
       logger(
         `[MOCK] fetchSubevents('${parentId}') =>`,
         JSON.stringify(result, null, 2)

--- a/apps/passport-server/test/zupass.spec.ts
+++ b/apps/passport-server/test/zupass.spec.ts
@@ -340,6 +340,82 @@ describe("zupass functionality", function () {
   );
 
   step(
+    "an error fetching orders via the PretixAPI should stop the sync from completing",
+    async () => {
+      const newAPI = getMockPretixAPI(pretixMocker.getMockData(), {
+        throwOnFetchOrders: true,
+      });
+      const pretixSyncService = application.services.pretixSyncService;
+
+      if (!pretixSyncService) {
+        throw new Error("expected there to be a pretix sync service running");
+      }
+
+      pretixSyncService.stop();
+      pretixSyncService.replaceApi(newAPI);
+      const successfulSync = await pretixSyncService.trySync();
+
+      expect(successfulSync).to.eq(false);
+    }
+  );
+
+  step(
+    "after a failed sync, the set of users should remain unchanged",
+    async () => {
+      expectCurrentSemaphoreToBe(application, {
+        p: [
+          updatedToOrganizerUser.commitment,
+          visitorUser.commitment,
+          organizerUser.commitment,
+        ],
+        r: [updatedToOrganizerUser.commitment, organizerUser.commitment],
+        v: [visitorUser.commitment],
+        o: [organizerUser.commitment, updatedToOrganizerUser.commitment],
+        g: [],
+      });
+      await testLatestHistoricSemaphoreGroupsMatchServerGroups(application);
+    }
+  );
+
+  step(
+    "an error fetching subevents via the PretixAPI should stop the sync from completing",
+    async () => {
+      const newAPI = getMockPretixAPI(pretixMocker.getMockData(), {
+        throwOnFetchSubevents: true,
+      });
+      const pretixSyncService = application.services.pretixSyncService;
+
+      if (!pretixSyncService) {
+        throw new Error("expected there to be a pretix sync service running");
+      }
+
+      pretixSyncService.stop();
+      pretixSyncService.replaceApi(newAPI);
+      const successfulSync = await pretixSyncService.trySync();
+
+      expect(successfulSync).to.eq(false);
+    }
+  );
+
+  step(
+    "after a failed sync, the set of users should remain unchanged",
+    async () => {
+      expectCurrentSemaphoreToBe(application, {
+        p: [
+          updatedToOrganizerUser.commitment,
+          visitorUser.commitment,
+          organizerUser.commitment,
+        ],
+        r: [updatedToOrganizerUser.commitment, organizerUser.commitment],
+        v: [visitorUser.commitment],
+        o: [organizerUser.commitment, updatedToOrganizerUser.commitment],
+        g: [],
+      });
+      await testLatestHistoricSemaphoreGroupsMatchServerGroups(application);
+    }
+  );
+
+  step(
     "replace api and sync should cause all users to be replaced",
     async function () {
       const oldTicketHolders =


### PR DESCRIPTION
sometimes the pretix API returns a `500` error, which causes the loop which loads users/events to exit prematurely. this causes the pretix sync service to get an incomplete picture of orders and events, which causes it to erroneously delete the orders that it didn't 'get to', logging people out.