### PR TITLE
EdDSA pubkey test

### DIFF
--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -152,7 +152,6 @@ export class IssuanceService {
       }
 
       const checkerSuperUserPermissions =
-        // here
         await fetchDevconnectSuperusersForEmail(
           this.context.dbPool,
           checker.email

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -2,8 +2,8 @@ import { EDdSAPublicKey, getEdDSAPublicKey } from "@pcd/eddsa-pcd";
 import {
   EdDSATicketPCD,
   EdDSATicketPCDPackage,
-  getEdDSATicketData,
-  ITicketData
+  ITicketData,
+  getEdDSATicketData
 } from "@pcd/eddsa-ticket-pcd";
 import { getHash } from "@pcd/passport-crypto";
 import {
@@ -70,7 +70,7 @@ export class IssuanceService {
     return this.exportedRSAPublicKey;
   }
 
-  public getEdDSAPublicKey(): EDdSAPublicKey {
+  public getEdDSAPublicKey(): Promise<EDdSAPublicKey> {
     return getEdDSAPublicKey(this.eddsaPrivateKey);
   }
 
@@ -152,6 +152,7 @@ export class IssuanceService {
       }
 
       const checkerSuperUserPermissions =
+        // here
         await fetchDevconnectSuperusersForEmail(
           this.context.dbPool,
           checker.email

--- a/packages/eddsa-pcd/src/EdDSAPCD.ts
+++ b/packages/eddsa-pcd/src/EdDSAPCD.ts
@@ -176,7 +176,11 @@ export const EdDSAPCDPackage: PCDPackage<
   deserialize
 };
 
-export function getEdDSAPublicKey(privateKey: string): [string, string] {
+export async function getEdDSAPublicKey(
+  privateKey: string
+): Promise<[string, string]> {
+  await ensureInitialized();
+
   return eddsa.prv2pub(fromHexString(privateKey)).map(toHexString) as [
     string,
     string


### PR DESCRIPTION
Closes #460 

Also fixes an oversight - `getEdDSAPublicKey()` in `@pcd/eddsa-pcd` should ensure the package is initialized, just as we do with prove and verify.

