### PR TITLE
redirect /prove back to localhost in dev

### DIFF
--- a/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
@@ -30,6 +30,19 @@ export function ProveScreen() {
   const screen = getScreen(request);
 
   useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      // NB: Telegram bot doesn't support localhost url and we had to use 127.0.0.1 instead
+      // We redirect back to localhost in development mode
+      if (window.location.hostname === "127.0.0.1") {
+        window.location.href = window.location.href.replace(
+          "://127.0.0.1",
+          "://localhost"
+        );
+      }
+    }
+  }, []);
+
+  useEffect(() => {
     if (screen === null) {
       err(dispatch, "Unsupported request", `Expected a PCD GET request`);
     }


### PR DESCRIPTION
Add automatic redirect on /prove route from 127.0.0.1 to localhost for convenience. The presence of `process.env.NODE_ENV !== "production"` ensures this block will be automatically optimized away in production build.

Tested locally