### PR TITLE
Add "Resend code" button to register and reset account flows

### DIFF
--- a/apps/passport-client/components/screens/EnterConfirmationCodeScreen.tsx
+++ b/apps/passport-client/components/screens/EnterConfirmationCodeScreen.tsx
@@ -12,6 +12,7 @@ import {
 import { RippleLoader } from "../core/RippleLoader";
 import { MaybeModal } from "../modals/Modal";
 import { AppContainer } from "../shared/AppContainer";
+import { ResendCodeButton } from "../shared/ResendCodeButton";
 
 export function EnterConfirmationCodeScreen() {
   const dispatch = useDispatch();
@@ -86,6 +87,8 @@ export function EnterConfirmationCodeScreen() {
               <>
                 <Spacer h={8} />
                 <Button onClick={onCreateClick}>Continue</Button>
+                <Spacer h={8} />
+                <ResendCodeButton email={email} />
                 <Spacer h={8} />
                 <Button onClick={onCancelClick}>Cancel</Button>
               </>

--- a/apps/passport-client/components/screens/NewPassportScreen.tsx
+++ b/apps/passport-client/components/screens/NewPassportScreen.tsx
@@ -22,6 +22,7 @@ import {
 import { Button, LinkButton } from "../core/Button";
 import { RippleLoader } from "../core/RippleLoader";
 import { AppContainer } from "../shared/AppContainer";
+import { ResendCodeButton } from "../shared/ResendCodeButton";
 
 /**
  * Show the user that we're generating their passport. Direct them to the email
@@ -123,7 +124,13 @@ function SendEmailVerification({ email }: { email: string }) {
         <Spacer h={64} />
         <TextCenter>
           <Header />
-          <PHeavy>{emailSent ? "Check your email." : <>&nbsp;</>}</PHeavy>
+          <PHeavy>
+            {emailSent ? (
+              "Check your email. Please use the most recent code you have received."
+            ) : (
+              <>&nbsp;</>
+            )}
+          </PHeavy>
         </TextCenter>
         <Spacer h={24} />
         <form onSubmit={verify}>
@@ -145,7 +152,11 @@ function SendEmailVerification({ email }: { email: string }) {
               </div>
             )}
             {!verifyingCode && emailSent && (
-              <Button type="submit">Verify</Button>
+              <>
+                <Button type="submit">Verify</Button>
+                <Spacer h={8} />
+                <ResendCodeButton email={email} />
+              </>
             )}
           </CenterColumn>
         </form>

--- a/apps/passport-client/components/shared/ResendCodeButton.tsx
+++ b/apps/passport-client/components/shared/ResendCodeButton.tsx
@@ -11,10 +11,10 @@ interface ResendCodeButtonProps {
 export function ResendCodeButton({ email }: ResendCodeButtonProps) {
   const identity = useIdentity();
   // If not zero, this is the number of seconds the user will have
-  // the wait before clicking this button again. Technically, this
-  // frontend check doesn't really matter for sophisticated actors
+  // to wait before clicking this button again. Technically, this
+  // frontend check doesn't really matter for sophisticated actors,
   // because our defense against spammers should happen with rate
-  // limiting at the API layer, but this is still useful to have.
+  // limiting at the API layer.
   const [waitCountInSeconds, setWaitCount] = useState(0);
   const handleClick = async (event: React.FormEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -27,8 +27,8 @@ export function ResendCodeButton({ email }: ResendCodeButtonProps) {
       false
     );
 
-    // We need a local variable `timer` because relying on state will have us stuck
-    // within the setInterval().
+    // We need a local variable `timer` because relying on React state
+    // will have us stuck within the setInterval().
     let timer = 10;
     setWaitCount(10);
 

--- a/apps/passport-client/components/shared/ResendCodeButton.tsx
+++ b/apps/passport-client/components/shared/ResendCodeButton.tsx
@@ -1,0 +1,52 @@
+import { requestConfirmationEmail } from "@pcd/passport-interface";
+import { useState } from "react";
+import { appConfig } from "../../src/appConfig";
+import { useIdentity } from "../../src/appHooks";
+import { Button } from "../core";
+
+interface ResendCodeButtonProps {
+  email: string;
+}
+
+export function ResendCodeButton({ email }: ResendCodeButtonProps) {
+  const identity = useIdentity();
+  // If not zero, this is the number of seconds the user will have
+  // the wait before clicking this button again. Technically, this
+  // frontend check doesn't really matter for sophisticated actors
+  // because our defense against spammers should happen with rate
+  // limiting at the API layer, but this is still useful to have.
+  const [waitCountInSeconds, setWaitCount] = useState(0);
+  const handleClick = async (event: React.FormEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    console.log("handling click");
+    await requestConfirmationEmail(
+      appConfig.passportServer,
+      appConfig.isZuzalu,
+      email,
+      identity.commitment.toString(),
+      false
+    );
+
+    // We need a local variable `timer` because relying on state will have us stuck
+    // within the setInterval().
+    let timer = 10;
+    setWaitCount(10);
+
+    const countdown = setInterval(() => {
+      timer -= 1;
+      setWaitCount(timer);
+
+      if (timer === 0) {
+        clearInterval(countdown);
+      }
+    }, 1000);
+  };
+
+  const disabled = waitCountInSeconds > 0;
+
+  return (
+    <Button disabled={disabled} onClick={handleClick}>
+      {disabled ? `Resend code (${waitCountInSeconds})` : "Resend code"}
+    </Button>
+  );
+}


### PR DESCRIPTION
Thanks @Ner0nzz for the suggestion!

Resending a code (with cooldown) in registering.

https://github.com/proofcarryingdata/zupass/assets/36896271/2f181180-e0b2-4ae5-a639-ba464ed1a8f0


Also in reset account flow:
<img width="413" alt="Screenshot 2023-09-27 at 3 53 17 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/e064b49e-f5a0-4c75-9752-d041e051b5f4">
