### PR TITLE
instrument pcd package functions on zupass sever-side

### DIFF
--- a/apps/passport-server/src/routing/routes/pcdIssuanceRoutes.ts
+++ b/apps/passport-server/src/routing/routes/pcdIssuanceRoutes.ts
@@ -91,13 +91,6 @@ export function initPCDIssuanceRoutes(
     res.json(result satisfies PollFeedResponseValue);
   });
 
-  /**
-   * Checks whether the given ticket is eligible for being checked in.
-   * Each reason that a ticket *wouldn't* be able to be checked in for
-   * is encapuslated in the response we generate here, via {@link CheckTicketError}.
-   *
-   * @todo - this should probably live in a different service.
-   */
   app.get("/feeds/:feedId", async (req: Request, res: Response) => {
     checkIssuanceServiceStarted(issuanceService);
     const feedId = checkUrlParam(req, "feedId");
@@ -107,6 +100,13 @@ export function initPCDIssuanceRoutes(
     res.json(await issuanceService.handleListSingleFeedRequest({ feedId }));
   });
 
+  /**
+   * Checks whether the given ticket is eligible for being checked in.
+   * Each reason that a ticket *wouldn't* be able to be checked in for
+   * is encapuslated in the response we generate here, via {@link CheckTicketError}.
+   *
+   * @todo - this should probably live in a different service.
+   */
   app.post("/issue/check-ticket", async (req: Request, res: Response) => {
     checkIssuanceServiceStarted(issuanceService);
     const result = await issuanceService.handleCheckTicketRequest(

--- a/apps/passport-server/src/services.ts
+++ b/apps/passport-server/src/services.ts
@@ -21,7 +21,7 @@ export async function startServices(
   apis: APIs
 ): Promise<GlobalServices> {
   await startTelemetry(context);
-  await instrumentPCDs(context);
+  instrumentPCDs();
 
   const discordService = await startDiscordService();
   const rollbarService = startRollbarService(context);

--- a/apps/passport-server/src/services.ts
+++ b/apps/passport-server/src/services.ts
@@ -14,12 +14,15 @@ import { startTelemetry } from "./services/telemetryService";
 import { startUserService } from "./services/userService";
 import { startZuzaluPretixSyncService } from "./services/zuzaluPretixSyncService";
 import { APIs, ApplicationContext, GlobalServices } from "./types";
+import { instrumentPCDs } from "./util/instrumentPCDs";
 
 export async function startServices(
   context: ApplicationContext,
   apis: APIs
 ): Promise<GlobalServices> {
   await startTelemetry(context);
+  await instrumentPCDs(context);
+
   const discordService = await startDiscordService();
   const rollbarService = startRollbarService(context);
   const telegramService = await startTelegramService(context, rollbarService);

--- a/apps/passport-server/src/services/telemetryService.ts
+++ b/apps/passport-server/src/services/telemetryService.ts
@@ -105,6 +105,8 @@ export async function traced<T>(
   }
 
   return tracer.startActiveSpan(service + "." + method, async (span) => {
+    span.setAttribute("trace_service_name", service);
+
     if (process.env.ROLLBAR_ENV_NAME) {
       span.setAttribute("env_name", process.env.ROLLBAR_ENV_NAME);
     }

--- a/apps/passport-server/src/util/instrumentPCDs.ts
+++ b/apps/passport-server/src/util/instrumentPCDs.ts
@@ -1,0 +1,5 @@
+import { logger } from "./logger";
+
+export function instrumentPCDs(context: ApplicationContext): Promise<void> {
+  logger(`[INIT] instrumenting PCDs`);
+}

--- a/apps/passport-server/src/util/instrumentPCDs.ts
+++ b/apps/passport-server/src/util/instrumentPCDs.ts
@@ -1,5 +1,49 @@
+import { EdDSAPCDPackage } from "@pcd/eddsa-pcd";
+import { EdDSATicketPCDPackage } from "@pcd/eddsa-ticket-pcd";
+import { EmailPCDPackage } from "@pcd/email-pcd";
+import { PCDPackage } from "@pcd/pcd-types";
+import { RSAImagePCDPackage } from "@pcd/rsa-image-pcd";
+import { RSAPCDPackage } from "@pcd/rsa-pcd";
+import { SemaphoreGroupPCDPackage } from "@pcd/semaphore-group-pcd";
+import { SemaphoreSignaturePCDPackage } from "@pcd/semaphore-signature-pcd";
+import { traced } from "../services/telemetryService";
 import { logger } from "./logger";
 
-export function instrumentPCDs(context: ApplicationContext): Promise<void> {
+export function instrumentPCDs(): void {
   logger(`[INIT] instrumenting PCDs`);
+
+  [
+    EdDSAPCDPackage,
+    EdDSATicketPCDPackage,
+    RSAImagePCDPackage,
+    RSAPCDPackage,
+    EmailPCDPackage,
+    SemaphoreSignaturePCDPackage,
+    SemaphoreGroupPCDPackage
+  ].forEach(instrumentPackage);
+}
+
+function instrumentPackage(pcdPackage: PCDPackage): void {
+  ["prove", "verify", "serialize", "deserialize", "init"].forEach(
+    (functionName) => instrumentSingleFunction(pcdPackage, functionName)
+  );
+}
+
+function instrumentSingleFunction(
+  pcdPackage: PCDPackage<unknown, unknown, unknown, unknown>,
+  functionName: string
+): void {
+  logger(`[INIT] instrumenting ${pcdPackage.name}.${functionName}`);
+
+  const packageAsAny = pcdPackage as any;
+  const uninstrumentedFunction = packageAsAny[functionName];
+
+  packageAsAny[functionName] = (...args: any[]): any => {
+    return traced("PCDPackage", functionName, async (span) => {
+      span?.setAttribute("pcd_package_name", pcdPackage.name);
+      span?.setAttribute("function_name", functionName);
+
+      return uninstrumentedFunction(...args);
+    });
+  };
 }


### PR DESCRIPTION
closes https://github.com/proofcarryingdata/zupass/issues/753

enables tracing like this on the server: 
https://ui.honeycomb.io/0xparc/environments/dev/datasets/server-telemetry/result/7cSsVQMAZY2

<img width="806" alt="Screenshot 2023-10-02 at 3 03 27 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/b122549c-4d46-4628-a926-91e783f710cc">
