### PR TITLE
[DO NOT MERGE] Performance Exploration

### DIFF
--- a/apps/passport-server/src/routing/routes/pcdIssuanceRoutes.ts
+++ b/apps/passport-server/src/routing/routes/pcdIssuanceRoutes.ts
@@ -85,9 +85,18 @@ export function initPCDIssuanceRoutes(
    */
   app.post("/feeds", async (req, res) => {
     checkIssuanceServiceStarted(issuanceService);
+    logger(`Got feed request`, Date.now());
+    const startTime = Date.now();
     const result = await issuanceService.handleFeedRequest(
       req.body as PollFeedRequest
     );
+    logger(
+      `Handled feed request in ${Date.now() - startTime} ms, ${
+        (Date.now() - startTime) / 1000
+      } s`,
+      result
+    );
+
     res.json(result satisfies PollFeedResponseValue);
   });
 


### PR DESCRIPTION
```js
export async function getCacheValue(
  db: Pool,
  key: string
): Promise<CacheEntry | undefined> {
  const result = await sqlQuery(
    db,
    `select * from cache where cache_key = $1`,
    [key]
  );

  if (result.rowCount === 0) {
    return undefined;
  }

  return result.rows[0];
}
```

It seems like this function takes 5 - 10s in the current Postgres schema. How can we improve it?

See the ZKMS Telegram chat for more info

One thing to try is a [hash index](https://hakibenita.com/postgresql-hash-index) instead of a B-Tree index. Update: adding a hash index did not change the lookup speed.