### PR TITLE
Stricter sync checks for missing events/items

### DIFF
--- a/apps/passport-server/src/apis/devconnect/devconnectPretixAPI.ts
+++ b/apps/passport-server/src/apis/devconnect/devconnectPretixAPI.ts
@@ -97,12 +97,6 @@ export class DevconnectPretixAPI implements IDevconnectPretixAPI {
         }
       }
 
-      if (!result.ok) {
-        throw new Error(
-          `[PRETIX] Error fetching ${input}: ${result.status} ${result.statusText}`
-        );
-      }
-
       return result;
     });
   }

--- a/apps/passport-server/src/services/devconnect/organizerSync.ts
+++ b/apps/passport-server/src/services/devconnect/organizerSync.ts
@@ -53,7 +53,7 @@ interface EventDataFromPretix {
 
 type SyncPhase = "fetching" | "validating" | "saving";
 
-interface SyncErrorCause {
+export interface SyncErrorCause {
   phase: SyncPhase;
   error: Error;
   organizerId: string;
@@ -82,19 +82,9 @@ export class OrganizerSync {
   private rollbarService: RollbarService | null;
   private db: Pool;
   private _isRunning: boolean;
-  private _error: boolean;
-  private _errorCause: SyncErrorCause | null;
 
   public get isRunning(): boolean {
     return this._isRunning;
-  }
-
-  public get errorCause(): SyncErrorCause | null {
-    return this._errorCause;
-  }
-
-  public get error(): boolean {
-    return this._error;
   }
 
   public constructor(
@@ -116,8 +106,6 @@ export class OrganizerSync {
   public async run(): Promise<void> {
     let fetchedData;
     this._isRunning = true;
-    this._error = false;
-    this._errorCause = null;
 
     try {
       try {
@@ -158,10 +146,6 @@ export class OrganizerSync {
           cause: errorCause("saving", this.organizer.id, e)
         });
       }
-    } catch (e) {
-      this._error = true;
-      this._errorCause = (e as Error).cause as SyncErrorCause;
-      throw e;
     } finally {
       this._isRunning = false;
     }

--- a/apps/passport-server/src/services/devconnect/organizerSync.ts
+++ b/apps/passport-server/src/services/devconnect/organizerSync.ts
@@ -98,8 +98,6 @@ export class OrganizerSync {
     this.rollbarService = rollbarService;
     this.db = db;
     this._isRunning = false;
-    this._error = false;
-    this._errorCause = null;
   }
 
   // Conduct a single sync run

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -42,7 +42,10 @@ import {
   insertPretixEventConfig,
   insertPretixOrganizerConfig
 } from "../src/database/queries/pretix_config/insertConfiguration";
-import { OrganizerSync } from "../src/services/devconnect/organizerSync";
+import {
+  OrganizerSync,
+  SyncErrorCause
+} from "../src/services/devconnect/organizerSync";
 import { DevconnectPretixSyncService } from "../src/services/devconnectPretixSyncService";
 import { PretixSyncStatus } from "../src/services/types";
 import { PCDPass } from "../src/types";
@@ -1163,14 +1166,18 @@ describe("devconnect functionality", function () {
         application.context.dbPool
       );
 
+      let cause: SyncErrorCause | null = null;
+      let error = null;
+
       try {
         await os.run();
       } catch (e) {
-        // This space intentionally left blank
+        error = e;
+        cause = (e as Error).cause as SyncErrorCause;
       }
 
-      expect(os.error).to.be.true;
-      expect(os.errorCause?.phase).to.eq("fetching");
+      expect(error).to.be.an("Error");
+      expect(cause?.phase).to.eq("fetching");
     }
   );
 
@@ -1212,14 +1219,18 @@ describe("devconnect functionality", function () {
         application.context.dbPool
       );
 
+      let error = null;
+      let cause: SyncErrorCause | null = null;
+
       try {
         await os.run();
       } catch (e) {
-        // This space intentionally left blank
+        error = e;
+        cause = (e as Error).cause as SyncErrorCause;
       }
 
-      expect(os.error).to.be.true;
-      expect(os.errorCause?.phase).to.eq("validating");
+      expect(error).to.be.an("Error");
+      expect(cause?.phase).to.eq("validating");
     }
   );
 
@@ -1261,14 +1272,18 @@ describe("devconnect functionality", function () {
         application.context.dbPool
       );
 
+      let error = null;
+      let cause: SyncErrorCause | null = null;
+
       try {
         await os.run();
       } catch (e) {
-        // This space intentionally left blank
+        error = e;
+        cause = (e as Error).cause as SyncErrorCause;
       }
 
-      expect(os.error).to.be.true;
-      expect(os.errorCause?.phase).to.eq("validating");
+      expect(error).to.be.an("Error");
+      expect(cause?.phase).to.eq("validating");
     }
   );
 

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -12,12 +12,6 @@ import {
   User
 } from "@pcd/passport-interface";
 import { ArgumentTypeName, SerializedPCD } from "@pcd/pcd-types";
-import { RSAPCDPackage } from "@pcd/rsa-pcd";
-import {
-  ITicketData,
-  RSATicketPCD,
-  RSATicketPCDPackage
-} from "@pcd/rsa-ticket-pcd";
 import { Identity } from "@semaphore-protocol/identity";
 import { expect } from "chai";
 import _ from "lodash";
@@ -665,15 +659,13 @@ describe("devconnect functionality", function () {
 
     expect(Array.isArray(responseBody.pcds)).to.eq(true);
     const ticketPCD = responseBody.pcds[0];
-    expect(ticketPCD.type).to.eq(RSATicketPCDPackage.name);
+    expect(ticketPCD.type).to.eq(EdDSATicketPCDPackage.name);
 
-    const deserializedEmailPCD = await RSATicketPCDPackage.deserialize(
+    const deserializedPCD = await EdDSATicketPCDPackage.deserialize(
       ticketPCD.pcd
     );
 
-    const ticketData = JSON.parse(
-      deserializedEmailPCD?.proof?.rsaPCD?.claim?.message ?? "{}"
-    ) as ITicketData;
+    const ticketData = deserializedPCD.claim.ticket;
 
     expect(ticketData.eventName).to.eq(updatedName);
   });
@@ -707,15 +699,13 @@ describe("devconnect functionality", function () {
 
     expect(Array.isArray(responseBody.pcds)).to.eq(true);
     const ticketPCD = responseBody.pcds[0];
-    expect(ticketPCD.type).to.eq(RSATicketPCDPackage.name);
+    expect(ticketPCD.type).to.eq(EdDSATicketPCDPackage.name);
 
-    const deserializedEmailPCD = await RSATicketPCDPackage.deserialize(
+    const deserializedPCD = await EdDSATicketPCDPackage.deserialize(
       ticketPCD.pcd
     );
 
-    const ticketData = JSON.parse(
-      deserializedEmailPCD?.proof?.rsaPCD?.claim?.message ?? "{}"
-    ) as ITicketData;
+    const ticketData = deserializedPCD.claim.ticket;
 
     // "Ticket name" is equivalent to item/product name
     expect(ticketData.ticketName).to.eq(updatedName);

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -12,6 +12,12 @@ import {
   User
 } from "@pcd/passport-interface";
 import { ArgumentTypeName, SerializedPCD } from "@pcd/pcd-types";
+import { RSAPCDPackage } from "@pcd/rsa-pcd";
+import {
+  ITicketData,
+  RSATicketPCD,
+  RSATicketPCDPackage
+} from "@pcd/rsa-ticket-pcd";
 import { Identity } from "@semaphore-protocol/identity";
 import { expect } from "chai";
 import _ from "lodash";
@@ -175,8 +181,9 @@ describe("devconnect functionality", function () {
   });
 
   step("devconnect pretix status should sync to completion", async function () {
-    const pretixSyncStatus =
-      await waitForDevconnectPretixSyncStatus(application);
+    const pretixSyncStatus = await waitForDevconnectPretixSyncStatus(
+      application
+    );
     expect(pretixSyncStatus).to.eq(PretixSyncStatus.Synced);
     // stop interval that polls the api so we have more granular control over
     // testing the sync functionality
@@ -624,6 +631,96 @@ describe("devconnect functionality", function () {
     });
   });
 
+  /**
+   * This test updates an event, runs a pretix sync, then fetches the
+   * affected PCD to see if the new event name is reflected there.
+   */
+  step("should see event updates reflected in PCDs", async function () {
+    const updatedName = "New name";
+
+    mocker.updateEvent(
+      mocker.get().organizer1.orgUrl,
+      mocker.get().organizer1.eventA.slug,
+      (event) => {
+        event.name.en = updatedName;
+      }
+    );
+
+    mocker.setEventSettings(
+      mocker.get().organizer1.orgUrl,
+      mocker.get().organizer1.eventA.slug,
+      { attendee_emails_asked: true, attendee_emails_required: true }
+    );
+
+    await devconnectPretixSyncService.trySync();
+
+    const response = await requestIssuedPCDs(
+      application,
+      identity,
+      ISSUANCE_STRING
+    );
+    const responseBody = response.body as IssuedPCDsResponse;
+
+    expect(responseBody.folder).to.eq("Devconnect");
+
+    expect(Array.isArray(responseBody.pcds)).to.eq(true);
+    const ticketPCD = responseBody.pcds[0];
+    expect(ticketPCD.type).to.eq(RSATicketPCDPackage.name);
+
+    const deserializedEmailPCD = await RSATicketPCDPackage.deserialize(
+      ticketPCD.pcd
+    );
+
+    const ticketData = JSON.parse(
+      deserializedEmailPCD?.proof?.rsaPCD?.claim?.message ?? "{}"
+    ) as ITicketData;
+
+    expect(ticketData.eventName).to.eq(updatedName);
+  });
+
+  /**
+   * This test updates a product, runs a pretix sync, then fetches the
+   * affected PCD to see if the new product name is reflected there.
+   */
+  step("should see product updates reflected in PCDs", async function () {
+    const updatedName = "New product name";
+
+    mocker.updateItem(
+      mocker.get().organizer1.orgUrl,
+      mocker.get().organizer1.eventA.slug,
+      mocker.get().organizer1.eventAItem1.id,
+      (item) => {
+        item.name.en = updatedName;
+      }
+    );
+
+    await devconnectPretixSyncService.trySync();
+
+    const response = await requestIssuedPCDs(
+      application,
+      identity,
+      ISSUANCE_STRING
+    );
+    const responseBody = response.body as IssuedPCDsResponse;
+
+    expect(responseBody.folder).to.eq("Devconnect");
+
+    expect(Array.isArray(responseBody.pcds)).to.eq(true);
+    const ticketPCD = responseBody.pcds[0];
+    expect(ticketPCD.type).to.eq(RSATicketPCDPackage.name);
+
+    const deserializedEmailPCD = await RSATicketPCDPackage.deserialize(
+      ticketPCD.pcd
+    );
+
+    const ticketData = JSON.parse(
+      deserializedEmailPCD?.proof?.rsaPCD?.claim?.message ?? "{}"
+    ) as ITicketData;
+
+    // "Ticket name" is equivalent to item/product name
+    expect(ticketData.ticketName).to.eq(updatedName);
+  });
+
   let checkerUser: User;
   let checkerIdentity: Identity;
   step("should be able to log in", async function () {
@@ -691,7 +788,7 @@ describe("devconnect functionality", function () {
   step(
     "should not able to check in with a ticket not signed by the server",
     async function () {
-      const prvKey = newEdDSAPrivateKey()
+      const prvKey = newEdDSAPrivateKey();
       const ticketData: ITicketData = {
         // the fields below are not signed and are used for display purposes
         attendeeName: "test name",


### PR DESCRIPTION
Closes #317 

Sync would already fail for missing events, because we iterate through all configured events and fetch them directly from the server, throwing an exception of the request fails/event is not found.

Sync now fails if an event has an `activeItemID` or `superuserItemID` that refers to an item which does not exist in Pretix. This error is detected during validation of fetched data, by comparing the fetched item IDs to the configured ones.

This PR also adds tests to verify that changes to event and product names are reflected in ticket PCDs.