### PR TITLE
Make password inputs readonly

### DIFF
--- a/apps/passport-client/components/screens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/AlreadyRegisteredScreen.tsx
@@ -145,7 +145,7 @@ export function AlreadyRegisteredScreen() {
           ) : (
             <>
               <CenterColumn w={280}>
-                <BigInput value={email} disabled={true} />
+                <BigInput value={email} disabled={true} readOnly />
                 <Spacer h={8} />
                 {/*
                  * If a user has a `salt` field, then that means they chose their own password

--- a/apps/passport-client/components/screens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/CreatePasswordScreen.tsx
@@ -98,7 +98,7 @@ export function CreatePasswordScreen() {
         <CenterColumn w={280}>
           <form onSubmit={onCreatePassword}>
             {/* For password manager autofill */}
-            <input hidden value={email} />
+            <input hidden readOnly value={email} />
             <SetPasswordInput
               value={password}
               setValue={setPassword}


### PR DESCRIPTION
To prevent errors like the following:

![image](https://github.com/proofcarryingdata/zupass/assets/36896271/4d497e68-2e21-4ea3-9d47-626c3b7359e7)
