### PR TITLE
Stop the correct sync service during testing

### DIFF
--- a/apps/passport-server/src/services.ts
+++ b/apps/passport-server/src/services.ts
@@ -86,5 +86,6 @@ export async function stopServices(services: GlobalServices): Promise<void> {
   services.metricsService.stop();
   services.telegramService?.stop();
   services.persistentCacheService.stop();
+  services.devconnectPretixSyncService?.stop();
   await services.discordService?.stop();
 }

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -215,7 +215,7 @@ describe("devconnect functionality", function () {
     expect(pretixSyncStatus).to.eq(PretixSyncStatus.Synced);
     // stop interval that polls the api so we have more granular control over
     // testing the sync functionality
-    application.services.pretixSyncService?.stop();
+    application.services.devconnectPretixSyncService?.stop();
   });
 
   step(
@@ -542,7 +542,9 @@ describe("devconnect functionality", function () {
     server.use(
       rest.get(orgUrl + `/events/:event/orders`, (req, res, ctx) => {
         const returnUnmodified = (req.params.event as string) !== eventID;
-        const originalOrders = org.ordersByEventID.get(eventID) as DevconnectPretixOrder[];
+        const originalOrders = org.ordersByEventID.get(
+          eventID
+        ) as DevconnectPretixOrder[];
         const orders: DevconnectPretixOrder[] = returnUnmodified
           ? originalOrders
           : originalOrders.map((order) => {
@@ -587,7 +589,8 @@ describe("devconnect functionality", function () {
     expect(tickets.length).to.eq(
       tickets.filter(
         (ticket: DevconnectPretixTicketWithCheckin) =>
-          ticket.is_consumed === true && ticket.checker === PRETIX_CHECKER &&
+          ticket.is_consumed === true &&
+          ticket.checker === PRETIX_CHECKER &&
           ticket.pretix_checkin_timestamp?.getTime() === checkInDate.getTime()
       ).length
     );


### PR DESCRIPTION
Playing around with [Knip](https://github.com/webpro/knip) to see if I could find any unused code, I noticed that it said that `DevconnectPretixSyncService.stop()` is unused. "That's weird", I thought, "because we definitely stop the service in `devconnect.spec.ts`". It turns out that we don't! We're actually stopping `pretixService`, not `devconnectPretixService`. This PR fixes that.