### PR TITLE
Add logging + potentially fix ethereum ownership PCD test

### DIFF
--- a/packages/ethereum-ownership-pcd/src/EthereumOwnershipPCD.ts
+++ b/packages/ethereum-ownership-pcd/src/EthereumOwnershipPCD.ts
@@ -176,7 +176,7 @@ export async function verify(pcd: EthereumOwnershipPCD): Promise<boolean> {
     // signed by the claimed ethereum address
     if (
       ethers.utils.getAddress(recoveredAddress) !==
-      ethers.utils.getAddress(pcd.claim.ethereumAddress)
+      ethers.utils.getAddress(pcd.claim.ethereumAddress.toLowerCase())
     ) {
       return false;
     }

--- a/packages/ethereum-ownership-pcd/test/EthereumOwnershipPCD.spec.ts
+++ b/packages/ethereum-ownership-pcd/test/EthereumOwnershipPCD.spec.ts
@@ -2,7 +2,7 @@
 import { ArgumentTypeName } from "@pcd/pcd-types";
 import {
   SemaphoreIdentityPCDPackage,
-  SemaphoreIdentityPCDTypeName,
+  SemaphoreIdentityPCDTypeName
 } from "@pcd/semaphore-identity-pcd";
 import { Identity } from "@semaphore-protocol/identity";
 import assert from "assert";
@@ -20,18 +20,17 @@ describe("Ethereum ownership PCD", function () {
   this.beforeAll(async function () {
     await EthereumOwnershipPCDPackage.init!({
       zkeyFilePath,
-      wasmFilePath,
+      wasmFilePath
     });
   });
 
   it("should work", async function () {
     const wallet = ethers.Wallet.createRandom();
     const identity = await SemaphoreIdentityPCDPackage.prove({
-      identity: new Identity(),
+      identity: new Identity()
     });
-    const serializedIdentity = await SemaphoreIdentityPCDPackage.serialize(
-      identity
-    );
+    const serializedIdentity =
+      await SemaphoreIdentityPCDPackage.serialize(identity);
     const signatureOfIdentityCommitment = await wallet.signMessage(
       identity.claim.identity.commitment.toString()
     );
@@ -39,30 +38,34 @@ describe("Ethereum ownership PCD", function () {
     const ethereumPCD = await EthereumOwnershipPCDPackage.prove({
       ethereumAddress: {
         argumentType: ArgumentTypeName.String,
-        value: wallet.address,
+        value: wallet.address
       },
       ethereumSignatureOfCommitment: {
         argumentType: ArgumentTypeName.String,
-        value: signatureOfIdentityCommitment,
+        value: signatureOfIdentityCommitment
       },
       identity: {
         argumentType: ArgumentTypeName.PCD,
         pcdType: SemaphoreIdentityPCDTypeName,
-        value: serializedIdentity,
-      },
+        value: serializedIdentity
+      }
     });
 
-    assert(await EthereumOwnershipPCDPackage.verify(ethereumPCD));
+    assert(
+      await EthereumOwnershipPCDPackage.verify(ethereumPCD),
+      `Verification failed for Ethereum ownership PCD: ${EthereumOwnershipPCDPackage.serialize(
+        ethereumPCD
+      )}`
+    );
   });
 
   it("should not be able create a PCD from an invalid signature", async function () {
     const wallet = ethers.Wallet.createRandom();
     const identity = await SemaphoreIdentityPCDPackage.prove({
-      identity: new Identity(),
+      identity: new Identity()
     });
-    const serializedIdentity = await SemaphoreIdentityPCDPackage.serialize(
-      identity
-    );
+    const serializedIdentity =
+      await SemaphoreIdentityPCDPackage.serialize(identity);
     const signatureOfIdentityCommitment = await wallet.signMessage(
       identity.claim.identity.commitment.toString()
     );
@@ -76,65 +79,64 @@ describe("Ethereum ownership PCD", function () {
       await EthereumOwnershipPCDPackage.prove({
         ethereumAddress: {
           argumentType: ArgumentTypeName.String,
-          value: wallet.address,
+          value: wallet.address
         },
         ethereumSignatureOfCommitment: {
           argumentType: ArgumentTypeName.String,
-          value: mangledSignature,
+          value: mangledSignature
         },
         identity: {
           argumentType: ArgumentTypeName.PCD,
           pcdType: SemaphoreIdentityPCDTypeName,
-          value: serializedIdentity,
-        },
+          value: serializedIdentity
+        }
       });
-    });
+    }, "Invalid signature of PCD should have failed:");
   });
 
   it("should not be able create a PCD where identity does not match identity pcd", async function () {
     const wallet = ethers.Wallet.createRandom();
     const identity = await SemaphoreIdentityPCDPackage.prove({
-      identity: new Identity(),
+      identity: new Identity()
     });
     const signatureOfIdentityCommitment = await wallet.signMessage(
       identity.claim.identity.commitment.toString()
     );
 
     const identity2 = await SemaphoreIdentityPCDPackage.prove({
-      identity: new Identity(),
+      identity: new Identity()
     });
-    const serializedIdentity2 = await SemaphoreIdentityPCDPackage.serialize(
-      identity2
-    );
+    const serializedIdentity2 =
+      await SemaphoreIdentityPCDPackage.serialize(identity2);
 
     await assert.rejects(
       async () =>
         await EthereumOwnershipPCDPackage.prove({
           ethereumAddress: {
             argumentType: ArgumentTypeName.String,
-            value: wallet.address,
+            value: wallet.address
           },
           ethereumSignatureOfCommitment: {
             argumentType: ArgumentTypeName.String,
-            value: signatureOfIdentityCommitment,
+            value: signatureOfIdentityCommitment
           },
           identity: {
             argumentType: ArgumentTypeName.PCD,
             pcdType: SemaphoreIdentityPCDTypeName,
-            value: serializedIdentity2,
-          },
-        })
+            value: serializedIdentity2
+          }
+        }),
+      "Identity does not match identity PCD - should have failed"
     );
   });
 
   it("should not be able verify a PCD whose Ethereum address was tampered with", async function () {
     const wallet = ethers.Wallet.createRandom();
     const identity = await SemaphoreIdentityPCDPackage.prove({
-      identity: new Identity(),
+      identity: new Identity()
     });
-    const serializedIdentity = await SemaphoreIdentityPCDPackage.serialize(
-      identity
-    );
+    const serializedIdentity =
+      await SemaphoreIdentityPCDPackage.serialize(identity);
     const signatureOfIdentityCommitment = await wallet.signMessage(
       identity.claim.identity.commitment.toString()
     );
@@ -142,17 +144,17 @@ describe("Ethereum ownership PCD", function () {
     const pcd = await EthereumOwnershipPCDPackage.prove({
       ethereumAddress: {
         argumentType: ArgumentTypeName.String,
-        value: wallet.address,
+        value: wallet.address
       },
       ethereumSignatureOfCommitment: {
         argumentType: ArgumentTypeName.String,
-        value: signatureOfIdentityCommitment,
+        value: signatureOfIdentityCommitment
       },
       identity: {
         argumentType: ArgumentTypeName.PCD,
         pcdType: SemaphoreIdentityPCDTypeName,
-        value: serializedIdentity,
-      },
+        value: serializedIdentity
+      }
     });
 
     const mangledAddress =
@@ -163,6 +165,11 @@ describe("Ethereum ownership PCD", function () {
 
     pcd.claim.ethereumAddress = mangledAddress;
 
-    assert(!(await EthereumOwnershipPCDPackage.verify(pcd)));
+    assert(
+      !(await EthereumOwnershipPCDPackage.verify(pcd)),
+      `Ethereum ownership PCD should have failed to verify but passed: ${EthereumOwnershipPCDPackage.serialize(
+        pcd
+      )}`
+    );
   });
 });


### PR DESCRIPTION
Potential fix to #403 

Adds messages to assert failures for better error visibility, and fixes an issue regarding Ethereum addresses. Essentially, [ethers.utils.getAddress](https://docs.ethers.org/v5/api/utils/address/#utils-getAddress) requires an Ethereum address that is either (1) fully lowercased or (2) mixed case and correctly checksummed. When passed a mixed cased address that is _not_ correctly checksummed, it will throw an error as displayed in the "Before" message below.


**Before:**

<img width="1191" alt="Screenshot 2023-09-18 at 2 24 54 AM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/a7f52981-146a-48b4-ba41-7bb1a57c0e24">

**After:**

<img width="719" alt="Screenshot 2023-09-18 at 2 27 14 AM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/6ef05f5f-728c-465a-acfa-a876d038006b">
