### PR TITLE
Update "Build and Test" to run for pushes _only_ on main and pull requests to main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,12 @@
 name: Build and Test
 run-name: Build and Test
-on: [push]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 jobs:
   Build-and-Test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will ensure that we aren't running the workflow for every push to a non-main branch, and that the workflow runs for all pull requests, both from branches in the repository and branches in forks.