### PR TITLE
Fix: Force users who have their server commitment deleted to log out

### DIFF
--- a/apps/passport-server/src/services/semaphoreService.ts
+++ b/apps/passport-server/src/services/semaphoreService.ts
@@ -88,7 +88,8 @@ export class SemaphoreService {
     const commitment = await fetchCommitmentByUuid(this.dbPool, uuid);
 
     if (!commitment) {
-      throw new Error("no user with that email exists");
+      logger("[SEMA] no user with that email exists");
+      return null;
     }
 
     const superuserPrivilages = await fetchDevconnectSuperusersForEmail(
@@ -126,7 +127,8 @@ export class SemaphoreService {
     const commitment = await fetchCommitment(this.dbPool, email);
 
     if (!commitment) {
-      throw new Error("no user with that email exists");
+      logger("[SEMA] no user with that email exists");
+      return null;
     }
 
     const superuserPrivilages = await fetchDevconnectSuperusersForEmail(


### PR DESCRIPTION
Fixes an issue that happens when a commitment is deleted on the server, and the client tries to refresh a logged-in session for the user corresponding to the just-deleted commitment.

Whenever the page is refreshed when logged in, we call `/pcdpass/participants/:uuid `to fetch the current state of the user. If the user from `semaphoreService.getUserByUUID(uuid)` is falsy, we return a 404, which the client interprets as "user not found" -> this takes us to the "Passport Invalid" screen that we want. However, we currently throw an Error, which return a generic 500 response code that client is unable to interpret.

To fix this, we simply return `null` and log an error rather than throwing an error. I've duplicated this same logic to `semaphoreService.getUserByEmail()` for consistency.

https://github.com/proofcarryingdata/zupass/assets/36896271/e6abb471-1a19-4bb6-a02a-05ff7be37332

