### PR TITLE
fix PCDArgs infinite loop

### DIFF
--- a/apps/passport-client/components/shared/PCDArgs.tsx
+++ b/apps/passport-client/components/shared/PCDArgs.tsx
@@ -21,6 +21,8 @@ import {
 import React, { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
 
+type ArgSetter = (argName: string, value: any) => void;
+
 /**
  * Given an {@link Argument}, renders a UI that displays its value.
  * If the user must supply this value, allows the user to input it.
@@ -34,10 +36,23 @@ export function PCDArgs<T extends PCDPackage>({
   pcdCollection
 }: {
   args: ArgsOf<T>;
-  setArgs: (args: ArgsOf<T>) => void;
+  setArgs: React.Dispatch<React.SetStateAction<ArgsOf<T>>>;
   pcdCollection: PCDCollection;
 }) {
   const entries = Object.entries(args);
+
+  const setArg = React.useCallback(
+    (argName: string, value: any) => {
+      setArgs((args) => ({
+        ...args,
+        [argName]: {
+          ...args[argName],
+          value
+        }
+      }));
+    },
+    [setArgs]
+  );
 
   return (
     <ArgsContainer>
@@ -47,102 +62,60 @@ export function PCDArgs<T extends PCDPackage>({
           key={i}
           argName={key}
           arg={value as any}
-          args={args}
-          setArgs={setArgs}
+          setArg={setArg}
         />
       ))}
     </ArgsContainer>
   );
 }
 
-export function ArgInput<T extends PCDPackage>({
+export function ArgInput({
   arg,
   argName,
-  args,
-  setArgs,
+  setArg,
   pcdCollection
 }: {
   arg: Argument<any, any>;
   argName: string;
-  args: ArgsOf<T>;
-  setArgs: (args: ArgsOf<T>) => void;
+  setArg: ArgSetter;
   pcdCollection: PCDCollection;
 }) {
   if (isStringArgument(arg)) {
-    return (
-      <StringArgInput
-        args={args}
-        arg={arg}
-        argName={argName}
-        setArgs={setArgs}
-      />
-    );
+    return <StringArgInput arg={arg} argName={argName} setArg={setArg} />;
   } else if (isNumberArgument(arg)) {
-    return (
-      <NumberArgInput
-        args={args}
-        arg={arg}
-        argName={argName}
-        setArgs={setArgs}
-      />
-    );
+    return <NumberArgInput arg={arg} argName={argName} setArg={setArg} />;
   } else if (isBigIntArgument(arg)) {
-    return (
-      <BigIntArgInput
-        args={args}
-        arg={arg}
-        argName={argName}
-        setArgs={setArgs}
-      />
-    );
+    return <BigIntArgInput arg={arg} argName={argName} setArg={setArg} />;
   } else if (isBooleanArgument(arg)) {
-    return (
-      <BooleanArgInput
-        args={args}
-        arg={arg}
-        argName={argName}
-        setArgs={setArgs}
-      />
-    );
+    return <BooleanArgInput arg={arg} argName={argName} setArg={setArg} />;
   } else if (isObjectArgument(arg)) {
-    return (
-      <ObjectArgInput
-        args={args}
-        arg={arg}
-        argName={argName}
-        setArgs={setArgs}
-      />
-    );
+    return <ObjectArgInput arg={arg} argName={argName} setArg={setArg} />;
   } else if (isPCDArgument(arg)) {
     return (
       <PCDArgInput
-        args={args}
         arg={arg}
         argName={argName}
-        setArgs={setArgs}
+        setArg={setArg}
         pcdCollection={pcdCollection}
       />
     );
   }
 }
 
-export function StringArgInput<T extends PCDPackage>({
+export function StringArgInput({
   arg,
   argName,
-  args,
-  setArgs
+  setArg
 }: {
   arg: StringArgument;
   argName: string;
-  args: ArgsOf<T>;
-  setArgs: (args: ArgsOf<T>) => void;
+  setArg: ArgSetter;
 }) {
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      args[argName].value = e.target.value;
-      setArgs(JSON.parse(JSON.stringify(args)));
+      setArg(argName, e.target.value);
     },
-    [args, setArgs, argName]
+    [argName, setArg]
   );
 
   return (
@@ -169,16 +142,14 @@ export function StringArgInput<T extends PCDPackage>({
   );
 }
 
-export function NumberArgInput<T extends PCDPackage>({
+export function NumberArgInput({
   arg,
   argName,
-  args,
-  setArgs
+  setArg
 }: {
   arg: NumberArgument;
   argName: string;
-  args: ArgsOf<T>;
-  setArgs: (args: ArgsOf<T>) => void;
+  setArg: ArgSetter;
 }) {
   const [valid, setValid] = useState(true);
   const validator = useCallback((arg: string): boolean => {
@@ -194,14 +165,13 @@ export function NumberArgInput<T extends PCDPackage>({
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (validator(e.target.value)) {
-        args[argName].value = e.target.value;
-        setArgs(JSON.parse(JSON.stringify(args)));
+        setArg(argName, e.target.value);
         setValid(true);
       } else {
         setValid(false);
       }
     },
-    [args, setArgs, argName, validator]
+    [setArg, argName, validator]
   );
 
   return (
@@ -231,16 +201,14 @@ export function NumberArgInput<T extends PCDPackage>({
   );
 }
 
-export function BigIntArgInput<T extends PCDPackage>({
+export function BigIntArgInput({
   arg,
   argName,
-  args,
-  setArgs
+  setArg
 }: {
   arg: BigIntArgument;
   argName: string;
-  args: ArgsOf<T>;
-  setArgs: (args: ArgsOf<T>) => void;
+  setArg: ArgSetter;
 }) {
   const [valid, setValid] = useState(true);
   const validator = useCallback((arg: string): boolean => {
@@ -255,15 +223,13 @@ export function BigIntArgInput<T extends PCDPackage>({
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (validator(e.target.value)) {
-        args[argName].value = e.target.value;
-        setArgs(JSON.parse(JSON.stringify(args)));
-        console.log("changing argument");
+        setArg(argName, e.target.value);
         setValid(true);
       } else {
         setValid(false);
       }
     },
-    [args, setArgs, argName, validator]
+    [setArg, argName, validator]
   );
 
   return (
@@ -293,23 +259,20 @@ export function BigIntArgInput<T extends PCDPackage>({
   );
 }
 
-export function BooleanArgInput<T extends PCDPackage>({
+export function BooleanArgInput({
   arg,
   argName,
-  args,
-  setArgs
+  setArg
 }: {
   arg: BooleanArgument;
   argName: string;
-  args: ArgsOf<T>;
-  setArgs: (args: ArgsOf<T>) => void;
+  setArg: ArgSetter;
 }) {
   const onChange = useCallback(
-    (_e: React.ChangeEvent<HTMLInputElement>) => {
-      args[argName].value = !args[argName].value;
-      setArgs(JSON.parse(JSON.stringify(args)));
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setArg(argName, e.target.checked);
     },
-    [args, setArgs, argName]
+    [setArg, argName]
   );
 
   return (
@@ -337,16 +300,14 @@ export function BooleanArgInput<T extends PCDPackage>({
   );
 }
 
-export function ObjectArgInput<T extends PCDPackage>({
+export function ObjectArgInput({
   arg,
   argName,
-  args,
-  setArgs
+  setArg
 }: {
   arg: ObjectArgument<any>;
   argName: string;
-  args: ArgsOf<T>;
-  setArgs: (args: ArgsOf<T>) => void;
+  setArg: ArgSetter;
 }) {
   const [_loading, setLoading] = useState(arg.remoteUrl !== undefined);
   const [loaded, setLoaded] = useState(false);
@@ -366,8 +327,7 @@ export function ObjectArgInput<T extends PCDPackage>({
         .then((obj) => {
           setLoading(false);
           setLoaded(true);
-          args[argName].value = obj;
-          setArgs(JSON.parse(JSON.stringify(args)));
+          setArg(argName, obj);
         })
         .catch((_e) => {
           setLoading(false);
@@ -375,7 +335,7 @@ export function ObjectArgInput<T extends PCDPackage>({
           console.log(`failed to load ${arg.remoteUrl}`);
         });
     }
-  }, [arg.remoteUrl, argName, args, load, setArgs, loaded]);
+  }, [arg.remoteUrl, argName, load, setArg, loaded]);
 
   const onChange = useCallback((_e: React.ChangeEvent<HTMLTextAreaElement>) => {
     // TODO: parse JSON object, validate it
@@ -409,17 +369,15 @@ export function ObjectArgInput<T extends PCDPackage>({
   );
 }
 
-export function PCDArgInput<T extends PCDPackage>({
+export function PCDArgInput({
   arg,
   argName,
-  args,
-  setArgs,
+  setArg,
   pcdCollection
 }: {
   arg: PCDArgument;
   argName: string;
-  args: ArgsOf<T>;
-  setArgs: (args: ArgsOf<T>) => void;
+  setArg: ArgSetter;
   pcdCollection: PCDCollection;
 }) {
   const relevantPCDs = pcdCollection.getAll().filter((pcd) => {
@@ -433,16 +391,10 @@ export function PCDArgInput<T extends PCDPackage>({
   const setPCDById = useCallback(
     async (id: string) => {
       const pcd = pcdCollection.getById(id);
-      if (pcd) {
-        const serialized = await pcdCollection.serialize(pcd);
-        args[argName].value = serialized;
-        setArgs(JSON.parse(JSON.stringify(args)));
-      } else {
-        args[argName].value = undefined;
-        setArgs(JSON.parse(JSON.stringify(args)));
-      }
+      const value = pcd ? await pcdCollection.serialize(pcd) : undefined;
+      setArg(argName, value);
     },
-    [argName, args, pcdCollection, setArgs]
+    [argName, pcdCollection, setArg]
   );
 
   const onChange = useCallback(


### PR DESCRIPTION
This fixes an infinite loop when navigating to prove screen at client side, for example, when using browser back/forward button. To reproduce this error, navigate to https://pcdpass.xyz/ then enter a prove URL at the browser address bar e.g. `https://pcdpass.xyz/#/prove?request=...`. Now click back to navigate back to wallet, and click forward to navigate forward to prove screen. We will see infinite loop in console and the tab is frozen:

<img width="851" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/7f26b919-93b3-4554-949f-07bfb4ddd794">

The immediate cause is a circular reference between the logic to update proof input args with a default PCD if one is available and reflect updated args in the PCDArgInput. The update arg didn't follow React best practice where it 1/ modified previous `args` in place 2/ used JSON.parse(JSON.stringify(args))` which invalidated the args completely even though we are only updating the value of a specific argument.

This PR refactor the update logic to a `setArg` function which is always referentially stable, and takes in argument name and value as input. This simplifies the logic, make it less prone to infinite loop and improves the performance.

Tested locally and verified we can still generate proof.


