### PR TITLE
pretix sync - update pcdpass ticket email if the corresponding position email changes in pretix

### DIFF
--- a/apps/passport-server/src/database/queries/devconnect_pretix_tickets/updateDevconnectPretixTicket.ts
+++ b/apps/passport-server/src/database/queries/devconnect_pretix_tickets/updateDevconnectPretixTicket.ts
@@ -14,8 +14,8 @@ export async function updateDevconnectPretixTicket(
     `\
 update devconnect_pretix_tickets
 set full_name=$1, is_deleted=$2, secret=$3, is_consumed=$4, checker=$5,
-pcdpass_checkin_timestamp=$6, pretix_checkin_timestamp=$7
-where position_id=$8
+pcdpass_checkin_timestamp=$6, pretix_checkin_timestamp=$7, email=$8
+where position_id=$9
 returning *`,
     [
       params.full_name,
@@ -25,6 +25,7 @@ returning *`,
       params.checker,
       params.pcdpass_checkin_timestamp,
       params.pretix_checkin_timestamp,
+      params.email,
       params.position_id
     ]
   );

--- a/apps/passport-server/src/util/devconnectTicket.ts
+++ b/apps/passport-server/src/util/devconnectTicket.ts
@@ -8,11 +8,11 @@ export function pretixTicketsDifferent(
   oldTicket: DevconnectPretixTicket,
   newTicket: DevconnectPretixTicket
 ): boolean {
-  if (oldTicket.is_deleted !== newTicket.is_deleted) {
+  if (oldTicket.full_name !== newTicket.full_name) {
     return true;
   }
 
-  if (oldTicket.full_name !== newTicket.full_name) {
+  if (oldTicket.is_deleted !== newTicket.is_deleted) {
     return true;
   }
 
@@ -21,6 +21,10 @@ export function pretixTicketsDifferent(
   }
 
   if (oldTicket.is_consumed !== newTicket.is_consumed) {
+    return true;
+  }
+
+  if (oldTicket.email !== newTicket.email) {
     return true;
   }
 

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -73,7 +73,7 @@ import { testLoginPCDpass } from "./user/testLoginPCDPass";
 import { overrideEnvironment, pcdpassTestingEnv } from "./util/env";
 import { startTestingApp } from "./util/startTestingApplication";
 
-describe.only("devconnect functionality", function () {
+describe("devconnect functionality", function () {
   this.timeout(30_000);
 
   let application: PCDpass;

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -73,7 +73,7 @@ import { testLoginPCDpass } from "./user/testLoginPCDPass";
 import { overrideEnvironment, pcdpassTestingEnv } from "./util/env";
 import { startTestingApp } from "./util/startTestingApplication";
 
-describe("devconnect functionality", function () {
+describe.only("devconnect functionality", function () {
   this.timeout(30_000);
 
   let application: PCDpass;
@@ -288,6 +288,129 @@ describe("devconnect functionality", function () {
           itemInfoID: item1EventAInfoID
         }
       ]);
+    }
+  );
+
+  step(
+    "updating a position's email address causes the ticket to change ownership",
+    async function () {
+      const order = mocker
+        .get()
+        .organizer1.ordersByEventID.get(mocker.get().organizer1.eventA.slug);
+      const orderCode = order ? order[0].code : undefined;
+
+      if (!orderCode) {
+        throw new Error("expected to be able to find order");
+      }
+
+      const updatedEmail = "abcdefg.com";
+      let oldEmail: string | null = "";
+
+      mocker.updateOrder(
+        mocker.get().organizer1.orgUrl,
+        mocker.get().organizer1.eventA.slug,
+        orderCode,
+        (order) => {
+          oldEmail = order.positions[0].attendee_email;
+          order.positions[0].attendee_email = updatedEmail;
+        }
+      );
+
+      await devconnectPretixSyncService.trySync();
+
+      const tickets = await fetchAllNonDeletedDevconnectPretixTickets(
+        application.context.dbPool
+      );
+
+      expect(tickets).to.have.length(14);
+
+      const ticketsWithEmailEventAndItems = tickets.map((o) => ({
+        email: o.email,
+        itemInfoID: o.devconnect_pretix_items_info_id
+      }));
+
+      // Get item info IDs for event A
+      const eventAItemInfo = await fetchPretixEventInfo(db, eventAConfigId);
+      if (!eventAItemInfo) {
+        throw new Error("expected to be able to fetch corresponding item info");
+      }
+      const [{ id: item1EventAInfoID }, { id: item2EventAInfoID }] =
+        await fetchPretixItemsInfoByEvent(db, eventAItemInfo.id);
+
+      // Get item info IDs for event B
+      const eventBItemInfo = await fetchPretixEventInfo(db, eventBConfigId);
+      if (!eventBItemInfo) {
+        throw new Error("expected to be able to fetch corresponding item info");
+      }
+
+      expect(ticketsWithEmailEventAndItems).to.have.deep.members([
+        {
+          email: updatedEmail,
+          itemInfoID: item1EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_1,
+          itemInfoID: item1EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_2,
+          itemInfoID: item1EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_2,
+          itemInfoID: item1EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_3,
+          itemInfoID: item1EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_1,
+          itemInfoID: item1EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_1,
+          itemInfoID: item2EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_1,
+          itemInfoID: item2EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_2,
+          itemInfoID: item2EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_1,
+          itemInfoID: item2EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_4,
+          itemInfoID: item2EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_4,
+          itemInfoID: item2EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_2,
+          itemInfoID: item2EventAInfoID
+        },
+        {
+          email: mocker.get().organizer1.EMAIL_1,
+          itemInfoID: item1EventAInfoID
+        }
+      ]);
+
+      // restore the email of that position back to what it was prior to this test case
+      mocker.updateOrder(
+        mocker.get().organizer1.orgUrl,
+        mocker.get().organizer1.eventA.slug,
+        orderCode,
+        (order) => {
+          order.positions[0].attendee_email = oldEmail;
+        }
+      );
     }
   );
 


### PR DESCRIPTION
closes https://github.com/proofcarryingdata/zupass/issues/392

in the case that the email address associated with a position changes, this causes the corresponding ticket in our database to change ownership as well.

during the next 'issuance', a user with a ticket in their pcdpass whose ownership was changed from their email address to another email address would have that ticket removed from their pcdpass.