### PR TITLE
Fix infinite loading error on Zupass screens

### DIFF
--- a/apps/passport-client/src/appHooks.ts
+++ b/apps/passport-client/src/appHooks.ts
@@ -5,6 +5,7 @@ import { PCD } from "@pcd/pcd-types";
 import { Identity } from "@semaphore-protocol/identity";
 import { useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
+import { appConfig } from "./appConfig";
 import { Dispatcher, StateContext } from "./dispatch";
 import { AppError, AppState, PendingAction } from "./state";
 import { useSelector } from "./subscribe";
@@ -89,7 +90,7 @@ export function useIsSyncSettled(): boolean {
   const isDownloaded = useIsDownloaded();
   const loadedIssued = useLoadedIssuedPCDs();
 
-  return isDownloaded && loadedIssued;
+  return isDownloaded && (appConfig.isZuzalu || loadedIssued);
 }
 
 export function useIsLoggedIn(): boolean {


### PR DESCRIPTION
Since we don't load issued PCDs on Zupass, loadedIssuedPCDs never gets set to `true`. As such, the `useSyncSettled()` hook that is called on all the screens (/prove, /get-without-proving, etc) always returns false.

Extends on #557 

Before:
<img width="360" alt="Screenshot 2023-09-16 at 11 39 50 AM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/9b962318-53cc-4437-969b-3d04522ee4b5">

After:
<img width="343" alt="Screenshot 2023-09-16 at 11 42 39 AM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/39c32c67-a8bd-413c-b287-4aba7064186e">

