### PR TITLE
New `-nc` option to not download artifacts if they exist

### DIFF
--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -10,7 +10,7 @@
     "lint": "tsc --noEmit && eslint \"**/*.ts{,x}\"",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",
     "clean": "rm -rf node_modules public/js public/artifacts public/index.html public/service-worker.js public/favicon.ico",
-    "artifacts:download": "pcd-artifacts download -o public"
+    "artifacts:download": "pcd-artifacts download -o public/artifacts"
   },
   "dependencies": {
     "@pcd/eddsa-pcd": "0.1.1",

--- a/apps/passport-server/package.json
+++ b/apps/passport-server/package.json
@@ -11,7 +11,7 @@
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",
     "scratch": "ts-node-dev -T scripts/scratch.ts",
     "clean": "rm -rf node_modules public/artifacts",
-    "artifacts:download": "pcd-artifacts download -o public"
+    "artifacts:download": "pcd-artifacts download -o public/artifacts"
   },
   "dependencies": {
     "@honeycombio/opentelemetry-node": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typecheck": "turbo run typecheck --parallel",
     "clean": "turbo run clean --parallel && yarn clean:root",
     "clean:root": "rm -rf node_modules",
-    "artifacts:download": "turbo run artifacts:download",
+    "artifacts:download": "turbo run artifacts:download -- -nc",
     "postinstall": "yarn artifacts:download"
   },
   "devDependencies": {

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -102,7 +102,7 @@ Generate zero-knowledge unsafe artifacts with a dummy trusted-setup (only for te
 
 Options:
   -p, --ptau-power <power>  Power of two of the maximum number of constraints that the ceremony can accept.
-  -o, --output <output>     Path to the directory where the output will be written [default: .].
+  -o, --output <output>     Path to the directory where the output will be written [default: artifacts].
   -h, --help                display help for command
 ```
 
@@ -136,6 +136,6 @@ Arguments:
   pcd-package            Supported PCD package.
 
 Options:
-  -o, --output <output>  Path to the directory where the output will be written [default: .].
+  -o, --output <output>  Path to the directory where the output will be written [default: artifacts].
   -h, --help             display help for command
 ```

--- a/packages/artifacts/src/commands/generate.js
+++ b/packages/artifacts/src/commands/generate.js
@@ -22,15 +22,9 @@ program
   )
   .option(
     "-o, --output <output>",
-    "Path to the directory where the output will be written [default: .]."
+    "Path to the directory where the output will be written [default: artifacts]."
   )
-  .action(async ({ ptauPower = 13, output: outputPath }) => {
-    if (!outputPath) {
-      outputPath = ".";
-    }
-
-    outputPath += "/artifacts";
-
+  .action(async ({ ptauPower = 13, output: outputPath = "artifacts" }) => {
     const ptauFilePath = `${tmpdir()}/${
       pkg.name
     }/powersOfTau28_hez_final_${ptauPower}.ptau`;
@@ -62,7 +56,7 @@ program
       if (existsSync(outputPath)) {
         if (
           await confirm(
-            `An '${outputPath}' directory already exists. Do you want to remove it?`
+            `The '${outputPath}' directory already exists. Do you want to remove it?`
           )
         ) {
           // Remove old artifacts.

--- a/packages/artifacts/src/commands/upload.js
+++ b/packages/artifacts/src/commands/upload.js
@@ -14,12 +14,8 @@ program
     "-a, --artifacts <artifacts-path>",
     "Path to the directory containing the artifacts [default: artifacts]."
   )
-  .action(async (packageName, { artifacts: artifactsPath }) => {
+  .action(async (packageName, { artifacts: artifactsPath = "artifacts" }) => {
     const client = await getS3ClientInstance();
-
-    if (!artifactsPath) {
-      artifactsPath = "artifacts";
-    }
 
     if (!packageName) {
       console.info(
@@ -39,7 +35,7 @@ program
       process.exit(1);
     }
 
-    if (!existsSync(`${artifactsPath}`)) {
+    if (!existsSync(artifactsPath)) {
       console.info(
         `${logSymbols.error}`,
         `Error: The '${artifactsPath}' folder does not exist`


### PR DESCRIPTION
Closes #652

It also sets `artifacts` as the default directory for the following commands: `download`, `generate`.