### PR TITLE
add /setup tg command

### DIFF
--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -118,7 +118,7 @@ export class TelegramService {
     this.bot.command("start", async (ctx) => {
       try {
         // Only process the command if it comes as a private message.
-        if (ctx.message) {
+        if (ctx.message && ctx.chat.type === "private") {
           const userId = ctx.message.from.id;
 
           const fieldsToReveal: EdDSATicketFieldsToReveal = {
@@ -187,6 +187,30 @@ export class TelegramService {
         logger("[TELEGRAM] start error", e);
         this.rollbarService?.reportError(e);
       }
+    });
+
+    // The "setup" command helps prospective event organizer to collect necessary information.
+    // Currently, this just prints the ID of the channel.
+    this.bot.command("setup", async (ctx) => {
+      if (ctx.chat?.type === "private") {
+        await ctx.reply(
+          "To get you started, can you please add me as an admin to the telegram channel associated with your event? Once you are done, please ping me again with /setup in the channel."
+        );
+        return;
+      }
+
+      const admins = await ctx.getChatAdministrators();
+      const isAdmin = admins.some(
+        (admin) => admin.user.id === this.bot.botInfo.id
+      );
+      if (!isAdmin) {
+        await ctx.reply(
+          "Please add me as an admin to the telegram channel associated with your event."
+        );
+        return;
+      }
+
+      await ctx.reply("Your telegram channel id is " + ctx.chat.id);
     });
   }
 


### PR DESCRIPTION
Not sure if we will find this useful but I added a new /setup command that can be used in channel to quickly find the channel id. We could iterate on this to provide a user friendly onboarding experience in the future. We could also consider create a separate admin/onboarding bot for these commands.

I don't particularly like the fact this posts in the channel but presumably we could ask bot to automatically clean them up after the fact. I have tried other approach via PM but the only success I found was to ask admin to forward a message from the channel, which felt less ergnomic.

Also, fix a small bug where we didn't check if `/start` command was sent via private chat.

ptal @rrrliu 

channel 
<img width="781" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/2ed9ced6-c5cf-4392-aa49-98d22e01008d">


PM 

<img width="752" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/f90610fa-f520-4e7b-9b89-c6a60bfca3e0">
