### PR TITLE
display email address of the zupass account in the settings pane

### DIFF
--- a/apps/passport-client/components/modals/SettingsModal.tsx
+++ b/apps/passport-client/components/modals/SettingsModal.tsx
@@ -1,11 +1,12 @@
 import { useCallback } from "react";
-import { useDispatch } from "../../src/appHooks";
+import { useDispatch, useSelf } from "../../src/appHooks";
 import { Button, CenterColumn, Spacer, TextCenter } from "../core";
 import { LinkButton } from "../core/Button";
 import { icons } from "../icons";
 
 export function SettingsModal() {
   const dispatch = useDispatch();
+  const self = useSelf();
 
   const close = useCallback(() => {
     dispatch({ type: "set-modal", modal: "" });
@@ -29,6 +30,8 @@ export function SettingsModal() {
       </TextCenter>
       <Spacer h={24} />
       <CenterColumn>
+        <TextCenter>{self.email}</TextCenter>
+        <Spacer h={16} />
         <LinkButton primary={true} to="/scan">
           Scan Ticket
         </LinkButton>


### PR DESCRIPTION
closes https://github.com/proofcarryingdata/zupass/issues/636

<img width="489" alt="Screenshot 2023-09-30 at 8 32 00 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/f5defe0b-3b52-4bcc-974e-165f94d7379b">
