### PR TITLE
render revealed fields as chips

### DIFF
--- a/apps/consumer-client/src/pages/pcdpass-examples/zk-eddsa-event-ticket-proof.tsx
+++ b/apps/consumer-client/src/pages/pcdpass-examples/zk-eddsa-event-ticket-proof.tsx
@@ -336,7 +336,7 @@ export function openZKEdDSAEventTicketPopup(
       userProvided: false
     },
     fieldsToReveal: {
-      argumentType: ArgumentTypeName.Object,
+      argumentType: ArgumentTypeName.ToggleList,
       value: fieldsToReveal,
       userProvided: false
     },

--- a/apps/passport-client/components/core/Chip.tsx
+++ b/apps/passport-client/components/core/Chip.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+
+import styled from "styled-components";
+
+/**
+ * Chips are small, compact elements that represent an attribute, text, or action.
+ *
+ * See https://m3.material.io/components/chips/overview
+ */
+export function Chip({
+  icon,
+  label,
+  onClick,
+  disabled,
+  checked
+}: {
+  // optional leading icon left of the label
+  icon?: React.ReactNode;
+  // label text to display in the chip
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  checked?: boolean;
+}) {
+  return (
+    <Container onClick={onClick} disabled={disabled} checked={checked}>
+      {icon}
+      <Label>{label}</Label>
+    </Container>
+  );
+}
+
+const Container = styled.div<{
+  onClick?: () => void;
+  disabled?: boolean;
+  checked?: boolean;
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: 24px;
+  border-radius: 6px;
+  padding: 2px 6px;
+  border: 1px solid
+    ${(p) =>
+      p.checked
+        ? "rgba(var(--white-rgb), 0.3)"
+        : "rgba(var(--white-rgb), 0.1)"};
+  background: ${(p) =>
+    p.checked ? "rgba(var(--white-rgb), 0.05)" : "transparent"};
+  color: ${(p) => (p.checked ? "var(--white)" : "rgba(var(--white-rgb), 0.5)")};
+  cursor: ${(p) => !p.disabled && p.onClick && "pointer"};
+  pointer-events: ${(p) => (p.disabled ? "none" : "auto")};
+`;
+
+const Label = styled.div`
+  font-size: 14px;
+`;
+
+export const ChipsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 8px;
+`;

--- a/apps/passport-client/components/shared/PCDArgs.tsx
+++ b/apps/passport-client/components/shared/PCDArgs.tsx
@@ -16,16 +16,21 @@ import {
   isNumberArgument,
   isObjectArgument,
   isPCDArgument,
+  isRevealListArgument,
   isStringArgument,
+  isToggleListArgument,
   NumberArgument,
   ObjectArgument,
   PCD,
   PCDArgument,
   PCDPackage,
-  StringArgument
+  StringArgument,
+  ToggleList,
+  ToogleListArgument
 } from "@pcd/pcd-types";
 
 import { Caption } from "../core";
+import { Chip, ChipsContainer } from "../core/Chip";
 import { icons } from "../icons";
 
 type ArgSetter = (argName: string, value: any) => void;
@@ -95,6 +100,15 @@ export function ArgInput({
     return <BigIntArgInput arg={arg} argName={argName} setArg={setArg} />;
   } else if (isBooleanArgument(arg)) {
     return <BooleanArgInput arg={arg} argName={argName} setArg={setArg} />;
+  } else if (isToggleListArgument(arg)) {
+    return (
+      <ToggleListArgInput
+        arg={arg}
+        argName={argName}
+        setArg={setArg}
+        type={isRevealListArgument(arg) ? "reveal" : "default"}
+      />
+    );
   } else if (isObjectArgument(arg)) {
     return <ObjectArgInput arg={arg} argName={argName} setArg={setArg} />;
   } else if (isPCDArgument(arg)) {
@@ -313,6 +327,68 @@ export function ObjectArgInput({
   );
 }
 
+function ToggleListArgInput({
+  arg,
+  argName,
+  setArg,
+  type
+}: {
+  arg: ToogleListArgument<ToggleList>;
+  argName: string;
+  setArg: ArgSetter;
+  type: "default" | "reveal";
+}) {
+  const getLabel = useCallback(
+    (key: string) => {
+      switch (type) {
+        case "reveal":
+          return key.replace(/^reveal/, "");
+        default:
+          return key;
+      }
+    },
+    [type]
+  );
+  const getIcon = useCallback(
+    (value: boolean) => {
+      switch (type) {
+        case "reveal":
+          return (
+            <img
+              draggable="false"
+              src={value ? icons.eyeOpen : icons.eyeClosed}
+              width={18}
+              height={18}
+            />
+          );
+        default:
+          return undefined;
+      }
+    },
+    [type]
+  );
+
+  return (
+    <ArgContainer argName={argName} arg={arg}>
+      <ChipsContainer>
+        {Object.entries(arg.value).map(([key, value]) => (
+          <Chip
+            key={key}
+            label={getLabel(key)}
+            onClick={
+              arg.userProvided
+                ? () => setArg(argName, { ...arg.value, [key]: !value })
+                : undefined
+            }
+            checked={value}
+            icon={getIcon(value)}
+          />
+        ))}
+      </ChipsContainer>
+    </ArgContainer>
+  );
+}
+
 export function PCDArgInput({
   arg,
   argName,
@@ -444,6 +520,7 @@ const argTypeIcons: Record<ArgumentTypeName, string> = {
   Boolean: icons.checkmark,
   StringArray: icons.inputObject,
   Object: icons.inputObject,
+  ToggleList: icons.inputObject,
   PCD: icons.inputPcd,
   Unknown: icons.question
 };

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -156,7 +156,7 @@ export class TelegramService {
               userProvided: true
             },
             fieldsToReveal: {
-              argumentType: ArgumentTypeName.Object,
+              argumentType: ArgumentTypeName.ToggleList,
               value: fieldsToReveal,
               userProvided: false
             },

--- a/packages/pcd-types/src/pcd.ts
+++ b/packages/pcd-types/src/pcd.ts
@@ -208,6 +208,7 @@ export enum ArgumentTypeName {
   Object = "Object",
   StringArray = "StringArray",
   PCD = "PCD",
+  ToggleList = "ToggleList",
   Unknown = "Unknown"
 }
 
@@ -264,4 +265,35 @@ export type PCDArgument<T extends PCD = PCD> = Argument<
 };
 export function isPCDArgument(arg: Argument<any, unknown>): arg is PCDArgument {
   return arg.argumentType === ArgumentTypeName.PCD;
+}
+
+export type ToggleList = Record<string, boolean>;
+export type ToogleListArgument<T extends ToggleList> = Argument<
+  ArgumentTypeName.ToggleList,
+  T
+>;
+export function isToggleListArgument(
+  arg: Argument<any, unknown>
+): arg is ToogleListArgument<ToggleList> {
+  return (
+    arg.argumentType === ArgumentTypeName.ToggleList &&
+    arg.value !== undefined &&
+    arg.value !== null &&
+    typeof arg.value === "object" &&
+    Object.values(arg.value).every((v) => typeof v === "boolean")
+  );
+}
+
+export type RevealList = Record<`reveal${string}`, boolean>;
+export type RevealListArgument<T extends RevealList> = Argument<
+  ArgumentTypeName.ToggleList,
+  T
+>;
+export function isRevealListArgument(
+  arg: ToogleListArgument<ToggleList>
+): arg is RevealListArgument<RevealList> {
+  return (
+    arg.value !== undefined &&
+    Object.keys(arg.value).every((k) => k.startsWith("reveal"))
+  );
 }

--- a/packages/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCD.ts
+++ b/packages/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCD.ts
@@ -1,3 +1,8 @@
+import { BabyJub, buildBabyjub, buildEddsa, Eddsa } from "circomlibjs";
+import JSONBig from "json-bigint";
+import { groth16, Groth16Proof } from "snarkjs";
+import { v4 as uuid } from "uuid";
+
 import type { EDdSAPublicKey } from "@pcd/eddsa-pcd";
 import {
   EdDSATicketPCD,
@@ -8,10 +13,10 @@ import {
 import {
   BigIntArgument,
   DisplayOptions,
-  ObjectArgument,
   PCD,
   PCDArgument,
   PCDPackage,
+  RevealListArgument,
   SerializedPCD,
   StringArrayArgument
 } from "@pcd/pcd-types";
@@ -30,12 +35,7 @@ import {
   numberToBigInt,
   uuidToBigInt
 } from "@pcd/util";
-import { BabyJub, Eddsa, buildBabyjub, buildEddsa } from "circomlibjs";
-import JSONBig from "json-bigint";
-import { Groth16Proof, groth16 } from "snarkjs";
-import { v4 as uuid } from "uuid";
 import vkey from "../artifacts/circuit.json";
-
 import { ZKEdDSAEventTicketCardBody } from "./CardBody";
 
 export const STATIC_TICKET_PCD_NULLIFIER = generateSnarkMessageHash(
@@ -52,7 +52,7 @@ let savedInitArgs: ZKEdDSAEventTicketPCDInitArgs | undefined = undefined;
 /**
  * Specifies which fields of an EdDSATicket should be revealed in a proof.
  */
-export interface EdDSATicketFieldsToReveal {
+export type EdDSATicketFieldsToReveal = {
   revealTicketId?: boolean;
   revealEventId?: boolean;
   revealProductId?: boolean;
@@ -62,7 +62,7 @@ export interface EdDSATicketFieldsToReveal {
   revealIsConsumed?: boolean;
   revealIsRevoked?: boolean;
   revealTicketCategory?: boolean;
-}
+};
 
 /**
  * Info required to initialize this PCD package.  These are the artifacts
@@ -92,7 +92,7 @@ export interface ZKEdDSAEventTicketPCDArgs {
   validEventIds: StringArrayArgument;
 
   // `fieldsToReveal`, `externalNullifier`, `watermark` are usually app-specified
-  fieldsToReveal: ObjectArgument<EdDSATicketFieldsToReveal>;
+  fieldsToReveal: RevealListArgument<EdDSATicketFieldsToReveal>;
   watermark: BigIntArgument;
 
   // provide externalNullifier field to request a nullifierHash

--- a/packages/zk-eddsa-event-ticket-pcd/test/ZKEdDSAEventTicketPCD.spec.ts
+++ b/packages/zk-eddsa-event-ticket-pcd/test/ZKEdDSAEventTicketPCD.spec.ts
@@ -1,3 +1,8 @@
+import assert from "assert";
+import { expect } from "chai";
+import * as path from "path";
+import { v4 as uuid } from "uuid";
+
 import {
   EdDSATicketPCDPackage,
   ITicketData,
@@ -11,21 +16,19 @@ import {
 } from "@pcd/semaphore-identity-pcd";
 import { BABY_JUB_NEGATIVE_ONE, uuidToBigInt } from "@pcd/util";
 import { Identity } from "@semaphore-protocol/identity";
-import assert from "assert";
-import { expect } from "chai";
-import "mocha";
-import * as path from "path";
-import { v4 as uuid } from "uuid";
+
 import {
   EdDSATicketFieldsToReveal,
+  snarkInputForValidEventIds,
   VALID_EVENT_IDS_MAX_LEN,
   ZKEdDSAEventTicketPCD,
   ZKEdDSAEventTicketPCDArgs,
   ZKEdDSAEventTicketPCDClaim,
   ZKEdDSAEventTicketPCDPackage,
-  ZKEdDSAEventTicketPCDTypeName,
-  snarkInputForValidEventIds
+  ZKEdDSAEventTicketPCDTypeName
 } from "../src";
+
+import "mocha";
 
 const zkeyFilePath = path.join(__dirname, `../artifacts/circuit.zkey`);
 const wasmFilePath = path.join(__dirname, `../artifacts/circuit.wasm`);
@@ -219,7 +222,7 @@ describe("ZKEdDSAEventTicketPCD should work", function () {
       },
       fieldsToReveal: {
         value: fieldsToReveal,
-        argumentType: ArgumentTypeName.Object
+        argumentType: ArgumentTypeName.ToggleList
       },
       validEventIds: {
         value: validEventIds,


### PR DESCRIPTION
#597 

Introduce a new RevealMapArgument sub type under ObjectArgument, which renders with Chip component. 

Before

<img width="482" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/4a0c3fb6-90c4-4f71-9bcf-4fe25ab92d0f">


After

<img width="482" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/e1dfe5a8-495f-4c67-a1c7-cfa7a85e61d6">


~p.s. I will make a separate PR to refactor argument description into a clickable tooltip where we can tell users more about how to interpret these inputs. We are inline description today but it is too verbose to be fit cleanly into the UI.~

I also plan to add a toggle of some sort so user can inspect the underlying raw input (e.g. the object JSON in this case.) But suffice to say, everyday user would immediately understand with this improved UI where they likely gloss over the raw json completely in the original UI.