### PR TITLE
Normalize pretix email before inserting into DB

### DIFF
--- a/apps/passport-server/src/services/devconnect/organizerSync.ts
+++ b/apps/passport-server/src/services/devconnect/organizerSync.ts
@@ -37,6 +37,7 @@ import {
 } from "../../database/queries/pretixItemInfo";
 import { pretixTicketsDifferent } from "../../util/devconnectTicket";
 import { logger } from "../../util/logger";
+import { normalizeEmail } from "../../util/util";
 import { RollbarService } from "../rollbarService";
 import { setError, traced } from "../telemetryService";
 
@@ -866,7 +867,7 @@ export class OrganizerSync {
               })
             );
           }
-          const email = (attendee_email || order.email).toLowerCase();
+          const email = normalizeEmail(attendee_email || order.email);
           const pretix_checkin_timestamp =
             checkins.length > 0 ? checkins[0].datetime : null;
 


### PR DESCRIPTION
To ensure that #522 and remaining devconnect ticketing works properly, we need to account for the edge case of extraneous whitespace characters at the beginning or end of emails from Pretix. This replaces the `.toLowerCase()` operation with the `normalizeEmail()` function from passport-server's utils.