### PR TITLE
Fix customer client app environments

### DIFF
--- a/apps/consumer-client/build.ts
+++ b/apps/consumer-client/build.ts
@@ -7,7 +7,7 @@ const consumerClientAppOpts: BuildOptions = {
   sourcemap: true,
   bundle: true,
   define: {
-    "process.env.NODE_ENV": `'${process.env.NODE_ENV ?? "production"}'`
+    "process.env.NODE_ENV": `'${process.env.NODE_ENV}'`
   },
   entryPoints: ["src/main.tsx"],
   plugins: [

--- a/apps/consumer-client/package.json
+++ b/apps/consumer-client/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "ts-node build.ts dev",
-    "build": "tsc --noEmit && ts-node build.ts build",
+    "build": "NODE_ENV=production tsc --noEmit && ts-node build.ts build",
     "build:staging": "NODE_ENV=staging yarn build",
     "lint": "tsc --noEmit && eslint \"**/*.ts{,x}\"",
     "clean": "rm -rf node_modules public/js"

--- a/apps/consumer-client/package.json
+++ b/apps/consumer-client/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "dev": "ts-node build.ts dev",
-    "build": "NODE_ENV=production tsc --noEmit && ts-node build.ts build",
+    "build": "tsc --noEmit && ts-node build.ts build",
+    "build:production": "NODE_ENV=production yarn build",
     "build:staging": "NODE_ENV=staging yarn build",
     "lint": "tsc --noEmit && eslint \"**/*.ts{,x}\"",
     "clean": "rm -rf node_modules public/js"


### PR DESCRIPTION
This PR sets the production environment explicitly and leaves the dev one by default, so that `yarn dev` build the project with the right URLs.

\*`yarn dev` was previously using the production environment.