### PR TITLE
Add a better error message for weak zxcvbn passwords

### DIFF
--- a/apps/passport-client/components/screens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/CreatePasswordScreen.tsx
@@ -69,7 +69,11 @@ export function CreatePasswordScreen() {
         `Password must be at least ${PASSWORD_MINIMUM_LENGTH} characters.`
       );
     } else if (!checkPasswordStrength(password)) {
-      setErrorMessage("Password is too weak.");
+      // Inspired by Dashlane's zxcvbn guidance:
+      // https://www.dashlane.com/blog/dashlanes-new-zxcvbn-guidance-helps-you-create-stronger-master-passwords-and-eliminates-the-guessing-game
+      setErrorMessage(
+        "Password is too weak. Add another word or two. Uncommon words are better."
+      );
     } else if (confirmPassword === "") {
       setErrorMessage("Please confirm your password.");
     } else if (password !== confirmPassword) {

--- a/apps/passport-client/components/screens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/CreatePasswordScreen.tsx
@@ -62,7 +62,6 @@ export function CreatePasswordScreen() {
 
   const onCreatePassword = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setErrorMessage("");
     if (password === "") {
       setErrorMessage("Please enter a password.");
     } else if (password.length < PASSWORD_MINIMUM_LENGTH) {
@@ -107,7 +106,10 @@ export function CreatePasswordScreen() {
             <input hidden readOnly value={email} />
             <SetPasswordInput
               value={password}
-              setValue={setPassword}
+              setValue={(value) => {
+                setErrorMessage("");
+                setPassword(value);
+              }}
               placeholder="Password"
               autoFocus
               revealPassword={revealPassword}
@@ -116,7 +118,10 @@ export function CreatePasswordScreen() {
             <Spacer h={8} />
             <SetPasswordInput
               value={confirmPassword}
-              setValue={setConfirmPassword}
+              setValue={(value) => {
+                setErrorMessage("");
+                setConfirmPassword(value);
+              }}
               placeholder="Confirm password"
               revealPassword={revealPassword}
               setRevealPassword={setRevealPassword}

--- a/apps/passport-client/components/screens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/CreatePasswordScreen.tsx
@@ -62,6 +62,7 @@ export function CreatePasswordScreen() {
 
   const onCreatePassword = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setErrorMessage("");
     if (password === "") {
       setErrorMessage("Please enter a password.");
     } else if (password.length < PASSWORD_MINIMUM_LENGTH) {

--- a/apps/passport-client/components/screens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/CreatePasswordScreen.tsx
@@ -72,7 +72,7 @@ export function CreatePasswordScreen() {
       // Inspired by Dashlane's zxcvbn guidance:
       // https://www.dashlane.com/blog/dashlanes-new-zxcvbn-guidance-helps-you-create-stronger-master-passwords-and-eliminates-the-guessing-game
       setErrorMessage(
-        "Password is too weak. Add another word or two. Uncommon words are better."
+        "Password is too weak. Try adding another word or two. Uncommon words are better."
       );
     } else if (confirmPassword === "") {
       setErrorMessage("Please confirm your password.");


### PR DESCRIPTION
<img width="440" alt="Screenshot 2023-09-14 at 11 14 45 AM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/09f782f1-ca3d-43b2-aa3c-1cd4dea8abf3">


The suggestion comes directly from the `zxcvbn` array of suggestions.

<img width="630" alt="Screenshot 2023-09-14 at 11 12 01 AM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/2b129c92-cfc8-479e-9e49-573cdee4cc2b">
