### PR TITLE
fix flickering background color

### DIFF
--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -129,7 +129,15 @@ function compileHtml() {
 
   const html = template({
     title: IS_ZUZALU ? "Zuzalu Passport" : "PCDpass",
-    cssPath: IS_ZUZALU ? "/global-zupass.css" : "/global-pcdpass.css"
+    cssPath: IS_ZUZALU ? "/global-zupass.css" : "/global-pcdpass.css",
+    grayBgPaths: [
+      "", // home
+      "get-without-proving",
+      "halo",
+      "add",
+      "prove",
+      "scan"
+    ].join("|")
   });
 
   fs.writeFileSync(path.join("public", "index.html"), html);

--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import Handlebars from "handlebars";
 import * as path from "path";
 import { v4 as uuid } from "uuid";
+import { appConfig } from "./src/appConfig";
 
 dotenv.config();
 
@@ -130,14 +131,7 @@ function compileHtml() {
   const html = template({
     title: IS_ZUZALU ? "Zuzalu Passport" : "PCDpass",
     cssPath: IS_ZUZALU ? "/global-zupass.css" : "/global-pcdpass.css",
-    grayBgPaths: [
-      "", // home
-      "get-without-proving",
-      "halo",
-      "add",
-      "prove",
-      "scan"
-    ].join("|")
+    grayBgPaths: appConfig.grayBackgroundRoutes.join("|")
   });
 
   fs.writeFileSync(path.join("public", "index.html"), html);

--- a/apps/passport-client/components/screens/AddScreen/AddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/AddScreen.tsx
@@ -56,7 +56,7 @@ export function AddScreen() {
 
   if (screen == null) {
     // Need AppContainer to display error
-    return <AppContainer bg="gray" />;
+    return <AppContainer />;
   }
   return screen;
 }

--- a/apps/passport-client/components/screens/AddScreen/JustAddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/JustAddScreen.tsx
@@ -51,7 +51,7 @@ export function JustAddScreen({ request }: { request: PCDAddRequest }) {
   }
 
   return (
-    <AppContainer bg="gray">
+    <AppContainer>
       <MaybeModal fullScreen />
       <Container>
         <Spacer h={16} />

--- a/apps/passport-client/components/screens/AddScreen/ProveAndAddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/ProveAndAddScreen.tsx
@@ -64,7 +64,7 @@ export function ProveAndAddScreen({
   }
 
   return (
-    <AppContainer >
+    <AppContainer>
       <MaybeModal fullScreen />
       <Container>
         <Spacer h={24} />

--- a/apps/passport-client/components/screens/AddScreen/ProveAndAddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/ProveAndAddScreen.tsx
@@ -64,7 +64,7 @@ export function ProveAndAddScreen({
   }
 
   return (
-    <AppContainer bg="gray">
+    <AppContainer >
       <MaybeModal fullScreen />
       <Container>
         <Spacer h={24} />

--- a/apps/passport-client/components/screens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/AlreadyRegisteredScreen.tsx
@@ -132,7 +132,7 @@ export function AlreadyRegisteredScreen() {
   return (
     <>
       <MaybeModal />
-      <AppContainer bg="primary">
+      <AppContainer>
         <BackgroundGlow
           y={224}
           from="var(--bg-lite-primary)"

--- a/apps/passport-client/components/screens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/CreatePasswordScreen.tsx
@@ -90,7 +90,7 @@ export function CreatePasswordScreen() {
   };
 
   return (
-    <AppContainer bg="primary">
+    <AppContainer>
       <BackgroundGlow
         y={224}
         from="var(--bg-lite-primary)"

--- a/apps/passport-client/components/screens/DevconnectCheckinScreen.tsx
+++ b/apps/passport-client/components/screens/DevconnectCheckinScreen.tsx
@@ -151,7 +151,7 @@ function TicketError({
   }
 
   return (
-    <AppContainer bg={"primary"}>
+    <AppContainer>
       <Container>
         {showTicket && <TicketInfoSection ticketData={ticketData} />}
         <ErrorContainer>{errorContent}</ErrorContainer>
@@ -198,7 +198,7 @@ function UserReadyForCheckin({
   ticket: EdDSATicketPCD;
 }) {
   return (
-    <AppContainer bg={"primary"}>
+    <AppContainer>
       <Container>
         <TicketInfoSection ticketData={ticketData} />
         <CheckInSection ticket={ticket} />

--- a/apps/passport-client/components/screens/DeviceLoginScreen.tsx
+++ b/apps/passport-client/components/screens/DeviceLoginScreen.tsx
@@ -26,7 +26,7 @@ export function DeviceLoginScreen() {
   }, []);
 
   return (
-    <AppContainer bg="primary">
+    <AppContainer>
       <Container>
         <Spacer h={64} />
         <TextCenter>

--- a/apps/passport-client/components/screens/EnterConfirmationCodeScreen.tsx
+++ b/apps/passport-client/components/screens/EnterConfirmationCodeScreen.tsx
@@ -52,7 +52,7 @@ export function EnterConfirmationCodeScreen() {
   return (
     <>
       <MaybeModal />
-      <AppContainer bg="primary">
+      <AppContainer>
         <BackgroundGlow
           y={224}
           from="var(--bg-lite-primary)"

--- a/apps/passport-client/components/screens/GetWithoutProvingScreen.tsx
+++ b/apps/passport-client/components/screens/GetWithoutProvingScreen.tsx
@@ -95,7 +95,7 @@ export function GetWithoutProvingScreen() {
   }
 
   return (
-    <AppContainer bg="gray">
+    <AppContainer>
       <MaybeModal fullScreen />
       <Container>
         <Spacer h={16} />

--- a/apps/passport-client/components/screens/HaloScreen/AddHaloScreen.tsx
+++ b/apps/passport-client/components/screens/HaloScreen/AddHaloScreen.tsx
@@ -94,12 +94,12 @@ export function AddHaloScreen({
   let content: ReactNode;
 
   if (invalidPCD) {
-    return <AppContainer bg="gray" />;
+    return <AppContainer />;
   } else if (!pcd) {
     return <SyncingPCDs />;
   } else if (!loggedIn) {
     return (
-      <AppContainer bg="gray">
+      <AppContainer>
         <MaybeModal fullScreen />
         <Container>
           <Spacer h={16} />
@@ -135,7 +135,7 @@ export function AddHaloScreen({
   }
 
   return (
-    <AppContainer bg="gray">
+    <AppContainer>
       <MaybeModal fullScreen />
       <Container>
         <Spacer h={16} />

--- a/apps/passport-client/components/screens/HaloScreen/HaloScreen.tsx
+++ b/apps/passport-client/components/screens/HaloScreen/HaloScreen.tsx
@@ -27,7 +27,7 @@ export function HaloScreen() {
 
   if (!syncSettled) {
     return (
-      <AppContainer bg="gray">
+      <AppContainer>
         <SyncingPCDs />
       </AppContainer>
     );
@@ -35,7 +35,7 @@ export function HaloScreen() {
 
   if (screen == null) {
     // Need AppContainer to display error
-    return <AppContainer bg="gray" />;
+    return <AppContainer />;
   }
 
   return screen;

--- a/apps/passport-client/components/screens/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen.tsx
@@ -128,7 +128,7 @@ export function HomeScreenImpl() {
   return (
     <>
       <MaybeModal />
-      <AppContainer bg="gray">
+      <AppContainer>
         <Spacer h={24} />
         <AppHeader />
         <Spacer h={24} />

--- a/apps/passport-client/components/screens/LoginInterstitialScreen.tsx
+++ b/apps/passport-client/components/screens/LoginInterstitialScreen.tsx
@@ -25,7 +25,7 @@ export function LoginInterstitialScreen() {
 
   return (
     <>
-      <AppContainer bg="primary">
+      <AppContainer>
         <BackgroundGlow
           y={224}
           from="var(--bg-lite-primary)"

--- a/apps/passport-client/components/screens/LoginScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreen.tsx
@@ -106,7 +106,7 @@ export function LoginScreen() {
   }, [self]);
 
   return (
-    <AppContainer bg="primary">
+    <AppContainer>
       <BackgroundGlow
         y={224}
         from="var(--bg-lite-primary)"

--- a/apps/passport-client/components/screens/MissingScreen.tsx
+++ b/apps/passport-client/components/screens/MissingScreen.tsx
@@ -8,7 +8,7 @@ export function MissingScreen() {
   const loc = useLocation();
 
   return (
-    <AppContainer bg="gray">
+    <AppContainer overrideBackgroundColor="gray">
       <CenterColumn w={290}>
         <TextCenter>
           <Spacer h={64} />

--- a/apps/passport-client/components/screens/NewPassportScreen.tsx
+++ b/apps/passport-client/components/screens/NewPassportScreen.tsx
@@ -92,7 +92,7 @@ function SendEmailVerification({ email }: { email: string }) {
   );
 
   return (
-    <AppContainer bg="primary">
+    <AppContainer>
       <BackgroundGlow
         y={224}
         from="var(--bg-lite-primary)"

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
@@ -44,7 +44,7 @@ export function GenericProveScreen({ req }: { req: PCDGetRequest }) {
   }
 
   return (
-    <AppContainer bg="gray">
+    <AppContainer>
       <Spacer h={24} />
       <AppHeader />
       <Spacer h={24} />

--- a/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
@@ -64,7 +64,7 @@ export function ProveScreen() {
 
   if (!syncSettled) {
     return (
-      <AppContainer bg="gray">
+      <AppContainer>
         <SyncingPCDs />
       </AppContainer>
     );
@@ -72,7 +72,7 @@ export function ProveScreen() {
 
   if (screen == null) {
     // Need AppContainer to display error
-    return <AppContainer bg="gray" />;
+    return <AppContainer />;
   }
 
   return screen;
@@ -109,7 +109,7 @@ function getScreen(request: PCDGetRequest) {
   return (
     <>
       <MaybeModal fullScreen={true} />
-      <AppContainer bg="gray">
+      <AppContainer>
         <Spacer h={24} />
         <H2>{title.toUpperCase()}</H2>
         <Spacer h={24} />

--- a/apps/passport-client/components/screens/ScanScreen.tsx
+++ b/apps/passport-client/components/screens/ScanScreen.tsx
@@ -11,7 +11,7 @@ import { AppContainer } from "../shared/AppContainer";
 export function ScanScreen() {
   const nav = useNavigate();
   return (
-    <AppContainer bg="gray">
+    <AppContainer>
       <QrReader
         onResult={(result, error) => {
           if (result != null) {

--- a/apps/passport-client/components/screens/SyncExistingScreen.tsx
+++ b/apps/passport-client/components/screens/SyncExistingScreen.tsx
@@ -94,7 +94,7 @@ export function SyncExistingScreen() {
   }, []);
 
   return (
-    <AppContainer bg="primary">
+    <AppContainer>
       <BackgroundGlow
         y={224}
         from="var(--bg-lite-primary)"
@@ -106,8 +106,8 @@ export function SyncExistingScreen() {
           <Spacer h={32} />
           <TextCenter>
             If you've already registered, you can sync with your other device
-            here using your Sync Key. You can find your Sync Key
-            on your existing device by clicking on the settings icon.
+            here using your Sync Key. You can find your Sync Key on your
+            existing device by clicking on the settings icon.
           </TextCenter>
           <Spacer h={32} />
           <CenterColumn w={280}>

--- a/apps/passport-client/components/screens/VerifyScreen.tsx
+++ b/apps/passport-client/components/screens/VerifyScreen.tsx
@@ -80,7 +80,7 @@ export function VerifyScreen() {
   }["" + result?.valid];
 
   return (
-    <AppContainer bg={bg}>
+    <AppContainer overrideBackgroundColor={bg}>
       <BackgroundGlow y={96} {...{ from, to }}>
         <Spacer h={48} />
         <TextCenter>

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -79,7 +79,10 @@ class App extends React.Component<object, AppState> {
         {hasStack && (
           <HashRouter>
             <Routes>
-              <Route path="*" element={<AppContainer bg="gray" />} />
+              <Route
+                path="*"
+                element={<AppContainer overrideBackgroundColor="gray" />}
+              />
             </Routes>
           </HashRouter>
         )}
@@ -152,7 +155,9 @@ function RouterImpl() {
           <Route path="add" element={<AddScreen />} />
           <Route path="prove" element={<ProveScreen />} />
           <Route path="scan" element={<ScanScreen />} />
-          {appConfig.isZuzalu && <Route path="sync-existing" element={<SyncExistingScreen />} />}
+          {appConfig.isZuzalu && (
+            <Route path="sync-existing" element={<SyncExistingScreen />} />
+          )}
           <Route
             path="verify"
             element={

--- a/apps/passport-client/public/global-pcdpass.css
+++ b/apps/passport-client/public/global-pcdpass.css
@@ -18,13 +18,19 @@ html {
   --black: #000000;
   --black-rgb: 0, 0, 0;
 
-  background: var(--bg-dark-primary);
   color: var(--white);
   font:
     16px PlexSans,
     system-ui,
     sans-serif;
   line-height: 1.5;
+}
+
+html.bg-gray {
+  background-color: var(--bg-dark-gray);
+}
+html.bg-primary {
+  background-color: var(--bg-dark-primary);
 }
 
 a,

--- a/apps/passport-client/public/global-zupass.css
+++ b/apps/passport-client/public/global-zupass.css
@@ -18,13 +18,19 @@ html {
   --black: #000000;
   --black-rgb: 0, 0, 0;
 
-  background: var(--bg-dark-primary);
   color: var(--white);
   font:
     16px PlexSans,
     system-ui,
     sans-serif;
   line-height: 1.5;
+}
+
+html.bg-gray {
+  background-color: var(--bg-dark-gray);
+}
+html.bg-primary {
+  background-color: var(--bg-dark-primary);
 }
 
 a,

--- a/apps/passport-client/public/index.hbs
+++ b/apps/passport-client/public/index.hbs
@@ -6,9 +6,9 @@
     <link rel="stylesheet" href="{{cssPath}}" />
     <script>
       // set background color based on path upon initial paint
-      document.getElementsByTagName("html")[0].setAttribute( "class",
-      window.location.hash.match( /^#\/({{grayBgPaths}})(\?.+)?$/ ) ? "bg-gray"
-      : "bg-primary" );
+      document.getElementsByTagName("html")[0].setAttribute("class",
+      !window.location.hash || window.location.hash.match(/^#\/({{grayBgPaths}})(\?.+)?$/
+      ) ? "bg-gray" : "bg-primary");
     </script>
     <script defer src="/js/index.js"></script>
   </head>

--- a/apps/passport-client/public/index.hbs
+++ b/apps/passport-client/public/index.hbs
@@ -1,28 +1,31 @@
 <html>
-  <head>
-    <title>{{title}}</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, user-scalable=no" />
-    <link rel="stylesheet" href="{{cssPath}}" />
-    <script>
-      // set background color based on path upon initial paint
-      document.getElementsByTagName("html")[0].setAttribute("class",
+
+<head>
+  <title>{{title}}</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, user-scalable=no" />
+  <link rel="stylesheet" href="{{cssPath}}" />
+  <script>
+    // Set background color based on path upon initial paint
+    //
+    // We have two background colors, primary and gray, in our app depending on the route
+    // However, if we rely on the AppContainer component to set the background color,
+    // we will see a flash of the primary background color before the gray background color
+    // is set. This is because the AppContainer component is not rendered until after the
+    // initial paint. To avoid this, we use this eagerly evaludated JS blob to set the
+    // background color here based on the path before the initial paint.
+    document.getElementsByTagName("html")[0].setAttribute("class",
       !window.location.hash || window.location.hash.match(/^#\/({{grayBgPaths}})(\?.+)?$/
       ) ? "bg-gray" : "bg-primary");
-    </script>
-    <script defer src="/js/index.js"></script>
-  </head>
-  <body>
-    <div id="root" />
-    <script
-      async
-      defer
-      src="https://scripts.simpleanalyticscdn.com/latest.js"
-    ></script>
-    <noscript><img
-        src="https://queue.simpleanalyticscdn.com/noscript.gif"
-        alt=""
-        referrerpolicy="no-referrer-when-downgrade"
-      /></noscript>
-  </body>
+  </script>
+  <script defer src="/js/index.js"></script>
+</head>
+
+<body>
+  <div id="root" />
+  <script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
+  <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt=""
+      referrerpolicy="no-referrer-when-downgrade" /></noscript>
+</body>
+
 </html>

--- a/apps/passport-client/public/index.hbs
+++ b/apps/passport-client/public/index.hbs
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, user-scalable=no" />
     <link rel="stylesheet" href="{{cssPath}}" />
+    <script>
+      // set background color based on path upon initial paint
+      document.getElementsByTagName("html")[0].setAttribute( "class",
+      window.location.hash.match( /^#\/({{grayBgPaths}})(\?.+)?$/ ) ? "bg-gray"
+      : "bg-primary" );
+    </script>
     <script defer src="/js/index.js"></script>
   </head>
   <body>

--- a/apps/passport-client/src/appConfig.ts
+++ b/apps/passport-client/src/appConfig.ts
@@ -12,6 +12,8 @@ interface AppConfig {
   rollbarToken: string | undefined;
   // the environment to which the client uploads errors in rollbar
   rollbarEnvName: string | undefined;
+  // path without leading slash for routes that use gray background color
+  grayBackgroundRoutes: string[];
 }
 
 export const appConfig: AppConfig = {
@@ -20,7 +22,15 @@ export const appConfig: AppConfig = {
   maxIdentityProofAgeMs: 1000 * 60 * 60 * 4,
   isZuzalu: process.env.IS_ZUZALU === "true" ? true : false,
   rollbarToken: process.env.ROLLBAR_TOKEN,
-  rollbarEnvName: process.env.ROLLBAR_ENV_NAME
+  rollbarEnvName: process.env.ROLLBAR_ENV_NAME,
+  grayBackgroundRoutes: [
+    "", // home
+    "get-without-proving",
+    "halo",
+    "add",
+    "prove",
+    "scan"
+  ]
 };
 
 console.log("App Config: " + JSON.stringify(appConfig));


### PR DESCRIPTION
When loading PCDPass app, we always get the `--bg-dark-primary` bg color from the static css file first. However, many screens use `gray` bg colors and it creates a odd experience when loading a path directly. For example, opening the /prove link from Telegram, one would see a flickering background color.

If we simply remove the background color in the stylesheet, the background color ended up to be a flash of white on first paint because AppContainer is not yet loaded. Indeed, this is a common problem especially for websites with dark mode: https://stackoverflow.com/questions/37126401/modify-bodys-classes-before-first-paint

This PR introduces an eagerly executed js blob that pattern matches on location hash. This ensure the bg color is correctly set on first paint. It also refactor the AppContainer bg to switch on a centralized list of routes config. We still want to keep the AppContainer injection because the hand written js might not always give the correct result as the HashRouter.

Tested locally with both `yarn dev` and `yarn build` to ensure build can access the config file.

See the comparison between this branch and production build


https://github.com/proofcarryingdata/zupass/assets/4317392/6d952d0b-27a7-4b64-a53f-2029f19c187a

relates to https://github.com/proofcarryingdata/zupass/issues/597