### PR TITLE
invoke useSyncE2EEStorage in the subscription management screens - that way subscriptions get polled in those screens

### DIFF
--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -35,6 +35,7 @@ import {
   pendingAddSubscriptionRequestKey,
   setPendingAddSubscriptionRequest
 } from "../../src/sessionStorage";
+import { useSyncE2EEStorage } from "../../src/useSyncE2EEStorage";
 import { BigInput, Button, H2, Spacer } from "../core";
 import { AppContainer } from "../shared/AppContainer";
 import { Spinner } from "../shared/Spinner";
@@ -43,6 +44,7 @@ import { SubscriptionNavigation } from "../shared/SubscriptionNavigation";
 const DEFAULT_FEEDS_URL = appConfig.zupassServer + "/feeds";
 
 export function AddSubscriptionScreen() {
+  useSyncE2EEStorage();
   const query = useQuery();
   const url = query?.get("url") ?? "";
   const [providerUrl, setProviderUrl] = useState(

--- a/apps/passport-client/components/screens/SubscriptionsScreen.tsx
+++ b/apps/passport-client/components/screens/SubscriptionsScreen.tsx
@@ -7,6 +7,7 @@ import {
   pendingViewSubscriptionsRequestKey,
   setPendingViewSubscriptionsRequest
 } from "../../src/sessionStorage";
+import { useSyncE2EEStorage } from "../../src/useSyncE2EEStorage";
 import { Button, H2, Spacer } from "../core";
 import { MaybeModal } from "../modals/Modal";
 import { AppContainer } from "../shared/AppContainer";
@@ -14,6 +15,7 @@ import { SubscriptionNavigation } from "../shared/SubscriptionNavigation";
 import { SubscriptionInfoRow } from "./AddSubscriptionScreen";
 
 export function SubscriptionsScreen() {
+  useSyncE2EEStorage();
   const { value: subs } = useSubscriptions();
   const self = useSelf();
 


### PR DESCRIPTION
closes https://github.com/proofcarryingdata/zupass/issues/704