### PR TITLE
Add default subscriptions after emitter listener is set up

### DIFF
--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -187,9 +187,11 @@ async function loadInitialState(): Promise<AppState> {
   const userInvalid = loadUserInvalid();
   const subscriptions = await loadSubscriptions();
 
-  await addDefaultSubscriptions(identity, subscriptions);
-
   subscriptions.updatedEmitter.listen(() => saveSubscriptions(subscriptions));
+
+  if (self) {
+    await addDefaultSubscriptions(identity, subscriptions);
+  }
 
   let modal = "" as AppState["modal"];
 


### PR DESCRIPTION
Default subscriptions were being added before the subscription emitter listener was set up, so these changes were not being persisted. This meant that default subscriptions were being set up on each page load, with a negative performance impact due to the need to create `SemaphoreSignaturePCD`s with the subscriptions.