### PR TITLE
Aggregate logging of related errors

### DIFF
--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -58,7 +58,7 @@ import {
 import {
   OrganizerSync,
   PRETIX_CHECKER,
-  SyncErrorCause
+  SyncFailureError
 } from "../src/services/devconnect/organizerSync";
 import { DevconnectPretixSyncService } from "../src/services/devconnectPretixSyncService";
 import { PretixSyncStatus } from "../src/services/types";
@@ -542,7 +542,9 @@ describe("devconnect functionality", function () {
     server.use(
       rest.get(orgUrl + `/events/:event/orders`, (req, res, ctx) => {
         const returnUnmodified = (req.params.event as string) !== eventID;
-        const originalOrders = org.ordersByEventID.get(eventID) as DevconnectPretixOrder[];
+        const originalOrders = org.ordersByEventID.get(
+          eventID
+        ) as DevconnectPretixOrder[];
         const orders: DevconnectPretixOrder[] = returnUnmodified
           ? originalOrders
           : originalOrders.map((order) => {
@@ -572,7 +574,6 @@ describe("devconnect functionality", function () {
     const os = new OrganizerSync(
       organizer,
       new DevconnectPretixAPI({ requestsPerInterval: 300 }),
-      application.services.rollbarService,
       application.context.dbPool
     );
 
@@ -587,7 +588,8 @@ describe("devconnect functionality", function () {
     expect(tickets.length).to.eq(
       tickets.filter(
         (ticket: DevconnectPretixTicketWithCheckin) =>
-          ticket.is_consumed === true && ticket.checker === PRETIX_CHECKER &&
+          ticket.is_consumed === true &&
+          ticket.checker === PRETIX_CHECKER &&
           ticket.pretix_checkin_timestamp?.getTime() === checkInDate.getTime()
       ).length
     );
@@ -611,7 +613,6 @@ describe("devconnect functionality", function () {
     const os = new OrganizerSync(
       organizer,
       new DevconnectPretixAPI({ requestsPerInterval: 300 }),
-      application.services.rollbarService,
       application.context.dbPool
     );
 
@@ -695,7 +696,6 @@ describe("devconnect functionality", function () {
       const os = new OrganizerSync(
         organizer,
         new DevconnectPretixAPI({ requestsPerInterval: 300 }),
-        application.services.rollbarService,
         application.context.dbPool
       );
 
@@ -1381,7 +1381,6 @@ describe("devconnect functionality", function () {
     const os = new OrganizerSync(
       organizer,
       new DevconnectPretixAPI({ requestsPerInterval: 3 }),
-      application.services.rollbarService,
       application.context.dbPool
     );
 
@@ -1418,7 +1417,6 @@ describe("devconnect functionality", function () {
     const os = new OrganizerSync(
       organizer,
       new DevconnectPretixAPI({ requestsPerInterval: 300 }),
-      application.services.rollbarService,
       application.context.dbPool
     );
 
@@ -1469,22 +1467,19 @@ describe("devconnect functionality", function () {
       const os = new OrganizerSync(
         organizer,
         new DevconnectPretixAPI({ requestsPerInterval: 300 }),
-        application.services.rollbarService,
         application.context.dbPool
       );
 
-      let cause: SyncErrorCause | null = null;
-      let error = null;
+      let error: SyncFailureError | null = null;
 
       try {
         await os.run();
       } catch (e) {
-        error = e;
-        cause = (e as Error).cause as SyncErrorCause;
+        error = e as SyncFailureError;
       }
 
-      expect(error).to.be.an("Error");
-      expect(cause?.phase).to.eq("fetching");
+      expect(error instanceof SyncFailureError).to.be.true;
+      expect(error?.phase).to.eq("fetching");
     }
   );
 
@@ -1521,22 +1516,19 @@ describe("devconnect functionality", function () {
       const os = new OrganizerSync(
         organizer,
         new DevconnectPretixAPI({ requestsPerInterval: 300 }),
-        application.services.rollbarService,
         application.context.dbPool
       );
 
-      let error = null;
-      let cause: SyncErrorCause | null = null;
+      let error: SyncFailureError | null = null;
 
       try {
         await os.run();
       } catch (e) {
-        error = e;
-        cause = (e as Error).cause as SyncErrorCause;
+        error = e as SyncFailureError;
       }
 
-      expect(error).to.be.an("Error");
-      expect(cause?.phase).to.eq("validating");
+      expect(error instanceof SyncFailureError).to.be.true;
+      expect(error?.phase).to.eq("validating");
     }
   );
 
@@ -1573,22 +1565,19 @@ describe("devconnect functionality", function () {
       const os = new OrganizerSync(
         organizer,
         new DevconnectPretixAPI({ requestsPerInterval: 300 }),
-        application.services.rollbarService,
         application.context.dbPool
       );
 
-      let error = null;
-      let cause: SyncErrorCause | null = null;
+      let error: SyncFailureError | null = null;
 
       try {
         await os.run();
       } catch (e) {
-        error = e;
-        cause = (e as Error).cause as SyncErrorCause;
+        error = e as SyncFailureError;
       }
 
-      expect(error).to.be.an("Error");
-      expect(cause?.phase).to.eq("validating");
+      expect(error instanceof SyncFailureError).to.be.true;
+      expect(error?.phase).to.eq("validating");
     }
   );
 


### PR DESCRIPTION
Closes #555

This simplifies logging during sync. Previously, we were throwing exceptions, catching them, logging the exception, then returning a boolean `false` to a higher level function, which would then throw an exception, that would get logged, and so on.

Because these exceptions get logged separately, Rollbar doesn't know that they're connected. As a result, the higher-level log messages are pretty useless, saying that a failure occurred but with no context as to why.

This PR removes all of the lower-level logging to Rollbar. Instead, exceptions bubble up and get logged by a high-level handler - in this case, the `syncSingleOrganizer` method of `DevconnectPretixSyncService`. If intermediate functions need to add context, then they can catch and throw a new exception that gives the original as the `cause`.

In the `reportError` method of `RollbarService`, we take the causal chain of exceptions and pass them all to a single call to `Rollbar.error`, which means that Rollbar knows how to display them as a single error in the UI:

<img width="587" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/a092db90-080c-41b8-a97c-226de4427312">

The outcome here is that all sync errors will appear under a single heading "Devconnect Pretix Sync failed", and each individual occurrence might have a different stack trace containing the details of what caused the error.