### PR TITLE
Fix all lints

### DIFF
--- a/apps/consumer-client/pages/pcdpass-examples/zkeddsa-proof.tsx
+++ b/apps/consumer-client/pages/pcdpass-examples/zkeddsa-proof.tsx
@@ -9,10 +9,10 @@ import { ArgumentTypeName } from "@pcd/pcd-types";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import {
   EdDSATicketFieldsToReveal,
-  generateMessageHash,
   ZKEdDSATicketPCD,
   ZKEdDSATicketPCDArgs,
-  ZKEdDSATicketPCDPackage
+  ZKEdDSATicketPCDPackage,
+  generateMessageHash
 } from "@pcd/zk-eddsa-ticket-pcd";
 import path from "path";
 import { useEffect, useState } from "react";
@@ -201,7 +201,7 @@ function useZKEdDSATicketProof(
   watermark: bigint,
   externalNullifier?: string
 ): { pcd: ZKEdDSATicketPCD | undefined; error: any } {
-  const [error, setError] = useState<Error | undefined>();
+  const [error, _setError] = useState<Error | undefined>();
   const zkEdDSATicketPCD = useSerializedPCD(ZKEdDSATicketPCDPackage, pcdStr);
 
   useEffect(() => {

--- a/apps/passport-client/components/screens/NewPassportScreen.tsx
+++ b/apps/passport-client/components/screens/NewPassportScreen.tsx
@@ -157,14 +157,6 @@ function Header() {
   }
 }
 
-const PItalic = styled.p`
-  font-size: 20px;
-  font-weight: 300;
-  font-style: italic;
-  color: rgba(var(--white-rgb), 0.5);
-  line-height: 2;
-`;
-
 const PHeavy = styled.p`
   font-size: 20px;
   font-weight: 400;

--- a/apps/passport-client/components/shared/PCDArgs.tsx
+++ b/apps/passport-client/components/shared/PCDArgs.tsx
@@ -16,7 +16,7 @@ import {
   PCD,
   PCDArgument,
   PCDPackage,
-  StringArgument,
+  StringArgument
 } from "@pcd/pcd-types";
 import React, { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
@@ -31,7 +31,7 @@ import styled from "styled-components";
 export function PCDArgs<T extends PCDPackage>({
   args,
   setArgs,
-  pcdCollection,
+  pcdCollection
 }: {
   args: ArgsOf<T>;
   setArgs: (args: ArgsOf<T>) => void;
@@ -60,7 +60,7 @@ export function ArgInput<T extends PCDPackage>({
   argName,
   args,
   setArgs,
-  pcdCollection,
+  pcdCollection
 }: {
   arg: Argument<any, any>;
   argName: string;
@@ -130,7 +130,7 @@ export function StringArgInput<T extends PCDPackage>({
   arg,
   argName,
   args,
-  setArgs,
+  setArgs
 }: {
   arg: StringArgument;
   argName: string;
@@ -173,7 +173,7 @@ export function NumberArgInput<T extends PCDPackage>({
   arg,
   argName,
   args,
-  setArgs,
+  setArgs
 }: {
   arg: NumberArgument;
   argName: string;
@@ -235,7 +235,7 @@ export function BigIntArgInput<T extends PCDPackage>({
   arg,
   argName,
   args,
-  setArgs,
+  setArgs
 }: {
   arg: BigIntArgument;
   argName: string;
@@ -297,7 +297,7 @@ export function BooleanArgInput<T extends PCDPackage>({
   arg,
   argName,
   args,
-  setArgs,
+  setArgs
 }: {
   arg: BooleanArgument;
   argName: string;
@@ -305,7 +305,7 @@ export function BooleanArgInput<T extends PCDPackage>({
   setArgs: (args: ArgsOf<T>) => void;
 }) {
   const onChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (_e: React.ChangeEvent<HTMLInputElement>) => {
       args[argName].value = !args[argName].value;
       setArgs(JSON.parse(JSON.stringify(args)));
     },
@@ -341,7 +341,7 @@ export function ObjectArgInput<T extends PCDPackage>({
   arg,
   argName,
   args,
-  setArgs,
+  setArgs
 }: {
   arg: ObjectArgument<any>;
   argName: string;
@@ -397,7 +397,7 @@ export function ObjectArgInput<T extends PCDPackage>({
           <textarea
             style={{
               width: "100%",
-              height: "4em",
+              height: "4em"
             }}
             value={JSON.stringify(arg.value)}
             onChange={onChange}
@@ -414,7 +414,7 @@ export function PCDArgInput<T extends PCDPackage>({
   argName,
   args,
   setArgs,
-  pcdCollection,
+  pcdCollection
 }: {
   arg: PCDArgument;
   argName: string;

--- a/apps/passport-server/src/services/discordService.ts
+++ b/apps/passport-server/src/services/discordService.ts
@@ -2,7 +2,7 @@ import {
   Client,
   Events,
   GatewayIntentBits,
-  TextBasedChannel,
+  TextBasedChannel
 } from "discord.js";
 import { logger } from "../util/logger";
 import { traced } from "./telemetryService";
@@ -59,7 +59,7 @@ async function instantiateDiscordClient(): Promise<Client | null> {
   }
 
   const client = new Client({ intents: [GatewayIntentBits.Guilds] });
-  const clientPromise = new Promise<Client | null>((resolve, reject) => {
+  const clientPromise = new Promise<Client | null>((resolve, _reject) => {
     client.once(Events.ClientReady, (c) => {
       logger(`[DISCORD] Ready! Logged in as ${c.user.tag}`);
       resolve(c);

--- a/apps/passport-server/src/services/pretixSyncService.ts
+++ b/apps/passport-server/src/services/pretixSyncService.ts
@@ -160,7 +160,9 @@ export class PretixSyncService {
       const updatedTickets = pretixTickets
         .filter((p) => existingTicketsByEmail.has(p.email))
         .filter((p) => {
-          const oldTicket = existingTicketsByEmail.get(p.email)!;
+          const oldTicket = existingTicketsByEmail.get(
+            p.email
+          ) as ZuzaluPretixTicket;
           const newTicket = p;
           return pretixTicketsDifferent(oldTicket, newTicket);
         });
@@ -323,7 +325,7 @@ export class PretixSyncService {
             ({
               date_from: subEvent?.date_from,
               date_to: subEvent?.date_to
-            } satisfies DateRange)
+            }) satisfies DateRange
         );
 
         return {

--- a/apps/passport-server/src/services/provingService.ts
+++ b/apps/passport-server/src/services/provingService.ts
@@ -183,18 +183,18 @@ export async function startProvingService(
 ): Promise<ProvingService> {
   const fullPath = path.join(__dirname, "../../public");
 
-  await SemaphoreGroupPCDPackage.init!({
+  await SemaphoreGroupPCDPackage.init?.({
     wasmFilePath: fullPath + "/semaphore-artifacts/16.wasm",
     zkeyFilePath: fullPath + "/semaphore-artifacts/16.zkey"
   });
 
-  await SemaphoreSignaturePCDPackage.init!({
+  await SemaphoreSignaturePCDPackage.init?.({
     wasmFilePath: fullPath + "/semaphore-artifacts/16.wasm",
     zkeyFilePath: fullPath + "/semaphore-artifacts/16.zkey"
   });
 
-  await RSATicketPCDPackage.init!({ makeEncodedVerifyLink: undefined });
-  await EdDSATicketPCDPackage.init!({ makeEncodedVerifyLink: undefined });
+  await RSATicketPCDPackage.init?.({ makeEncodedVerifyLink: undefined });
+  await EdDSATicketPCDPackage.init?.({ makeEncodedVerifyLink: undefined });
 
   await ZKEdDSATicketPCDPackage.init?.({
     wasmFilePath: fullPath + "/zkeddsa-artifacts-unsafe/eddsaTicket.wasm",

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -7,8 +7,7 @@ import {
 import {
   CheckInResponse,
   ISSUANCE_STRING,
-  IssuedPCDsResponse,
-  User
+  IssuedPCDsResponse
 } from "@pcd/passport-interface";
 import { ArgumentTypeName, SerializedPCD } from "@pcd/pcd-types";
 import { Identity } from "@semaphore-protocol/identity";
@@ -195,9 +194,8 @@ describe("devconnect functionality", function () {
   });
 
   step("devconnect pretix status should sync to completion", async function () {
-    const pretixSyncStatus = await waitForDevconnectPretixSyncStatus(
-      application
-    );
+    const pretixSyncStatus =
+      await waitForDevconnectPretixSyncStatus(application);
     expect(pretixSyncStatus).to.eq(PretixSyncStatus.Synced);
     // stop interval that polls the api so we have more granular control over
     // testing the sync functionality
@@ -231,10 +229,6 @@ describe("devconnect functionality", function () {
       if (!eventBItemInfo) {
         throw new Error("expected to be able to fetch corresponding item info");
       }
-      const [{ id: item1EventBInfoID }] = await fetchPretixItemsInfoByEvent(
-        db,
-        eventBItemInfo.id
-      );
 
       expect(ticketsWithEmailEventAndItems).to.have.deep.members([
         {
@@ -505,9 +499,8 @@ describe("devconnect functionality", function () {
   step(
     "should be able to check in a ticket and sync to Pretix",
     async function () {
-      const devconnectPretixAPIConfigFromDB = await getDevconnectPretixConfig(
-        db
-      );
+      const devconnectPretixAPIConfigFromDB =
+        await getDevconnectPretixConfig(db);
       if (!devconnectPretixAPIConfigFromDB) {
         throw new Error("Could not load API configuration");
       }
@@ -779,7 +772,6 @@ describe("devconnect functionality", function () {
     }
   );
 
-  let user: User;
   let identity: Identity;
   let publicKey: NodeRSA;
 
@@ -810,7 +802,6 @@ describe("devconnect functionality", function () {
       throw new Error("failed to log in");
     }
 
-    user = result.user;
     identity = result.identity;
   });
 
@@ -968,7 +959,6 @@ describe("devconnect functionality", function () {
     expect(ticketData.ticketName).to.eq(updatedName);
   });
 
-  let checkerUser: User;
   let checkerIdentity: Identity;
   step("should be able to log in", async function () {
     const result = await testLoginPCDpass(
@@ -985,7 +975,6 @@ describe("devconnect functionality", function () {
       throw new Error("failed to log in");
     }
 
-    checkerUser = result.user;
     checkerIdentity = result.identity;
   });
 
@@ -1387,9 +1376,8 @@ describe("devconnect functionality", function () {
   step(
     "should fail to sync if an event we're tracking is deleted",
     async function () {
-      const devconnectPretixAPIConfigFromDB = await getDevconnectPretixConfig(
-        db
-      );
+      const devconnectPretixAPIConfigFromDB =
+        await getDevconnectPretixConfig(db);
       if (!devconnectPretixAPIConfigFromDB) {
         throw new Error("Could not load API configuration");
       }
@@ -1439,9 +1427,8 @@ describe("devconnect functionality", function () {
   step(
     "should fail to sync if an active product we're tracking is deleted",
     async function () {
-      const devconnectPretixAPIConfigFromDB = await getDevconnectPretixConfig(
-        db
-      );
+      const devconnectPretixAPIConfigFromDB =
+        await getDevconnectPretixConfig(db);
       if (!devconnectPretixAPIConfigFromDB) {
         throw new Error("Could not load API configuration");
       }
@@ -1492,9 +1479,8 @@ describe("devconnect functionality", function () {
   step(
     "should fail to sync if a superuser product we're tracking is deleted",
     async function () {
-      const devconnectPretixAPIConfigFromDB = await getDevconnectPretixConfig(
-        db
-      );
+      const devconnectPretixAPIConfigFromDB =
+        await getDevconnectPretixConfig(db);
       if (!devconnectPretixAPIConfigFromDB) {
         throw new Error("Could not load API configuration");
       }

--- a/apps/passport-server/test/pcdpass.spec.ts
+++ b/apps/passport-server/test/pcdpass.spec.ts
@@ -1,5 +1,4 @@
 import { User } from "@pcd/passport-interface";
-import { Identity } from "@semaphore-protocol/identity";
 import { expect } from "chai";
 import "mocha";
 import { step } from "mocha-steps";
@@ -25,7 +24,6 @@ describe("pcd-pass functionality", function () {
   const testEmail = randomEmail();
   let application: PCDpass;
   let user: User;
-  let identity: Identity;
   let emailAPI: IEmailAPI;
 
   this.beforeAll(async () => {
@@ -67,7 +65,6 @@ describe("pcd-pass functionality", function () {
     }
 
     user = result.user;
-    identity = result.identity;
     expect(emailAPI.send).to.have.been.called.exactly(1);
   });
 
@@ -117,7 +114,6 @@ describe("pcd-pass functionality", function () {
       }
 
       user = result.user;
-      identity = result.identity;
       expect(emailAPI.send).to.have.been.called.exactly(2);
     }
   );

--- a/apps/passport-server/test/proving.spec.ts
+++ b/apps/passport-server/test/proving.spec.ts
@@ -80,7 +80,7 @@ describe("server-side proving functionality", function () {
         expect(settledStatusResponse).to.haveOwnProperty("serializedPCD");
 
         const parsedPCD = await SemaphoreSignaturePCDPackage.deserialize(
-          JSON.parse(settledStatusResponse.serializedPCD!).pcd
+          JSON.parse(settledStatusResponse.serializedPCD as string).pcd
         );
 
         expect(parsedPCD.claim).to.deep.eq(expectedResult.claim);

--- a/apps/passport-server/test/zupass.spec.ts
+++ b/apps/passport-server/test/zupass.spec.ts
@@ -277,7 +277,7 @@ describe("zupass functionality", function () {
         throw new Error("expected user");
       }
 
-      const oldResidentCommitment = resident.commitment!;
+      const oldResidentCommitment = resident.commitment;
       const newResidentCommitment = residentUser.commitment;
 
       expect(oldResidentCommitment != null).to.be.true;

--- a/packages/eddsa-ticket-pcd/test/EdDSATicketPCD.spec.ts
+++ b/packages/eddsa-ticket-pcd/test/EdDSATicketPCD.spec.ts
@@ -10,7 +10,7 @@ describe("EdDSA ticket should work", function () {
   let ticket: EdDSATicketPCD;
 
   this.beforeAll(async () => {
-    await EdDSATicketPCDPackage.init!({});
+    await EdDSATicketPCDPackage.init?.({});
 
     // Key borrowed from https://github.com/iden3/circomlibjs/blob/4f094c5be05c1f0210924a3ab204d8fd8da69f49/test/eddsa.js#L103
     const prvKey =

--- a/packages/emitter/test/emitter.spec.ts
+++ b/packages/emitter/test/emitter.spec.ts
@@ -9,7 +9,7 @@ describe("Emitter", async function () {
   it("should call listeners on event emission", function () {
     const emitter = new Emitter<number>();
 
-    const callback = function (number: number) {
+    const callback = function (_number: number) {
       //
     };
 

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -4,7 +4,7 @@ module.exports = {
     "turbo",
     "prettier",
     "turbo",
-    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended"
   ],
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint", "react", "react-hooks"],
@@ -13,17 +13,18 @@ module.exports = {
     "no-case-declarations": "off",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": [
-      "warn", // or "error"
+      "error",
       {
         argsIgnorePattern: "^_",
         varsIgnorePattern: "^_",
-        caughtErrorsIgnorePattern: "^_",
-      },
+        caughtErrorsIgnorePattern: "^_"
+      }
     ],
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-non-null-assertion": "error",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
     "@typescript-eslint/no-empty-interface": "off",
-    "react/no-unescaped-entities": "off",
-  },
+    "react/no-unescaped-entities": "off"
+  }
 };

--- a/packages/ethereum-group-pcd/src/EthereumGroupPCD.ts
+++ b/packages/ethereum-group-pcd/src/EthereumGroupPCD.ts
@@ -5,23 +5,23 @@ import {
   PCDArgument,
   PCDPackage,
   SerializedPCD,
-  StringArgument,
+  StringArgument
 } from "@pcd/pcd-types";
 import {
   SemaphoreIdentityPCD,
   SemaphoreIdentityPCDPackage,
-  SemaphoreIdentityPCDTypeName,
+  SemaphoreIdentityPCDTypeName
 } from "@pcd/semaphore-identity-pcd";
 import {
   SemaphoreSignaturePCD,
-  SemaphoreSignaturePCDPackage,
+  SemaphoreSignaturePCDPackage
 } from "@pcd/semaphore-signature-pcd";
 import {
   CircuitPubInput,
   MembershipProver,
   MembershipVerifier,
   ProverConfig,
-  PublicInput,
+  PublicInput
 } from "@personaelabs/spartan-ecdsa";
 import { ethers } from "ethers";
 import JSONBig from "json-bigint";
@@ -58,7 +58,7 @@ export interface EthereumGroupPCDClaim {
 
 export enum GroupType {
   PUBLICKEY = "public_key",
-  ADDRESS = "address",
+  ADDRESS = "address"
 }
 
 export interface EthereumGroupPCDProof {
@@ -117,9 +117,9 @@ export async function init(args: EthereumGroupPCDInitArgs): Promise<void> {
     addrProver.initWasm(),
     pubkeyProver.initWasm(),
     addrVerifier.initWasm(),
-    pubkeyVerifier.initWasm(),
+    pubkeyVerifier.initWasm()
   ]);
-  return SemaphoreSignaturePCDPackage.init!(args);
+  return SemaphoreSignaturePCDPackage.init?.(args);
 }
 
 /**
@@ -191,12 +191,12 @@ export async function prove(
     identity: {
       argumentType: ArgumentTypeName.PCD,
       pcdType: SemaphoreIdentityPCDTypeName,
-      value: args.identity.value,
+      value: args.identity.value
     },
     signedMessage: {
       argumentType: ArgumentTypeName.String,
-      value: Buffer.from(proof).toString("hex"),
-    },
+      value: Buffer.from(proof).toString("hex")
+    }
   });
 
   return new EthereumGroupPCD(
@@ -206,13 +206,12 @@ export async function prove(
       groupType:
         args.groupType.value === "address"
           ? GroupType.ADDRESS
-          : GroupType.PUBLICKEY,
+          : GroupType.PUBLICKEY
     },
     {
-      signatureProof: await SemaphoreSignaturePCDPackage.serialize(
-        semaphoreSignature
-      ),
-      ethereumGroupProof: Buffer.from(proof).toString("hex"),
+      signatureProof:
+        await SemaphoreSignaturePCDPackage.serialize(semaphoreSignature),
+      ethereumGroupProof: Buffer.from(proof).toString("hex")
     }
   );
 }
@@ -221,9 +220,8 @@ export async function verify(pcd: EthereumGroupPCD): Promise<boolean> {
   const semaphoreSignature = await SemaphoreSignaturePCDPackage.deserialize(
     pcd.proof.signatureProof.pcd
   );
-  const signatureProofValid = await SemaphoreSignaturePCDPackage.verify(
-    semaphoreSignature
-  );
+  const signatureProofValid =
+    await SemaphoreSignaturePCDPackage.verify(semaphoreSignature);
 
   // the semaphore signature of the group membership proof must be valid
   if (!signatureProofValid) {
@@ -274,7 +272,7 @@ export async function serialize(
 ): Promise<SerializedPCD<EthereumGroupPCD>> {
   return {
     type: EthereumGroupPCDTypeName,
-    pcd: JSONBig({ useNativeBigInt: true }).stringify(pcd),
+    pcd: JSONBig({ useNativeBigInt: true }).stringify(pcd)
   } as SerializedPCD<EthereumGroupPCD>;
 }
 
@@ -305,7 +303,7 @@ export function getDisplayOptions(pcd: EthereumGroupPCD): DisplayOptions {
       pcd.claim.publicInput.circuitPubInput.merkleRoot
         .toString(16)
         .substring(0, 12),
-    displayName: "eth-group-" + pcd.id.substring(0, 4),
+    displayName: "eth-group-" + pcd.id.substring(0, 4)
   };
 }
 
@@ -326,5 +324,5 @@ export const EthereumGroupPCDPackage: PCDPackage<
   prove,
   verify,
   serialize,
-  deserialize,
+  deserialize
 };

--- a/packages/ethereum-ownership-pcd/src/EthereumOwnershipPCD.ts
+++ b/packages/ethereum-ownership-pcd/src/EthereumOwnershipPCD.ts
@@ -5,16 +5,16 @@ import {
   PCDArgument,
   PCDPackage,
   SerializedPCD,
-  StringArgument,
+  StringArgument
 } from "@pcd/pcd-types";
 import {
   SemaphoreIdentityPCD,
   SemaphoreIdentityPCDPackage,
-  SemaphoreIdentityPCDTypeName,
+  SemaphoreIdentityPCDTypeName
 } from "@pcd/semaphore-identity-pcd";
 import {
   SemaphoreSignaturePCD,
-  SemaphoreSignaturePCDPackage,
+  SemaphoreSignaturePCDPackage
 } from "@pcd/semaphore-signature-pcd";
 import { ethers } from "ethers";
 import JSONBig from "json-bigint";
@@ -72,7 +72,7 @@ export class EthereumOwnershipPCD
 }
 
 export async function init(args: EthereumOwnershipPCDInitArgs): Promise<void> {
-  return SemaphoreSignaturePCDPackage.init!(args);
+  return SemaphoreSignaturePCDPackage.init?.(args);
 }
 
 export async function prove(
@@ -119,24 +119,23 @@ export async function prove(
     identity: {
       argumentType: ArgumentTypeName.PCD,
       pcdType: SemaphoreIdentityPCDTypeName,
-      value: args.identity.value,
+      value: args.identity.value
     },
     signedMessage: {
       argumentType: ArgumentTypeName.String,
-      value: args.ethereumSignatureOfCommitment.value,
-    },
+      value: args.ethereumSignatureOfCommitment.value
+    }
   });
 
   return new EthereumOwnershipPCD(
     uuid(),
     {
-      ethereumAddress: args.ethereumAddress.value,
+      ethereumAddress: args.ethereumAddress.value
     },
     {
-      signatureProof: await SemaphoreSignaturePCDPackage.serialize(
-        semaphoreSignature
-      ),
-      ethereumSignatureOfCommitment: args.ethereumSignatureOfCommitment.value,
+      signatureProof:
+        await SemaphoreSignaturePCDPackage.serialize(semaphoreSignature),
+      ethereumSignatureOfCommitment: args.ethereumSignatureOfCommitment.value
     }
   );
 }
@@ -145,9 +144,8 @@ export async function verify(pcd: EthereumOwnershipPCD): Promise<boolean> {
   const semaphoreSignature = await SemaphoreSignaturePCDPackage.deserialize(
     pcd.proof.signatureProof.pcd
   );
-  const proofValid = await SemaphoreSignaturePCDPackage.verify(
-    semaphoreSignature
-  );
+  const proofValid =
+    await SemaphoreSignaturePCDPackage.verify(semaphoreSignature);
 
   // the semaphore signature of the ethereum signature must be valid
   if (!proofValid) {
@@ -195,7 +193,7 @@ export async function serialize(
 ): Promise<SerializedPCD<EthereumOwnershipPCD>> {
   return {
     type: EthereumOwnershipPCDTypeName,
-    pcd: JSONBig().stringify(pcd),
+    pcd: JSONBig().stringify(pcd)
   } as SerializedPCD<EthereumOwnershipPCD>;
 }
 
@@ -208,7 +206,7 @@ export async function deserialize(
 export function getDisplayOptions(pcd: EthereumOwnershipPCD): DisplayOptions {
   return {
     header: "Ethereum " + pcd.claim.ethereumAddress.substring(0, 12),
-    displayName: "eth-owner-" + pcd.id.substring(0, 4),
+    displayName: "eth-owner-" + pcd.id.substring(0, 4)
   };
 }
 
@@ -230,5 +228,5 @@ export const EthereumOwnershipPCDPackage: PCDPackage<
   prove,
   verify,
   serialize,
-  deserialize,
+  deserialize
 };

--- a/packages/rsa-ticket-pcd/test/RSATicketPCD.spec.ts
+++ b/packages/rsa-ticket-pcd/test/RSATicketPCD.spec.ts
@@ -15,21 +15,21 @@ describe("RSA Ticket PCD should work", function () {
   let ticketPCD: RSATicketPCD;
 
   this.beforeAll(async () => {
-    await RSATicketPCDPackage.init!({});
+    await RSATicketPCDPackage.init?.({});
 
     rsaPCD = await RSAPCDPackage.prove({
       privateKey: {
         argumentType: ArgumentTypeName.String,
-        value: exportedKey,
+        value: exportedKey
       },
       signedMessage: {
         argumentType: ArgumentTypeName.String,
-        value: message,
+        value: message
       },
       id: {
         argumentType: ArgumentTypeName.String,
-        value: undefined,
-      },
+        value: undefined
+      }
     });
   });
 
@@ -37,12 +37,12 @@ describe("RSA Ticket PCD should work", function () {
     ticketPCD = await RSATicketPCDPackage.prove({
       id: {
         argumentType: ArgumentTypeName.String,
-        value: undefined,
+        value: undefined
       },
       rsaPCD: {
         argumentType: ArgumentTypeName.PCD,
-        value: await RSAPCDPackage.serialize(rsaPCD),
-      },
+        value: await RSAPCDPackage.serialize(rsaPCD)
+      }
     });
 
     const valid = await RSATicketPCDPackage.verify(ticketPCD);

--- a/packages/zk-eddsa-ticket-pcd/test/ZKEdDSATicketPCD.spec.ts
+++ b/packages/zk-eddsa-ticket-pcd/test/ZKEdDSATicketPCD.spec.ts
@@ -178,7 +178,6 @@ describe("EdDSA partial ticket should work", function () {
     const pcdArgs = await toArgs(ticketData1, fieldsToReveal1, false);
     const pcd = await ZKEdDSATicketPCDPackage.prove(pcdArgs);
 
-    const claim = pcd.claim;
     expect(pcd.claim.externalNullifier).to.be.equal(undefined);
     expect(pcd.claim.nullifierHash).to.be.equal(undefined);
 


### PR DESCRIPTION
Fixes #428 

The majority of these are non-null assertions. These break down mostly into two categories: one, where we're `.get()`ing something from a map, often as part of a test, and we know that the item is present even though the type-checker doesn't. In this cases, `.get("id") as TYPE` has the same effect but without causing a linting warning.

The second is `init()` calls on PCD packages. The problem is that the base PCD package interface defines its function members as optional, and even when the concrete class defines them, the type-checker still thinks it's optional. The non-null assertion gets around the type-checker, but our ESlint rules don't like non-null assertions. Converting to optional invocations (`?.()`) satisfies the type-checker. However, this will produce slightly different JS output, where if the function is in fact undefined, no attempt will be made to call it. This would mean that no run-time error would occur.

In practice, this seems very unlikely to happen, because we're only calling `init()` for packages where we know that we've defined it. However, we could replace it with a run-time assertion (`if (!somePackage.init) throw new Error(...)`) which would also satisfy the type-checker and cause a run-time error, at the cost of making each invocation of `init` a bit noisier. I'd be happy to switch it to that approach.