### PR TITLE
Save subscriptions after adding default subscriptions

### DIFF
--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -187,7 +187,9 @@ async function loadInitialState(): Promise<AppState> {
   const userInvalid = loadUserInvalid();
   const subscriptions = await loadSubscriptions();
 
-  await addDefaultSubscriptions(identity, subscriptions);
+  if (self) {
+    await addDefaultSubscriptions(identity, subscriptions);
+  }
 
   subscriptions.updatedEmitter.listen(() => saveSubscriptions(subscriptions));
 

--- a/apps/passport-client/src/defaultSubscriptions.ts
+++ b/apps/passport-client/src/defaultSubscriptions.ts
@@ -13,6 +13,7 @@ import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import { SemaphoreSignaturePCDPackage } from "@pcd/semaphore-signature-pcd";
 import { Identity } from "@semaphore-protocol/identity";
 import { appConfig } from "../src/appConfig";
+import { saveSubscriptions } from "./localstorage";
 
 const DEFAULT_FEED_URL = `${appConfig.passportServer}/feeds`;
 
@@ -55,5 +56,7 @@ export async function addDefaultSubscriptions(
       },
       await SemaphoreSignaturePCDPackage.serialize(signaturePCD)
     );
+
+    await saveSubscriptions(subscriptions);
   }
 }


### PR DESCRIPTION
Adding default subscriptions has some performance overhead, mostly because it requires generating a `SemaphoreSignaturePCD` to act as a credential. This is fine as a one-off, but we were not saving the default subscriptions to localStorage, meaning that this process was occurring on every load.