### PR TITLE
Password visual updates

### DIFF
--- a/apps/passport-client/components/screens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/AlreadyRegisteredScreen.tsx
@@ -28,6 +28,7 @@ import {
 import { RippleLoader } from "../core/RippleLoader";
 import { MaybeModal } from "../modals/Modal";
 import { AppContainer } from "../shared/AppContainer";
+import { PasswordInput } from "../shared/NewPasswordForm";
 
 export function AlreadyRegisteredScreen() {
   const dispatch = useDispatch();
@@ -38,6 +39,7 @@ export function AlreadyRegisteredScreen() {
   const identityCommitment = query?.get("identityCommitment");
   const [isLoading, setLoading] = useState(false);
   const [password, setPassword] = useState("");
+  const [revealPassword, setRevealPassword] = useState(false);
 
   const handleConfirmationEmailResult = useCallback(
     async (result: ConfirmEmailResult) => {
@@ -194,12 +196,13 @@ export function AlreadyRegisteredScreen() {
                 )}
                 {salt && (
                   <form onSubmit={onSubmitPassword}>
-                    <BigInput
-                      placeholder="Password"
+                    <PasswordInput
                       autoFocus
                       value={password}
-                      type="password"
-                      onChange={(e) => setPassword(e.target.value)}
+                      setValue={setPassword}
+                      placeholder="Password"
+                      revealPassword={revealPassword}
+                      setRevealPassword={setRevealPassword}
                     />
                     <Spacer h={8} />
                     <Button type="submit">Login</Button>

--- a/apps/passport-client/components/screens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/AlreadyRegisteredScreen.tsx
@@ -28,7 +28,7 @@ import {
 import { RippleLoader } from "../core/RippleLoader";
 import { MaybeModal } from "../modals/Modal";
 import { AppContainer } from "../shared/AppContainer";
-import { PasswordInput } from "../shared/NewPasswordForm";
+import { PasswordInput } from "../shared/PasswordInput";
 
 export function AlreadyRegisteredScreen() {
   const dispatch = useDispatch();

--- a/apps/passport-client/components/screens/ChangePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/ChangePasswordScreen.tsx
@@ -10,7 +10,8 @@ import { CenterColumn, H2, Spacer, TextCenter } from "../core";
 import { LinkButton } from "../core/Button";
 import { MaybeModal } from "../modals/Modal";
 import { AppContainer } from "../shared/AppContainer";
-import { NewPasswordForm, PasswordInput } from "../shared/NewPasswordForm";
+import { NewPasswordForm } from "../shared/NewPasswordForm";
+import { PasswordInput } from "../shared/PasswordInput";
 
 export function ChangePasswordScreen() {
   const self = useSelf();

--- a/apps/passport-client/components/screens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/CreatePasswordScreen.tsx
@@ -76,6 +76,7 @@ export function CreatePasswordScreen() {
 
         <CenterColumn w={280}>
           <NewPasswordForm
+            autoFocus
             email={email}
             password={password}
             confirmPassword={confirmPassword}

--- a/apps/passport-client/components/shared/NewPasswordForm.tsx
+++ b/apps/passport-client/components/shared/NewPasswordForm.tsx
@@ -1,75 +1,11 @@
 import { Dispatch, FormEvent, SetStateAction, useState } from "react";
-import styled from "styled-components";
 import {
   PASSWORD_MINIMUM_LENGTH,
   checkPasswordStrength
 } from "../../src/password";
-import { BigInput, Button, Spacer } from "../core";
+import { Button, Spacer } from "../core";
 import { ErrorMessage } from "../core/error";
-import { icons } from "../icons";
-
-interface SetPasswordInputProps {
-  value: string;
-  setValue: Dispatch<SetStateAction<string>>;
-  revealPassword: boolean;
-  setRevealPassword: Dispatch<SetStateAction<boolean>>;
-  placeholder: string;
-  autoFocus?: boolean;
-}
-
-export function PasswordInput({
-  value,
-  setValue,
-  revealPassword,
-  autoFocus,
-  setRevealPassword,
-  placeholder
-}: SetPasswordInputProps) {
-  return (
-    <Container>
-      <PasswordBigInput
-        autoFocus={autoFocus}
-        type={revealPassword ? "text" : "password"}
-        placeholder={placeholder}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
-      <ShowHidePasswordIconContainer>
-        <ShowHidePasswordIcon
-          draggable="false"
-          src={revealPassword ? icons.eyeClosed : icons.eyeOpen}
-          width={32}
-          height={32}
-          onClick={() => setRevealPassword((curr) => !curr)}
-        />
-      </ShowHidePasswordIconContainer>
-    </Container>
-  );
-}
-
-const PasswordBigInput = styled(BigInput)`
-  /* To account for show/hide password icon. We add it to both sides to preserve center text alignment. */
-  padding-right: 48px;
-  padding-left: 48px;
-`;
-
-const Container = styled.div`
-  width: 100%;
-  position: relative;
-`;
-
-const ShowHidePasswordIconContainer = styled.div`
-  position: absolute;
-  right: 12px;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  top: 0;
-`;
-
-const ShowHidePasswordIcon = styled.img`
-  cursor: pointer;
-`;
+import { PasswordInput } from "./PasswordInput";
 
 interface NewPasswordForm {
   email: string; // As a hidden element for autofill

--- a/apps/passport-client/components/shared/NewPasswordForm.tsx
+++ b/apps/passport-client/components/shared/NewPasswordForm.tsx
@@ -27,7 +27,7 @@ export function PasswordInput({
 }: SetPasswordInputProps) {
   return (
     <Container>
-      <BigInput
+      <PasswordBigInput
         autoFocus={autoFocus}
         type={revealPassword ? "text" : "password"}
         placeholder={placeholder}
@@ -38,14 +38,20 @@ export function PasswordInput({
         <ShowHidePasswordIcon
           draggable="false"
           src={revealPassword ? icons.eyeClosed : icons.eyeOpen}
-          width={24}
-          height={24}
+          width={32}
+          height={32}
           onClick={() => setRevealPassword((curr) => !curr)}
         />
       </ShowHidePasswordIconContainer>
     </Container>
   );
 }
+
+const PasswordBigInput = styled(BigInput)`
+  /* To account for show/hide password icon. We add it to both sides to preserve center text alignment. */
+  padding-right: 48px;
+  padding-left: 48px;
+`;
 
 const Container = styled.div`
   width: 100%;

--- a/apps/passport-client/components/shared/PasswordInput.tsx
+++ b/apps/passport-client/components/shared/PasswordInput.tsx
@@ -1,0 +1,67 @@
+import { Dispatch, SetStateAction } from "react";
+import styled from "styled-components";
+import { BigInput } from "../core";
+import { icons } from "../icons";
+
+interface SetPasswordInputProps {
+  value: string;
+  setValue: Dispatch<SetStateAction<string>>;
+  revealPassword: boolean;
+  setRevealPassword: Dispatch<SetStateAction<boolean>>;
+  placeholder: string;
+  autoFocus?: boolean;
+}
+
+export function PasswordInput({
+  value,
+  setValue,
+  revealPassword,
+  autoFocus,
+  setRevealPassword,
+  placeholder
+}: SetPasswordInputProps) {
+  return (
+    <Container>
+      <PasswordBigInput
+        autoFocus={autoFocus}
+        type={revealPassword ? "text" : "password"}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <ShowHidePasswordIconContainer>
+        <ShowHidePasswordIcon
+          draggable="false"
+          src={revealPassword ? icons.eyeClosed : icons.eyeOpen}
+          width={32}
+          height={32}
+          onClick={() => setRevealPassword((curr) => !curr)}
+        />
+      </ShowHidePasswordIconContainer>
+    </Container>
+  );
+}
+
+const PasswordBigInput = styled(BigInput)`
+  /* To account for show/hide password icon. We add it to both sides to preserve center text alignment. */
+  padding-right: 48px;
+  padding-left: 48px;
+`;
+
+const Container = styled.div`
+  width: 100%;
+  position: relative;
+`;
+
+const ShowHidePasswordIconContainer = styled.div`
+  position: absolute;
+  right: 12px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  top: 0;
+`;
+
+const ShowHidePasswordIcon = styled.img`
+  cursor: pointer;
+`;


### PR DESCRIPTION
Three main things:
- Added show/hide password to login screen
- Added padding to password inputs such that 1password autofill button does not cover show/hide password
- Moved PasswordInput to its own module

Login before:

<img width="406" alt="Screenshot 2023-09-27 at 2 04 44 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/873ea3f7-5565-4472-a5d7-29c4d48266e1">

Login now:

<img width="426" alt="Screenshot 2023-09-27 at 2 02 46 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/e1a8d9ef-7bef-4a5c-9886-e249ad6bb3b1">

Change Password before (notice how show/hide button is covered):

<img width="403" alt="Screenshot 2023-09-27 at 2 05 53 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/28203d9c-aafd-40a0-ad8c-bfd0415576fb">

Change Password now:

<img width="399" alt="Screenshot 2023-09-27 at 2 03 10 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/7c58cda3-8eb0-435a-8c0b-307386fc64e8">

Create Password before (notice again how it's covered):

<img width="404" alt="Screenshot 2023-09-27 at 2 07 17 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/433efbe4-05c6-405a-886a-19046d252a3f">

Create Password now:

<img width="405" alt="Screenshot 2023-09-27 at 2 10 00 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/f7e1e2a2-cc05-42c2-a4e6-4217f682b05e">


Video:

https://github.com/proofcarryingdata/zupass/assets/36896271/5524923d-2e43-40ef-a6ed-12eeb85ebb8f

