### PR TITLE
[DO NOT MERGE] Migration to reset commitments table

### DIFF
--- a/apps/passport-server/migrations/32_dev_only_prune_commitments_table_of_null_salt.sql
+++ b/apps/passport-server/migrations/32_dev_only_prune_commitments_table_of_null_salt.sql
@@ -1,0 +1,1 @@
+delete from commitments where salt is null;;

--- a/apps/passport-server/migrations/32_dev_only_reset_commitments_table.sql
+++ b/apps/passport-server/migrations/32_dev_only_reset_commitments_table.sql
@@ -1,0 +1,1 @@
+delete from commitments;

--- a/apps/passport-server/migrations/32_dev_only_reset_commitments_table.sql
+++ b/apps/passport-server/migrations/32_dev_only_reset_commitments_table.sql
@@ -1,1 +1,0 @@
-delete from commitments;


### PR DESCRIPTION
After an overhaul to our authentication flow with #514, existing local PCDPass accounts that have been created with the old flow will have issues when attempting the reset account flow. To fix this locally, you can run this migration locally, which will clear out stale accounts from the commitments table. Note that this is a destructive action that will delete all non-ticket PCDs.

```sh
git pull
git checkout reset-commitments
yarn dev
```