### PR TITLE
return error html in case of legitimate unhandled error as well as errors we are aware of; update the error page to include some contact information

### DIFF
--- a/apps/passport-server/resources/telegram/error.html
+++ b/apps/passport-server/resources/telegram/error.html
@@ -5,8 +5,8 @@
   </head>
   <body>
     <p>
-      We were unable to verify your PCD. Make sure you're submitting your SRW
-      ticket PCD!
+      We were unable to verify that you have a Stanford Research Workshop
+      ticket. Make sure that you selected "SBC SRW" ticket in the dropdown!
     </p>
     <p>
       If you need help getting added to the telegram group, please email

--- a/apps/passport-server/resources/telegram/error.html
+++ b/apps/passport-server/resources/telegram/error.html
@@ -1,9 +1,16 @@
 <html>
   <head>
     <title>Error</title>
+    <style></style>
   </head>
   <body>
-    We were unable to verify your PCD. Please try a different PCD, or try again
-    later!
+    <p>
+      We were unable to verify your PCD. Make sure you're submitting your SRW
+      ticket PCD!
+    </p>
+    <p>
+      If you need help getting added to the telegram group, please email
+      <b>passport@0xparc.org</b> for help.
+    </p>
   </body>
 </html>

--- a/apps/passport-server/src/routing/routes/telegramRoutes.ts
+++ b/apps/passport-server/src/routing/routes/telegramRoutes.ts
@@ -63,6 +63,7 @@ export function initTelegramRoutes(
       logger("[TELEGRAM] failed to verify", e);
       rollbarService?.reportError(e);
       res.sendStatus(500);
+      res.sendFile(path.resolve("resources/telegram/error.html"));
     }
   });
 }


### PR DESCRIPTION
<img width="703" alt="Screenshot 2023-08-30 at 9 28 06 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/b5eaf0f9-56e7-4af1-adc0-50331cb347aa">
