### PR TITLE
PCDPass logged-out UI fixes

### DIFF
--- a/apps/passport-client/components/screens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/AlreadyRegisteredScreen.tsx
@@ -16,7 +16,7 @@ import {
   BigInput,
   Button,
   CenterColumn,
-  H2,
+  H1,
   HR,
   Spacer,
   TextCenter
@@ -140,7 +140,7 @@ export function AlreadyRegisteredScreen() {
         >
           <Spacer h={64} />
           <TextCenter>
-            <H2>LOGIN</H2>
+            <H1>PCDPASS</H1>
           </TextCenter>
           <Spacer h={32} />
           <TextCenter>

--- a/apps/passport-client/components/screens/EnterConfirmationCodeScreen.tsx
+++ b/apps/passport-client/components/screens/EnterConfirmationCodeScreen.tsx
@@ -5,7 +5,7 @@ import {
   BigInput,
   Button,
   CenterColumn,
-  H2,
+  H1,
   Spacer,
   TextCenter
 } from "../core";
@@ -60,7 +60,7 @@ export function EnterConfirmationCodeScreen() {
         >
           <Spacer h={64} />
           <TextCenter>
-            <H2>ENTER CONFIRMATION CODE</H2>
+            <H1>PCDPASS</H1>
           </TextCenter>
           <Spacer h={32} />
           <TextCenter>

--- a/apps/passport-client/components/screens/NewPassportScreen.tsx
+++ b/apps/passport-client/components/screens/NewPassportScreen.tsx
@@ -101,9 +101,7 @@ function SendEmailVerification({ email }: { email: string }) {
         <Spacer h={64} />
         <TextCenter>
           <Header />
-          <PHeavy>
-            {emailSent ? "Check your email for a six-digit code." : <>&nbsp;</>}
-          </PHeavy>
+          <PHeavy>{emailSent ? "Check your email." : <>&nbsp;</>}</PHeavy>
         </TextCenter>
         <Spacer h={24} />
         <form onSubmit={verify}>
@@ -151,7 +149,7 @@ function Header() {
     return (
       <>
         <H1>PCDPASS</H1>
-        <Spacer h={48} />
+        <Spacer h={24} />
       </>
     );
   } else {

--- a/apps/passport-client/components/screens/NewPassportScreen.tsx
+++ b/apps/passport-client/components/screens/NewPassportScreen.tsx
@@ -101,8 +101,9 @@ function SendEmailVerification({ email }: { email: string }) {
         <Spacer h={64} />
         <TextCenter>
           <Header />
-          <RippleLoader />
-          <PHeavy>{emailSent ? "Check your email." : <>&nbsp;</>}</PHeavy>
+          <PHeavy>
+            {emailSent ? "Check your email for a six-digit code." : <>&nbsp;</>}
+          </PHeavy>
         </TextCenter>
         <Spacer h={24} />
         <form onSubmit={verify}>


### PR DESCRIPTION
Fixes #564, fixes #591.

Removes unnecessary ripple spinner from <NewPassportScreen /> and ensures that all logged-out states in PCDPass have the `<H1>PCDPASS</H1>` header.

<img width="374" alt="Screenshot 2023-09-18 at 3 36 39 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/d6264c43-f616-4e62-abf7-5e3466a3d12b">
