### PR TITLE
more robust ts-node-dev hot reload

### DIFF
--- a/apps/passport-server/.env.local.example
+++ b/apps/passport-server/.env.local.example
@@ -66,9 +66,12 @@ SERVER_RSA_PRIVATE_KEY_BASE64=
 SERVER_EDDSA_PRIVATE_KEY=
 
 # To enable notifications from the server to be sent to Discord
-DISCORD_TOKEN=
-DISCORD_ALERTS_CHANNEL_ID=
+#DISCORD_TOKEN=
+#DISCORD_ALERTS_CHANNEL_ID=
 
 # For Telegram-gated authentication and anonymous message posting
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_BOT_START_DELAY_MS=0
+
+# Disable Pretix sync for local development
+PRETIX_SYNC_DISABLED=TRUE

--- a/apps/passport-server/package.json
+++ b/apps/passport-server/package.json
@@ -4,7 +4,7 @@
   "license": "GPL-3.0-or-later",
   "private": true,
   "scripts": {
-    "dev": "NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=development ts-node-dev src/main.ts",
+    "dev": "NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=development ts-node-dev --exit-child -- src/main.ts",
     "build": "yarn tsc --noEmit",
     "start": "NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=production PORT=8080 ts-node src/main.ts",
     "lint": "eslint \"**/*.ts{,x}\"",


### PR DESCRIPTION
### Automatic Reload Not Working

ts-node-dev supports automatically restart node process when any source files change. For example, if we edit `telegramService`, the `passport-server:dev:` should restart and the Telegram bot should pick up the changes automatically. However, this is not working in my environment as below:

```
passport-server:dev: [METRICS] couldn't report metrics - missing honeycomb client
passport-server:dev: [TELEGRAM] Started bot 'forest_test_pcd_bot' successfully!
passport-server:dev: [INFO] 23:25:28 Restarting: /Users/forestfang/stripe/zupass/apps/passport-server/src/services/pretixSyncService.ts has been modified
passport-server:dev: [PROCESS] CAUGHT SIGTERM
passport-server:dev: [DISCORD] getting client
```

After the fix suggested by https://stackoverflow.com/questions/62434261/ts-node-dev-not-restarting-when-changes-made The hot restart started to work again


```
passport-server:dev: [METRICS] couldn't report metrics - missing honeycomb client
passport-server:dev: [TELEGRAM] Started bot 'forest_test_pcd_bot' successfully!
passport-server:dev: [INFO] 23:17:42 Restarting: /Users/forestfang/stripe/zupass/apps/passport-server/src/services/discordService.ts has been modified
passport-server:dev: Child got SIGTERM, exiting.
passport-server:dev: [INIT] Loading environment variables from: /Users/forestfang/stripe/zupass/apps/passport-server/.env 
passport-server:dev: [INIT] Starting application
passport-server:dev: [INIT] Initializing Postgres client
```

IIUC [The flag](https://github.com/wclr/ts-node-dev#:~:text=commas%2C%20chokidar%20patterns)-,%2D%2Dexit%2Dchild,-%2D%20Adds%20%27SIGTERM%27%20exit) ensures any child processes spawned are also SIGTERM'ed

### Root Cause

Upon further inspection, the root cause turned out to be there is a dangling child process preventing full shutdown of the service.

The dangling child process came from Discord service where the `.env.local.example` had `DISCORD_TOKEN=` which set the value to empty string and led to the following error. 

```
passport-server:dev: Error [TokenInvalid]: An invalid token was provided.
passport-server:dev:     at Client.login (/Users/forestfang/stripe/zupass/node_modules/discord.js/src/client/Client.js:214:52)
passport-server:dev:     at /Users/forestfang/stripe/zupass/apps/passport-server/src/services/discordService.ts:71:10
passport-server:dev:     at Generator.next (<anonymous>)
passport-server:dev:     at /Users/forestfang/stripe/zupass/apps/passport-server/src/services/discordService.ts:8:71
passport-server:dev:     at new Promise (<anonymous>)
passport-server:dev:     at __awaiter (/Users/forestfang/stripe/zupass/apps/passport-server/src/services/discordService.ts:4:12)
passport-server:dev:     at instantiateDiscordClient (/Users/forestfang/stripe/zupass/apps/passport-server/src/services/discordService.ts:56:12)
passport-server:dev:     at /Users/forestfang/stripe/zupass/apps/passport-server/src/services/discordService.ts:55:5
passport-server:dev:     at Generator.next (<anonymous>)
passport-server:dev:     at /Users/forestfang/stripe/zupass/apps/passport-server/src/services/discordService.ts:8:71
```

This PR also comment out these tokens by default. Also, `PRETIX_SYNC_DISABLED` is also set to TRUE for local development because PRETIX tokens were not listed as suggested env vars in this example .env file.

By the way, the latter fix technically renders the first change unnecessary (without the dangling discord process, auto restart work again) but the first change prevents similar pain in the future and has no downside as far as I can tell.


ptal @rrrliu 