### PR TITLE
Zuzalu tickets in PCDPass

### DIFF
--- a/apps/passport-server/src/apis/pretixAPI.ts
+++ b/apps/passport-server/src/apis/pretixAPI.ts
@@ -5,23 +5,23 @@ import { instrumentedFetch } from "./fetch";
 
 const TRACE_SERVICE = "PretixAPI";
 
-export interface IPretixAPI {
-  config: PretixConfig;
-  fetchOrders(eventID: string): Promise<PretixOrder[]>;
-  fetchSubevents(eventID: string): Promise<PretixSubevent[]>;
+export interface IZuzaluPretixAPI {
+  config: ZuzaluPretixConfig;
+  fetchOrders(eventID: string): Promise<ZuzaluPretixOrder[]>;
+  fetchSubevents(eventID: string): Promise<ZuzaluPretixSubevent[]>;
 }
 
-export class PretixAPI implements IPretixAPI {
-  public config: PretixConfig;
+export class ZuzaluPretixAPI implements IZuzaluPretixAPI {
+  public config: ZuzaluPretixConfig;
 
-  public constructor(config: PretixConfig) {
+  public constructor(config: ZuzaluPretixConfig) {
     this.config = config;
   }
 
   // Fetch all orders for a given event.
-  public async fetchOrders(eventID: string): Promise<PretixOrder[]> {
+  public async fetchOrders(eventID: string): Promise<ZuzaluPretixOrder[]> {
     return traced(TRACE_SERVICE, "fetchOrders", async () => {
-      const orders: PretixOrder[] = [];
+      const orders: ZuzaluPretixOrder[] = [];
 
       // Fetch orders from paginated API
       let url = `${this.config.orgUrl}/events/${eventID}/orders/`;
@@ -45,9 +45,11 @@ export class PretixAPI implements IPretixAPI {
   }
 
   // Fetch all item types for a given event.
-  public async fetchSubevents(eventID: string): Promise<PretixSubevent[]> {
+  public async fetchSubevents(
+    eventID: string
+  ): Promise<ZuzaluPretixSubevent[]> {
     return traced(TRACE_SERVICE, "fetchSubevents", async () => {
-      const orders: PretixSubevent[] = [];
+      const orders: ZuzaluPretixSubevent[] = [];
 
       // Fetch orders from paginated API
       let url = `${this.config.orgUrl}/events/${eventID}/subevents/`;
@@ -71,9 +73,9 @@ export class PretixAPI implements IPretixAPI {
   }
 }
 
-export function getPretixConfig(): PretixConfig | null {
+export function getZuzaluPretixConfig(): ZuzaluPretixConfig | null {
   // Make sure we can use the Pretix API.
-  let pretixConfig: PretixConfig;
+  let pretixConfig: ZuzaluPretixConfig;
   try {
     pretixConfig = {
       token: requireEnv("PRETIX_TOKEN"),
@@ -96,29 +98,29 @@ export function getPretixConfig(): PretixConfig | null {
   }
 }
 
-export function getPretixAPI(): IPretixAPI | null {
-  const config = getPretixConfig();
+export function getZuzaluPretixAPI(): IZuzaluPretixAPI | null {
+  const config = getZuzaluPretixConfig();
 
   if (config === null) {
     return null;
   }
 
-  const api = new PretixAPI(config);
+  const api = new ZuzaluPretixAPI(config);
   return api;
 }
 
 // A Pretix order. For our purposes, each order contains one ticket.
-export interface PretixOrder {
+export interface ZuzaluPretixOrder {
   code: string; // "Q0BHN"
   status: string; // "p"
   testmode: boolean;
   secret: string;
   email: string;
-  positions: PretixPosition[]; // should have exactly one
+  positions: ZuzaluPretixPosition[]; // should have exactly one
 }
 
 // Unclear why this is called a "position" rather than a ticket.
-export interface PretixPosition {
+export interface ZuzaluPretixPosition {
   id: number;
   order: string; // "Q0BHN"
   positionid: number;
@@ -130,13 +132,13 @@ export interface PretixPosition {
   secret: string;
 }
 
-export interface PretixSubevent {
+export interface ZuzaluPretixSubevent {
   id: number;
   date_from?: string | null;
   date_to?: string | null;
 }
 
-export interface PretixConfig {
+export interface ZuzaluPretixConfig {
   token: string;
   orgUrl: string;
   zuEventID: string;

--- a/apps/passport-server/src/application.ts
+++ b/apps/passport-server/src/application.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import { getDevconnectPretixAPI } from "./apis/devconnect/devconnectPretixAPI";
 import { IEmailAPI, mailgunSendEmail } from "./apis/emailAPI";
 import { getHoneycombAPI } from "./apis/honeycombAPI";
-import { getPretixAPI, PretixAPI } from "./apis/pretixAPI";
+import { ZuzaluPretixAPI, getZuzaluPretixAPI } from "./apis/pretixAPI";
 import { getDB } from "./database/postgresPool";
 import { startServer } from "./routing/server";
 import { startServices, stopServices } from "./services";
@@ -87,15 +87,13 @@ async function getOverridenApis(
     }
   }
 
-  let pretixAPI: PretixAPI | null = null;
+  let zuzaluPretixAPI: ZuzaluPretixAPI | null = null;
 
-  if (context.isZuzalu) {
-    if (apiOverrides?.pretixAPI) {
-      logger("[INIT] overriding pretix api");
-      pretixAPI = apiOverrides.pretixAPI;
-    } else {
-      pretixAPI = getPretixAPI();
-    }
+  if (apiOverrides?.zuzaluPretixAPI) {
+    logger("[INIT] overriding pretix api");
+    zuzaluPretixAPI = apiOverrides.zuzaluPretixAPI;
+  } else {
+    zuzaluPretixAPI = getZuzaluPretixAPI();
   }
 
   let devconnectPretixAPIFactory: DevconnectPretixAPIFactory | null = null;
@@ -109,7 +107,7 @@ async function getOverridenApis(
 
   return {
     emailAPI,
-    pretixAPI,
+    zuzaluPretixAPI,
     devconnectPretixAPIFactory
   };
 }

--- a/apps/passport-server/src/routing/routes/statusRoutes.ts
+++ b/apps/passport-server/src/routing/routes/statusRoutes.ts
@@ -9,9 +9,9 @@ export function initStatusRoutes(
   { dbPool }: ApplicationContext,
   {
     semaphoreService,
-    pretixSyncService,
+    zuzaluPretixSyncService,
     rollbarService,
-    devconnectPretixSyncService,
+    devconnectPretixSyncService
   }: GlobalServices
 ): void {
   logger("[INIT] initializing status routes");
@@ -19,9 +19,9 @@ export function initStatusRoutes(
 
   app.get("/pretix/status", async (req: Request, res: Response) => {
     try {
-      if (pretixSyncService) {
+      if (zuzaluPretixSyncService) {
         res.send(
-          pretixSyncService.hasCompletedSyncSinceStarting
+          zuzaluPretixSyncService.hasCompletedSyncSinceStarting
             ? PretixSyncStatus.Synced
             : PretixSyncStatus.NotSynced
         );
@@ -59,13 +59,13 @@ export function initStatusRoutes(
       const db_pool = {
         total: dbPool.totalCount,
         idle: dbPool.idleCount,
-        waiting: dbPool.waitingCount,
+        waiting: dbPool.waitingCount
       };
       const semaphore = {
         n_participants:
           semaphoreService.groupParticipants().group.members.length,
         n_residents: semaphoreService.groupResidents().group.members.length,
-        n_visitors: semaphoreService.groupVisitors().group.members.length,
+        n_visitors: semaphoreService.groupVisitors().group.members.length
       };
       const time = new Date().toISOString();
 
@@ -86,14 +86,14 @@ export function initStatusRoutes(
       const db_pool = {
         total: dbPool.totalCount,
         idle: dbPool.idleCount,
-        waiting: dbPool.waitingCount,
+        waiting: dbPool.waitingCount
       };
 
       const semaphore = {
         n_participants:
           semaphoreService.groupParticipants().group.members.length,
         n_residents: semaphoreService.groupResidents().group.members.length,
-        n_visitors: semaphoreService.groupVisitors().group.members.length,
+        n_visitors: semaphoreService.groupVisitors().group.members.length
       };
       const time = new Date().toISOString();
 

--- a/apps/passport-server/src/services.ts
+++ b/apps/passport-server/src/services.ts
@@ -31,11 +31,11 @@ export async function startServices(
   );
   const emailTokenService = startEmailTokenService(context);
   const semaphoreService = startSemaphoreService(context);
-  const pretixSyncService = startPretixSyncService(
+  const zuzaluPretixSyncService = startPretixSyncService(
     context,
     rollbarService,
     semaphoreService,
-    apis.pretixAPI
+    apis.zuzaluPretixAPI
   );
   const devconnectPretixSyncService = await startDevconnectPretixSyncService(
     context,
@@ -68,7 +68,7 @@ export async function startServices(
     emailTokenService,
     rollbarService,
     provingService,
-    pretixSyncService,
+    zuzaluPretixSyncService,
     devconnectPretixSyncService,
     metricsService,
     issuanceService,
@@ -82,7 +82,7 @@ export async function startServices(
 export async function stopServices(services: GlobalServices): Promise<void> {
   services.provingService.stop();
   services.semaphoreService.stop();
-  services.pretixSyncService?.stop();
+  services.zuzaluPretixSyncService?.stop();
   services.metricsService.stop();
   services.telegramService?.stop();
   services.persistentCacheService.stop();

--- a/apps/passport-server/src/services/pretixSyncService.ts
+++ b/apps/passport-server/src/services/pretixSyncService.ts
@@ -1,6 +1,10 @@
 import { DateRange } from "@pcd/passport-interface";
 import { Pool } from "postgres-pool";
-import { IPretixAPI, PretixOrder, PretixSubevent } from "../apis/pretixAPI";
+import {
+  IZuzaluPretixAPI,
+  ZuzaluPretixOrder,
+  ZuzaluPretixSubevent
+} from "../apis/pretixAPI";
 import { ZuzaluPretixTicket, ZuzaluUserRole } from "../database/models";
 import { deleteZuzaluUser } from "../database/queries/zuzalu_pretix_tickets/deleteZuzaluUser";
 import { fetchAllZuzaluUsers } from "../database/queries/zuzalu_pretix_tickets/fetchZuzaluUser";
@@ -21,8 +25,8 @@ const SERVICE_NAME_FOR_TRACING = "Pretix";
 /**
  * Responsible for syncing users from Pretix into an internal representation.
  */
-export class PretixSyncService {
-  private pretixAPI: IPretixAPI;
+export class ZuzaluPretixSyncService {
+  private pretixAPI: IZuzaluPretixAPI;
   private rollbarService: RollbarService | null;
   private semaphoreService: SemaphoreService;
   private context: ApplicationContext;
@@ -35,7 +39,7 @@ export class PretixSyncService {
 
   public constructor(
     context: ApplicationContext,
-    pretixAPI: IPretixAPI,
+    pretixAPI: IZuzaluPretixAPI,
     rollbarService: RollbarService | null,
     semaphoreService: SemaphoreService
   ) {
@@ -46,7 +50,7 @@ export class PretixSyncService {
     this._hasCompletedSyncSinceStarting = false;
   }
 
-  public replaceApi(newAPI: IPretixAPI): void {
+  public replaceApi(newAPI: IZuzaluPretixAPI): void {
     const wasRunning = !!this.timeout;
 
     if (wasRunning) {
@@ -297,8 +301,8 @@ export class PretixSyncService {
    * subevent events they have in their order.
    */
   private ordersToZuzaluTickets(
-    orders: PretixOrder[],
-    visitorSubEvents: PretixSubevent[],
+    orders: ZuzaluPretixOrder[],
+    visitorSubEvents: ZuzaluPretixSubevent[],
     role: ZuzaluUserRole
   ): ZuzaluPretixTicket[] {
     const tickets: ZuzaluPretixTicket[] = orders
@@ -376,8 +380,8 @@ export function startPretixSyncService(
   context: ApplicationContext,
   rollbarService: RollbarService | null,
   semaphoreService: SemaphoreService,
-  pretixAPI: IPretixAPI | null
-): PretixSyncService | null {
+  pretixAPI: IZuzaluPretixAPI | null
+): ZuzaluPretixSyncService | null {
   if (!pretixAPI) {
     logger("[PRETIX] can't start sync service - no api instantiated");
     return null;
@@ -388,7 +392,7 @@ export function startPretixSyncService(
     return null;
   }
 
-  const pretixSyncService = new PretixSyncService(
+  const pretixSyncService = new ZuzaluPretixSyncService(
     context,
     pretixAPI,
     rollbarService,

--- a/apps/passport-server/src/services/semaphoreService.ts
+++ b/apps/passport-server/src/services/semaphoreService.ts
@@ -169,6 +169,7 @@ export class SemaphoreService {
       if (this.isZuzalu) {
         await this.reloadZuzaluGroups();
       } else {
+        await this.reloadZuzaluGroups();
         await this.reloadGenericGroup();
       }
 

--- a/apps/passport-server/src/types.ts
+++ b/apps/passport-server/src/types.ts
@@ -3,7 +3,7 @@ import * as http from "http";
 import Libhoney from "libhoney";
 import { Pool } from "postgres-pool";
 import { IEmailAPI } from "./apis/emailAPI";
-import { IPretixAPI } from "./apis/pretixAPI";
+import { IZuzaluPretixAPI } from "./apis/pretixAPI";
 import {
   DevconnectPretixAPIFactory,
   DevconnectPretixSyncService
@@ -14,7 +14,7 @@ import { EmailTokenService } from "./services/emailTokenService";
 import { IssuanceService } from "./services/issuanceService";
 import { MetricsService } from "./services/metricsService";
 import { PersistentCacheService } from "./services/persistentCacheService";
-import { PretixSyncService } from "./services/pretixSyncService";
+import { ZuzaluPretixSyncService } from "./services/pretixSyncService";
 import { ProvingService } from "./services/provingService";
 import { RollbarService } from "./services/rollbarService";
 import { SemaphoreService } from "./services/semaphoreService";
@@ -39,7 +39,7 @@ export interface GlobalServices {
   emailTokenService: EmailTokenService;
   rollbarService: RollbarService | null;
   provingService: ProvingService;
-  pretixSyncService: PretixSyncService | null;
+  zuzaluPretixSyncService: ZuzaluPretixSyncService | null;
   devconnectPretixSyncService: DevconnectPretixSyncService | null;
   metricsService: MetricsService;
   issuanceService: IssuanceService | null;
@@ -57,7 +57,7 @@ export interface PCDpass {
 
 export interface APIs {
   emailAPI: IEmailAPI | null;
-  pretixAPI: IPretixAPI | null;
+  zuzaluPretixAPI: IZuzaluPretixAPI | null;
   devconnectPretixAPIFactory: DevconnectPretixAPIFactory | null;
 }
 

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -978,7 +978,7 @@ describe("devconnect functionality", function () {
       const responseBody = response.body as FeedResponse;
 
       expect(responseBody.actions.length).to.eq(3);
-      const action = responseBody.actions[2] as AppendToFolderAction;
+      const action = responseBody.actions[2] as ReplaceInFolderAction;
 
       expect(action.type).to.eq(PCDActionType.ReplaceInFolder);
       expect(action.folder).to.eq("Devconnect/Event A");
@@ -990,11 +990,13 @@ describe("devconnect functionality", function () {
 
       expect(ticketPCD.type).to.eq(EdDSATicketPCDPackage.name);
 
-      const deserializedEmailPCD = await EdDSATicketPCDPackage.deserialize(
+      const deserializedTicketPCD = await EdDSATicketPCDPackage.deserialize(
         ticketPCD.pcd
       );
 
-      const verified = await EdDSATicketPCDPackage.verify(deserializedEmailPCD);
+      const verified = await EdDSATicketPCDPackage.verify(
+        deserializedTicketPCD
+      );
       expect(verified).to.eq(true);
     }
   );

--- a/apps/passport-server/test/pcdpass.spec.ts
+++ b/apps/passport-server/test/pcdpass.spec.ts
@@ -4,10 +4,8 @@ import "mocha";
 import { step } from "mocha-steps";
 import { IEmailAPI } from "../src/apis/emailAPI";
 import { stopApplication } from "../src/application";
-import { PretixSyncStatus } from "../src/services/types";
 import { PCDpass } from "../src/types";
 import { requestIssuanceServiceEnabled } from "./issuance/issuance";
-import { waitForPretixSyncStatus } from "./pretix/waitForPretixSyncStatus";
 import {
   expectCurrentSemaphoreToBe,
   testLatestHistoricSemaphoreGroups
@@ -38,11 +36,6 @@ describe("pcd-pass functionality", function () {
   step("should have issuance service running", async function () {
     const status = await requestIssuanceServiceEnabled(application);
     expect(status).to.eq(true);
-  });
-
-  step("should not have a pretix service running", async function () {
-    const status = await waitForPretixSyncStatus(application);
-    expect(status).to.eq(PretixSyncStatus.NoPretix);
   });
 
   step("email client should be mocked", async function () {

--- a/apps/passport-server/test/pretix/mockPretixApi.ts
+++ b/apps/passport-server/test/pretix/mockPretixApi.ts
@@ -1,17 +1,17 @@
 import {
-  getPretixConfig,
-  IPretixAPI,
-  PretixOrder,
-  PretixSubevent,
+  IZuzaluPretixAPI,
+  ZuzaluPretixOrder,
+  ZuzaluPretixSubevent,
+  getZuzaluPretixConfig
 } from "../../src/apis/pretixAPI";
 import { logger } from "../../src/util/logger";
 import {
   IMockPretixData,
-  ZuzaluPretixDataMocker,
+  ZuzaluPretixDataMocker
 } from "./zuzaluPretixDataMocker";
 
-export function newMockZuzaluPretixAPI(): IPretixAPI | null {
-  const config = getPretixConfig();
+export function newMockZuzaluPretixAPI(): IZuzaluPretixAPI | null {
+  const config = getZuzaluPretixConfig();
 
   if (!config) {
     return null;
@@ -29,12 +29,12 @@ export function getMockPretixAPI(
     throwOnFetchOrders?: boolean;
     throwOnFetchSubevents?: boolean;
   }
-): IPretixAPI {
+): IZuzaluPretixAPI {
   logger("[MOCK] instantiating mock zuzalu pretix api");
 
   return {
     config: mockData.config,
-    fetchOrders: async (eventID: string): Promise<PretixOrder[]> => {
+    fetchOrders: async (eventID: string): Promise<ZuzaluPretixOrder[]> => {
       const result = mockData.ordersByEventId.get(eventID) ?? [];
       if (options?.throwOnFetchOrders) {
         throw new Error(`[MOCK] throwing for 'fetchOrders'`);
@@ -45,7 +45,9 @@ export function getMockPretixAPI(
       );
       return result;
     },
-    fetchSubevents: async (parentId: string): Promise<PretixSubevent[]> => {
+    fetchSubevents: async (
+      parentId: string
+    ): Promise<ZuzaluPretixSubevent[]> => {
       const result = mockData.subEventsByParentEventId.get(parentId) ?? [];
       if (options?.throwOnFetchSubevents) {
         throw new Error(`[MOCK] throwing for 'fetchSubevents'`);
@@ -55,6 +57,6 @@ export function getMockPretixAPI(
         JSON.stringify(result, null, 2)
       );
       return result;
-    },
+    }
   };
 }

--- a/apps/passport-server/test/pretix/zuzaluPretixDataMocker.ts
+++ b/apps/passport-server/test/pretix/zuzaluPretixDataMocker.ts
@@ -1,27 +1,27 @@
 import _ from "lodash";
 import { v4 as uuid } from "uuid";
 import {
-  PretixConfig,
-  PretixOrder,
-  PretixPosition,
-  PretixSubevent
+  ZuzaluPretixConfig,
+  ZuzaluPretixOrder,
+  ZuzaluPretixPosition,
+  ZuzaluPretixSubevent
 } from "../../src/apis/pretixAPI";
 import { logger } from "../../src/util/logger";
 import { randomEmail } from "../util/util";
 
 export interface IMockPretixData {
-  config: PretixConfig;
-  visitorSubevent: PretixSubevent;
-  subEventsByParentEventId: Map<string, PretixSubevent[]>;
-  ordersByEventId: Map<string, PretixOrder[]>;
+  config: ZuzaluPretixConfig;
+  visitorSubevent: ZuzaluPretixSubevent;
+  subEventsByParentEventId: Map<string, ZuzaluPretixSubevent[]>;
+  ordersByEventId: Map<string, ZuzaluPretixOrder[]>;
 }
 
 export class ZuzaluPretixDataMocker {
   private autoincrementingId = 0;
-  private config: PretixConfig;
+  private config: ZuzaluPretixConfig;
   private mockData: IMockPretixData;
 
-  public constructor(pretixConfig: PretixConfig) {
+  public constructor(pretixConfig: ZuzaluPretixConfig) {
     this.config = pretixConfig;
     this.mockData = this.newMockData();
   }
@@ -31,13 +31,13 @@ export class ZuzaluPretixDataMocker {
     return this.mockData;
   }
 
-  public getResidentsAndOrganizers(): PretixOrder[] {
+  public getResidentsAndOrganizers(): ZuzaluPretixOrder[] {
     const zuzaluEventOrders =
       this.mockData.ordersByEventId.get(this.mockData.config.zuEventID) ?? [];
     return zuzaluEventOrders;
   }
 
-  public getResidentsOrOrganizers(organizers: boolean): PretixOrder[] {
+  public getResidentsOrOrganizers(organizers: boolean): ZuzaluPretixOrder[] {
     return this.getResidentsAndOrganizers().filter((o) =>
       organizers
         ? o.positions[0].item === this.config.zuEventOrganizersItemID
@@ -45,7 +45,7 @@ export class ZuzaluPretixDataMocker {
     );
   }
 
-  public getVistors(): PretixOrder[] {
+  public getVistors(): ZuzaluPretixOrder[] {
     const visitorEventOrders =
       this.mockData.ordersByEventId.get(
         this.mockData.config.zuVisitorEventID
@@ -55,7 +55,7 @@ export class ZuzaluPretixDataMocker {
 
   public updateResidentOrOrganizer(
     code: string,
-    update: (order: PretixOrder) => void
+    update: (order: ZuzaluPretixOrder) => void
   ): void {
     const zuzaluEventOrders =
       this.mockData.ordersByEventId.get(this.mockData.config.zuEventID) ?? [];
@@ -68,7 +68,7 @@ export class ZuzaluPretixDataMocker {
 
   public updateVisitor(
     code: string,
-    update: (order: PretixOrder) => void
+    update: (order: ZuzaluPretixOrder) => void
   ): void {
     const visitorEventOrders =
       this.mockData.ordersByEventId.get(
@@ -81,7 +81,7 @@ export class ZuzaluPretixDataMocker {
     update(order);
   }
 
-  public addVisitor(): PretixOrder {
+  public addVisitor(): ZuzaluPretixOrder {
     const newVisitor = this.newVisitor(this.mockData.visitorSubevent);
     const visitorSeriesOrders =
       this.mockData.ordersByEventId.get(
@@ -103,7 +103,7 @@ export class ZuzaluPretixDataMocker {
     );
   }
 
-  public addResidentOrOrganizer(isOrganizer: boolean): PretixOrder {
+  public addResidentOrOrganizer(isOrganizer: boolean): ZuzaluPretixOrder {
     const newResident = this.newResidentOrOrganizer(isOrganizer);
     const zuzaluEventOrders =
       this.mockData.ordersByEventId.get(this.mockData.config.zuEventID) ?? [];
@@ -122,19 +122,20 @@ export class ZuzaluPretixDataMocker {
   }
 
   private newMockData(): IMockPretixData {
-    const residentOrders: PretixOrder[] = [
+    const residentOrders: ZuzaluPretixOrder[] = [
       this.newResidentOrOrganizer(true),
       this.newResidentOrOrganizer(false)
     ];
     const visitorSubevent = this.newVisitorSubEvent();
     const visitorOrders = [this.newVisitor(visitorSubevent)];
 
-    const subEventsByParentEventId: Map<string, PretixSubevent[]> = new Map();
+    const subEventsByParentEventId: Map<string, ZuzaluPretixSubevent[]> =
+      new Map();
     subEventsByParentEventId.set(this.config.zuVisitorEventID, [
       visitorSubevent
     ]);
 
-    const ordersByEventId: Map<string, PretixOrder[]> = new Map();
+    const ordersByEventId: Map<string, ZuzaluPretixOrder[]> = new Map();
     ordersByEventId.set(this.config.zuEventID, residentOrders);
     ordersByEventId.set(this.config.zuVisitorEventID, visitorOrders);
 
@@ -146,7 +147,7 @@ export class ZuzaluPretixDataMocker {
     };
   }
 
-  private newVisitorSubEvent(): PretixSubevent {
+  private newVisitorSubEvent(): ZuzaluPretixSubevent {
     return {
       id: this.nextId(),
       date_from: new Date(Date.now()).toString(),
@@ -154,7 +155,7 @@ export class ZuzaluPretixDataMocker {
     };
   }
 
-  private newVisitor(subevent: PretixSubevent): PretixOrder {
+  private newVisitor(subevent: ZuzaluPretixSubevent): ZuzaluPretixOrder {
     const orderId = this.randomOrderCode();
     const email = randomEmail();
 
@@ -168,7 +169,7 @@ export class ZuzaluPretixDataMocker {
     };
   }
 
-  private newResidentOrOrganizer(isOrganizer: boolean): PretixOrder {
+  private newResidentOrOrganizer(isOrganizer: boolean): ZuzaluPretixOrder {
     const orderId = this.randomOrderCode();
     const email = randomEmail();
 
@@ -194,7 +195,7 @@ export class ZuzaluPretixDataMocker {
     email: string,
     itemId: number,
     subevent: number
-  ): PretixPosition {
+  ): ZuzaluPretixPosition {
     return {
       id: this.nextId(),
       order: orderId,

--- a/apps/passport-server/test/util/env.ts
+++ b/apps/passport-server/test/util/env.ts
@@ -30,10 +30,10 @@ export const zuzaluTestingEnv: EnvironmentVariables = Object.freeze({
 export const pcdpassTestingEnv: EnvironmentVariables = Object.freeze({
   ...zuzaluTestingEnv,
   IS_ZUZALU: "false",
-  PRETIX_ORG_URL: undefined,
-  PRETIX_TOKEN: undefined,
-  PRETIX_VISITOR_EVENT_ID: undefined,
-  PRETIX_ZU_EVENT_ID: undefined,
+  PRETIX_ORG_URL: "pretix_org_url",
+  PRETIX_TOKEN: "pretix_token",
+  PRETIX_VISITOR_EVENT_ID: "visitor_event_id",
+  PRETIX_ZU_EVENT_ID: "zu_event_id",
   SERVER_RSA_PRIVATE_KEY_BASE64: Buffer.from(
     new NodeRSA({ b: 2048 }).exportKey("private")
   ).toString("base64"),

--- a/apps/passport-server/test/util/mockApis.ts
+++ b/apps/passport-server/test/util/mockApis.ts
@@ -1,14 +1,14 @@
 import chai from "chai";
 import { getDevconnectPretixAPI } from "../../src/apis/devconnect/devconnectPretixAPI";
 import { IEmailAPI } from "../../src/apis/emailAPI";
-import { IPretixAPI } from "../../src/apis/pretixAPI";
+import { IZuzaluPretixAPI } from "../../src/apis/pretixAPI";
 import { DevconnectPretixAPIFactory } from "../../src/services/devconnectPretixSyncService";
 import { APIs } from "../../src/types";
 import { newMockZuzaluPretixAPI } from "../pretix/mockPretixApi";
 
 export function mockAPIs(apiOverrides?: Partial<APIs>): APIs {
   let emailAPI: IEmailAPI | null;
-  let pretixAPI: IPretixAPI | null;
+  let pretixAPI: IZuzaluPretixAPI | null;
   let devconnectPretixAPIFactory: DevconnectPretixAPIFactory | null;
 
   if (apiOverrides?.emailAPI) {
@@ -25,8 +25,8 @@ export function mockAPIs(apiOverrides?: Partial<APIs>): APIs {
     chai.spy.on(emailAPI, "send");
   }
 
-  if (apiOverrides?.pretixAPI) {
-    pretixAPI = apiOverrides.pretixAPI;
+  if (apiOverrides?.zuzaluPretixAPI) {
+    pretixAPI = apiOverrides.zuzaluPretixAPI;
   } else {
     pretixAPI = newMockZuzaluPretixAPI();
   }
@@ -39,7 +39,7 @@ export function mockAPIs(apiOverrides?: Partial<APIs>): APIs {
 
   return {
     emailAPI,
-    pretixAPI,
+    zuzaluPretixAPI: pretixAPI,
     devconnectPretixAPIFactory
   };
 }

--- a/apps/passport-server/test/zupass.spec.ts
+++ b/apps/passport-server/test/zupass.spec.ts
@@ -3,10 +3,10 @@ import { expect } from "chai";
 import "mocha";
 import { step } from "mocha-steps";
 import { IEmailAPI } from "../src/apis/emailAPI";
-import { getPretixConfig } from "../src/apis/pretixAPI";
+import { getZuzaluPretixConfig } from "../src/apis/pretixAPI";
 import { stopApplication } from "../src/application";
 import { LoggedInZuzaluUser, ZuzaluUserRole } from "../src/database/models";
-import { PretixSyncService } from "../src/services/pretixSyncService";
+import { ZuzaluPretixSyncService } from "../src/services/pretixSyncService";
 import { PretixSyncStatus } from "../src/services/types";
 import { PCDpass } from "../src/types";
 import { requestIssuanceServiceEnabled } from "./issuance/issuance";
@@ -36,12 +36,12 @@ describe("zupass functionality", function () {
   let updatedToOrganizerUser: LoggedInZuzaluUser;
   let emailAPI: IEmailAPI;
   let pretixMocker: ZuzaluPretixDataMocker;
-  let pretixService: PretixSyncService;
+  let pretixService: ZuzaluPretixSyncService;
 
   this.beforeAll(async () => {
     await overrideEnvironment(zuzaluTestingEnv);
 
-    const pretixConfig = getPretixConfig();
+    const pretixConfig = getZuzaluPretixConfig();
 
     if (!pretixConfig) {
       throw new Error(
@@ -51,13 +51,13 @@ describe("zupass functionality", function () {
 
     pretixMocker = new ZuzaluPretixDataMocker(pretixConfig);
     const pretixAPI = getMockPretixAPI(pretixMocker.getMockData());
-    application = await startTestingApp({ pretixAPI });
+    application = await startTestingApp({ zuzaluPretixAPI: pretixAPI });
 
-    if (!application.services.pretixSyncService) {
+    if (!application.services.zuzaluPretixSyncService) {
       throw new Error("expected there to be a pretix sync service");
     }
 
-    pretixService = application.services.pretixSyncService;
+    pretixService = application.services.zuzaluPretixSyncService;
   });
 
   this.afterAll(async () => {
@@ -76,7 +76,7 @@ describe("zupass functionality", function () {
     expect(pretixSyncStatus).to.eq(PretixSyncStatus.Synced);
     // stop interval that polls the api so we have more granular control over
     // testing the sync functionality
-    application.services.pretixSyncService?.stop();
+    application.services.zuzaluPretixSyncService?.stop();
   });
 
   step("should NOT have issuance service running", async function () {
@@ -400,7 +400,7 @@ describe("zupass functionality", function () {
       const newAPI = getMockPretixAPI(pretixMocker.getMockData(), {
         throwOnFetchOrders: true
       });
-      const pretixSyncService = application.services.pretixSyncService;
+      const pretixSyncService = application.services.zuzaluPretixSyncService;
 
       if (!pretixSyncService) {
         throw new Error("expected there to be a pretix sync service running");
@@ -442,7 +442,7 @@ describe("zupass functionality", function () {
       const newAPI = getMockPretixAPI(pretixMocker.getMockData(), {
         throwOnFetchSubevents: true
       });
-      const pretixSyncService = application.services.pretixSyncService;
+      const pretixSyncService = application.services.zuzaluPretixSyncService;
 
       if (!pretixSyncService) {
         throw new Error("expected there to be a pretix sync service running");
@@ -488,7 +488,7 @@ describe("zupass functionality", function () {
       if (!newAPI) {
         throw new Error("couldn't instantiate a new pretix api");
       }
-      application.services.pretixSyncService?.replaceApi(newAPI);
+      application.services.zuzaluPretixSyncService?.replaceApi(newAPI);
       const syncStatus = await waitForPretixSyncStatus(application);
       expect(syncStatus).to.eq(PretixSyncStatus.Synced);
 

--- a/apps/passport-server/test/zuzalu-pcdpass.spec.ts
+++ b/apps/passport-server/test/zuzalu-pcdpass.spec.ts
@@ -1,0 +1,120 @@
+import { EdDSATicketPCDPackage } from "@pcd/eddsa-ticket-pcd";
+import {
+  FeedResponse,
+  ISSUANCE_STRING,
+  PCDPassFeedIds
+} from "@pcd/passport-interface";
+import { PCDActionType, ReplaceInFolderAction } from "@pcd/pcd-collection";
+import { Identity } from "@semaphore-protocol/identity";
+import { expect } from "chai";
+import "mocha";
+import { step } from "mocha-steps";
+import {
+  ZuzaluPretixOrder,
+  getZuzaluPretixConfig
+} from "../src/apis/pretixAPI";
+import { stopApplication } from "../src/application";
+import { ZUZALU_ORGANIZER_EVENT_ID } from "../src/services/issuanceService";
+import { PretixSyncStatus } from "../src/services/types";
+import { PCDpass } from "../src/types";
+import { requestIssuedPCDs } from "./issuance/issuance";
+import { getMockPretixAPI } from "./pretix/mockPretixApi";
+import { waitForPretixSyncStatus } from "./pretix/waitForPretixSyncStatus";
+import { ZuzaluPretixDataMocker } from "./pretix/zuzaluPretixDataMocker";
+import { testLoginPCDpass } from "./user/testLoginPCDPass";
+import { overrideEnvironment, pcdpassTestingEnv } from "./util/env";
+import { startTestingApp } from "./util/startTestingApplication";
+
+describe("zuzalu pcdpass functionality", function () {
+  this.timeout(30_000);
+
+  let application: PCDpass;
+
+  let pretixMocker: ZuzaluPretixDataMocker;
+  let identity: Identity;
+  let order: ZuzaluPretixOrder;
+
+  this.beforeAll(async () => {
+    await overrideEnvironment(pcdpassTestingEnv);
+    const pretixConfig = getZuzaluPretixConfig();
+
+    if (!pretixConfig) {
+      throw new Error(
+        "expected to be able to get a pretix config for zuzalu tests"
+      );
+    }
+
+    pretixMocker = new ZuzaluPretixDataMocker(pretixConfig);
+    const pretixAPI = getMockPretixAPI(pretixMocker.getMockData());
+    application = await startTestingApp({ zuzaluPretixAPI: pretixAPI });
+
+    if (!application.services.zuzaluPretixSyncService) {
+      throw new Error("expected there to be a pretix sync service");
+    }
+  });
+
+  this.afterAll(async () => {
+    await stopApplication(application);
+  });
+
+  step("pretix should sync to completion", async function () {
+    const pretixSyncStatus = await waitForPretixSyncStatus(application);
+    expect(pretixSyncStatus).to.eq(PretixSyncStatus.Synced);
+    // stop interval that polls the api so we have more granular control over
+    // testing the sync functionality
+    application.services.zuzaluPretixSyncService?.stop();
+  });
+
+  step("should be able to log in", async function () {
+    order = pretixMocker.getResidentsAndOrganizers()[0];
+    const result = await testLoginPCDpass(application, order.email, {
+      expectEmailIncorrect: false,
+      expectUserAlreadyLoggedIn: false,
+      force: false
+    });
+
+    if (!result) {
+      throw new Error("failed to log in");
+    }
+
+    identity = result.identity;
+  });
+
+  step(
+    "user should be able to be issued Zuzalu ticket PCDs from the server",
+    async function () {
+      const response = await requestIssuedPCDs(
+        application,
+        identity,
+        ISSUANCE_STRING,
+        PCDPassFeedIds.Zuzalu_1
+      );
+      const responseBody = response.body as FeedResponse;
+
+      expect(responseBody.actions.length).to.eq(2);
+      const action = responseBody.actions[1] as ReplaceInFolderAction;
+
+      expect(action.type).to.eq(PCDActionType.ReplaceInFolder);
+      expect(action.folder).to.eq("Zuzalu");
+
+      expect(Array.isArray(action.pcds)).to.eq(true);
+      expect(action.pcds.length).to.eq(1);
+
+      const zuzaluTicketPCD = action.pcds[0];
+
+      expect(zuzaluTicketPCD.type).to.eq(EdDSATicketPCDPackage.name);
+
+      const deserializedZuzaluTicketPCD =
+        await EdDSATicketPCDPackage.deserialize(zuzaluTicketPCD.pcd);
+
+      expect(deserializedZuzaluTicketPCD.claim.ticket.eventId).to.eq(
+        ZUZALU_ORGANIZER_EVENT_ID
+      );
+
+      const verified = await EdDSATicketPCDPackage.verify(
+        deserializedZuzaluTicketPCD
+      );
+      expect(verified).to.eq(true);
+    }
+  );
+});

--- a/packages/passport-interface/src/SubscriptionManager.ts
+++ b/packages/passport-interface/src/SubscriptionManager.ts
@@ -12,7 +12,8 @@ import { IFeedApi } from "./FeedAPI";
 export const enum PCDPassFeedIds {
   Devconnect = "1",
   Frogs = "2",
-  Email = "3"
+  Email = "3",
+  Zuzalu_1 = "4"
 }
 
 export async function applyActions(


### PR DESCRIPTION
Closes #618

This PR adopts a similar approach to verified email. There is a new feed, which serves up Zuzalu ticket PCDs, based on the EdDSATicketPCD.

For this to work, we have to enable the Pretix service (distinct from Devconnect Pretix service) in PCDPass. Local environment variables (`PRETIX_*`) will need to be set with working values as per Zupass.

Out of scope for this PR is anything that allows the user to sign in to Zuzalu.City or perform Zuzalu-specific actions with their ticket - this just gives them a ticket in their wallet.

The feed has not been added as a "default subscription", so subscribing requires manually subscribing (in the same manner as the Frog feed).

All Zuzalu use cases have been tested in `consumer-client`.