### PR TITLE
polish prove screen input sizing

### DIFF
--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -100,6 +100,7 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
 }
 
 const ErrorContainer = styled.div`
+  width: 100%;
   padding: 16px;
   background-color: white;
   color: var(--danger);

--- a/apps/passport-client/components/shared/PCDArgs.tsx
+++ b/apps/passport-client/components/shared/PCDArgs.tsx
@@ -153,9 +153,11 @@ export function StringArgInput<T extends PCDPackage>({
           <ArgTypeLabel argType={arg.argumentType} />
         </ArgName>
       </Row>
-      <Row>
-        <Description>{arg.description}</Description>
-      </Row>
+      {arg.description && (
+        <Row>
+          <Description>{arg.description}</Description>
+        </Row>
+      )}
       <Row>
         <InputContainer>
           <input
@@ -212,9 +214,11 @@ export function NumberArgInput<T extends PCDPackage>({
           <ArgTypeLabel argType={arg.argumentType} />
         </ArgName>
       </Row>
-      <Row>
-        <Description>{arg.description}</Description>
-      </Row>
+      {arg.description && (
+        <Row>
+          <Description>{arg.description}</Description>
+        </Row>
+      )}
       <Row>
         <InputContainer>
           <input
@@ -274,12 +278,14 @@ export function BigIntArgInput<T extends PCDPackage>({
           <ArgTypeLabel argType={arg.argumentType} />
         </ArgName>
       </Row>
-      <Row>
-        <Description>{arg.description}</Description>
-      </Row>
+      {arg.description && (
+        <Row>
+          <Description>{arg.description}</Description>
+        </Row>
+      )}
       <Row>
         <InputContainer>
-          <input
+          <Input
             value={arg.value ?? ""}
             onChange={onChange}
             disabled={!arg.userProvided}
@@ -320,9 +326,11 @@ export function BooleanArgInput<T extends PCDPackage>({
           <ArgTypeLabel argType={arg.argumentType} />
         </ArgName>
       </Row>
-      <Row>
-        <Description>{arg.description}</Description>
-      </Row>
+      {arg.description && (
+        <Row>
+          <Description>{arg.description}</Description>
+        </Row>
+      )}
       <Row>
         <InputContainer>
           <input
@@ -389,9 +397,11 @@ export function ObjectArgInput<T extends PCDPackage>({
           <ArgTypeLabel argType={arg.argumentType} />
         </ArgName>
       </Row>
-      <Row>
-        <Description>{arg.description}</Description>
-      </Row>
+      {arg.description && (
+        <Row>
+          <Description>{arg.description}</Description>
+        </Row>
+      )}
       <Row>
         <InputContainer>
           <textarea
@@ -482,14 +492,16 @@ export function PCDArgInput<T extends PCDPackage>({
           <ArgTypeLabel argType={arg.argumentType} />
         </ArgName>
       </Row>
-      <Row>
-        <Description>{arg.description}</Description>
-      </Row>
+      {arg.description && (
+        <Row>
+          <Description>{arg.description}</Description>
+        </Row>
+      )}
       <Row>
         <InputContainer>
-          <select value={value?.id} onChange={onChange}>
-            <option key="none" value={"none"}>
-              select
+          <Select value={value?.id} onChange={onChange}>
+            <option key="none" value="none" disabled>
+              Please select a {argName}
             </option>
             {relevantPCDs.map((pcd) => {
               const pcdPackage = pcdCollection.getPackage(pcd.type);
@@ -499,7 +511,7 @@ export function PCDArgInput<T extends PCDPackage>({
                 </option>
               );
             })}
-          </select>
+          </Select>
         </InputContainer>
       </Row>
     </ArgContainer>
@@ -525,7 +537,7 @@ const ArgName = styled.div`
   padding: 10px 10px 0px 10px;
   display: flex;
   justify-content: flex-start;
-  align-items: center;
+  align-items: baseline;
 `;
 
 const ArgContainer = styled.div`
@@ -540,13 +552,14 @@ const ArgContainer = styled.div`
 `;
 
 const ArgsContainer = styled.div`
+  width: 100%;
   border-radius: 16px;
   color: black;
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  gap: 16px;
+  gap: 8px;
   color: var(--bg-dark-primary);
   background-color: white;
   border: 1px solid var(--accent-lite);
@@ -570,4 +583,15 @@ const ArgTypeNameContainer = styled.span`
 const ErrorContainer = styled.div`
   padding: 0px 10px 0px 10px;
   color: var(--danger);
+`;
+
+const Select = styled.select`
+  width: 100%;
+  height: 32px;
+  border-radius: 4px;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  height: 32px;
 `;


### PR DESCRIPTION
first pass on https://github.com/proofcarryingdata/zupass/issues/597

* Make Select full width and verified it works for cases where option text is short and long
* Only render description row if the argument has a description. Otherwise this doubles the gap between argument name and input
* Set placeholder Select option to disabled so it cannot be selected. Polish placeholder text copy
* Fiddle gap and input height and text alignment to make them look good (tactically made sure it fits on a iPhone 12 Pro single screen to avoid scrolling)

Before / After

<img width="485" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/48733197-be04-4a0c-ae32-8720cf8a02d4">

<img width="450" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/5683a2a3-4764-43a0-a0b6-f8493e99c220">

Mobile Rendering

<img width="487" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/a2db1302-33a3-4587-bb7a-fb6c59458966">

Overflow option text:
<img width="569" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/526a0b76-ddbe-4e85-9db8-b498e21cf51a">

Short option text:
<img width="466" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/4eb90695-a100-4cfd-911f-e935508ea21a">
