### PR TITLE
Simplify handling of 429 error and cancellation of pending requests

### DIFF
--- a/apps/passport-server/src/apis/devconnect/devconnectPretixAPI.ts
+++ b/apps/passport-server/src/apis/devconnect/devconnectPretixAPI.ts
@@ -98,8 +98,10 @@ export class DevconnectPretixAPI implements IDevconnectPretixAPI {
 
         if (result.status === 429) {
           logger(
-            `[DEVCONNECT PRETIX] Received 429 error, indicating that server-side rate-limiting has been activated.
-            API client is currently enforcing a limit of ${this.intervalCap} requests per ${this.interval} milliseconds`
+            `[DEVCONNECT PRETIX] Received 429 error while fetching ${input.toString()}.
+            API client is currently enforcing a limit of ${
+              this.intervalCap
+            } requests per ${this.interval} milliseconds.`
           );
         }
 

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -195,9 +195,8 @@ describe("devconnect functionality", function () {
   });
 
   step("devconnect pretix status should sync to completion", async function () {
-    const pretixSyncStatus = await waitForDevconnectPretixSyncStatus(
-      application
-    );
+    const pretixSyncStatus =
+      await waitForDevconnectPretixSyncStatus(application);
     expect(pretixSyncStatus).to.eq(PretixSyncStatus.Synced);
     // stop interval that polls the api so we have more granular control over
     // testing the sync functionality
@@ -505,9 +504,8 @@ describe("devconnect functionality", function () {
   step(
     "should be able to check in a ticket and sync to Pretix",
     async function () {
-      const devconnectPretixAPIConfigFromDB = await getDevconnectPretixConfig(
-        db
-      );
+      const devconnectPretixAPIConfigFromDB =
+        await getDevconnectPretixConfig(db);
       if (!devconnectPretixAPIConfigFromDB) {
         throw new Error("Could not load API configuration");
       }
@@ -1275,121 +1273,11 @@ describe("devconnect functionality", function () {
     server.events.removeListener("response:mocked", listener);
   });
 
-  // step("should respect a 429 response during sync", async function () {
-  //   const devconnectPretixAPIConfigFromDB = await getDevconnectPretixConfig(db);
-  //   if (!devconnectPretixAPIConfigFromDB) {
-  //     throw new Error("Could not load API configuration");
-  //   }
-
-  //   const organizer = devconnectPretixAPIConfigFromDB?.organizers[0];
-
-  //   // Set up a sync manager for a single organizer
-  //   const os = new OrganizerSync(
-  //     organizer,
-  //     new DevconnectPretixAPI({ requestsPerInterval: 300 }),
-  //     application.services.rollbarService,
-  //     application.context.dbPool
-  //   );
-
-  //   let requestsCompleted = 0;
-
-  //   const listener = async (res: IsomorphicResponse): Promise<void> => {
-  //     if (res.status === 200) {
-  //       requestsCompleted++;
-  //     }
-  //   };
-  //   // Count each request
-  //   server.events.on("response:mocked", listener);
-
-  //   // The first request will return a 429, indicating server-side rate-limiting
-  //   server.use(
-  //     rest.get("*", (req, res, ctx) => {
-  //       // Instruct the client to wait 0.5 seconds before trying again
-  //       return res.once(ctx.set("Retry-After", "0.5"), ctx.status(429));
-  //     })
-  //   );
-
-  //   os.run();
-  //   // After 0.1 seconds, no requests have completed
-  //   await sleep(100);
-
-  //   expect(requestsCompleted).to.eq(0);
-  //   // After 0.6 seconds, we will have re-tried and successfully fetched something
-  //   await sleep(500);
-  //   expect(requestsCompleted).to.be.greaterThan(0);
-
-  //   os.cancel();
-  //   server.events.removeListener("response:mocked", listener);
-  // });
-
-  // step(
-  //   "should retry 5 times before giving up with 429 response",
-  //   async function () {
-  //     const devconnectPretixAPIConfigFromDB = await getDevconnectPretixConfig(
-  //       db
-  //     );
-  //     if (!devconnectPretixAPIConfigFromDB) {
-  //       throw new Error("Could not load API configuration");
-  //     }
-
-  //     const organizer = devconnectPretixAPIConfigFromDB?.organizers[0];
-
-  //     // Set up a sync manager for a single organizer
-  //     const os = new OrganizerSync(
-  //       organizer,
-  //       new DevconnectPretixAPI({ requestsPerInterval: 300 }),
-  //       application.services.rollbarService,
-  //       application.context.dbPool
-  //     );
-
-  //     let requestsCompleted = 0;
-
-  //     const listener = async (res: IsomorphicResponse): Promise<void> => {
-  //       if (res.status === 200) {
-  //         requestsCompleted++;
-  //       }
-  //     };
-  //     // Count each successful request
-  //     server.events.on("response:mocked", listener);
-
-  //     let url: string;
-  //     let attempts = 0;
-
-  //     server.use(
-  //       rest.get("*", (req, res, ctx) => {
-  //         attempts++;
-  //         if (!url) {
-  //           url = req.url.toString();
-  //         }
-
-  //         // Only one URL should ever be requested
-  //         // If this is not fetched within 5 requests, the entire sync run
-  //         // will fail
-  //         expect(url).to.eq(req.url.toString());
-  //         // Instruct the client to wait 0.01 seconds before trying again
-  //         return res(ctx.set("Retry-After", "0.01"), ctx.status(429));
-  //       })
-  //     );
-
-  //     os.run();
-  //     // After 0.2 seconds, no requests should have completed
-  //     await sleep(200);
-  //     expect(requestsCompleted).to.eq(0);
-
-  //     // But 6 attempts should have been made
-  //     expect(attempts).eq(6);
-
-  //     os.cancel();
-  //     server.events.removeListener("response:mocked", listener);
-  //   }
-  // );
-
   step(
     "should fail to sync if an event we're tracking is deleted",
     async function () {
-      const devconnectPretixAPIConfigFromDB = await getDevconnectPretixConfig(
-        db
-      );
+      const devconnectPretixAPIConfigFromDB =
+        await getDevconnectPretixConfig(db);
       if (!devconnectPretixAPIConfigFromDB) {
         throw new Error("Could not load API configuration");
       }
@@ -1439,9 +1327,8 @@ describe("devconnect functionality", function () {
   step(
     "should fail to sync if an active product we're tracking is deleted",
     async function () {
-      const devconnectPretixAPIConfigFromDB = await getDevconnectPretixConfig(
-        db
-      );
+      const devconnectPretixAPIConfigFromDB =
+        await getDevconnectPretixConfig(db);
       if (!devconnectPretixAPIConfigFromDB) {
         throw new Error("Could not load API configuration");
       }
@@ -1492,9 +1379,8 @@ describe("devconnect functionality", function () {
   step(
     "should fail to sync if a superuser product we're tracking is deleted",
     async function () {
-      const devconnectPretixAPIConfigFromDB = await getDevconnectPretixConfig(
-        db
-      );
+      const devconnectPretixAPIConfigFromDB =
+        await getDevconnectPretixConfig(db);
       if (!devconnectPretixAPIConfigFromDB) {
         throw new Error("Could not load API configuration");
       }


### PR DESCRIPTION
Fixes #467 and #468

Implementing a retry for 429 errors seems unnecessary, and is hard to test. Instead, we can log that it happened and perhaps adjust the limits on client-side rate-limiting to ensure that it doesn't happen again.

Separately, it seems that `fetch` does not remove event listeners in a timely fashion, so if we make a large number of sequential calls to `fetch`, we can easily end up with > 10 event listeners on a single `AbortController` signal, which causes a warning to be logged. In this implementation, each `fetch` gets its own `AbortController`, with a separate `AbortController` which is only used when cancelling the pending requests, and for which we manage event listeners manually.