### PR TITLE
Revert "change eddsa pub key format to normal form from montgomery form"

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "knip": "knip --no-gitignore"
   },
   "devDependencies": {
-    "@types/circomlibjs": "0.1.2",
-    "@types/snarkjs": "0.7.1",
+    "@types/circomlibjs": "^0.1.1",
+    "@types/snarkjs": "^0.7.1",
     "concurrently": "^8.2.0",
     "prettier": "^3.0.0",
     "prettier-plugin-organize-imports": "^3.2.2",

--- a/packages/eddsa-pcd/src/EdDSAPCD.ts
+++ b/packages/eddsa-pcd/src/EdDSAPCD.ts
@@ -97,7 +97,9 @@ export async function prove(args: EdDSAPCDArgs): Promise<EdDSAPCD> {
   const prvKey = fromHexString(args.privateKey.value);
 
   const hashedMessage = poseidon(message);
-  const publicKey = await getEdDSAPublicKey(prvKey);
+  const publicKey: EDdSAPublicKey = eddsa
+    .prv2pub(prvKey)
+    .map(toHexString) as EDdSAPublicKey;
   const signature = toHexString(
     eddsa.packSignature(eddsa.signPoseidon(prvKey, hashedMessage))
   );
@@ -109,8 +111,7 @@ export async function verify(pcd: EdDSAPCD): Promise<boolean> {
   await ensureInitialized();
 
   const signature = eddsa.unpackSignature(fromHexString(pcd.proof.signature));
-  const pubKey = pcd.claim.publicKey.map((p) => eddsa.F.fromObject(p)) as Point;
-
+  const pubKey = pcd.claim.publicKey.map(fromHexString) as unknown as Point;
   const hashedMessage = poseidon(pcd.claim.message);
 
   return eddsa.verifyPoseidon(hashedMessage, signature, pubKey);
@@ -177,17 +178,11 @@ export const EdDSAPCDPackage: PCDPackage<
 };
 
 export async function getEdDSAPublicKey(
-  privateKey: string | Uint8Array
+  privateKey: string
 ): Promise<EDdSAPublicKey> {
   await ensureInitialized();
 
-  if (typeof privateKey === "string") {
-    privateKey = fromHexString(privateKey);
-  }
-
   return eddsa
-    .prv2pub(privateKey)
-    .map((p) =>
-      eddsa.F.toObject(p).toString(16).padStart(64, "0")
-    ) as EDdSAPublicKey;
+    .prv2pub(fromHexString(privateKey))
+    .map(toHexString) as EDdSAPublicKey;
 }

--- a/packages/util/src/NumericRepresentation.ts
+++ b/packages/util/src/NumericRepresentation.ts
@@ -43,17 +43,6 @@ export function numberToBigInt(v: number): bigint {
 }
 
 /**
- * Converts a hex number to a bigint.
- */
-export function hexToBigInt(v: string): bigint {
-  if (!v.startsWith("0x")) {
-    v = "0x" + v;
-  }
-
-  return BigInt(v);
-}
-
-/**
  * Converts a boolean to a bigint value of 0 or 1.
  */
 export function booleanToBigInt(v: boolean): bigint {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4056,10 +4056,10 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.6.tgz#7b489e8baf393d5dd1266fb203ddd4ea941259e6"
   integrity sha512-VOVRLM1mBxIRxydiViqPcKn6MIxZytrbMpd6RJLIWKxUNr3zux8no0Oc7kJx0WAPIitgZ0gkrDS+btlqQpubpw==
 
-"@types/circomlibjs@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@types/circomlibjs/-/circomlibjs-0.1.2.tgz#2d6021ea0680973f4b522dbb4f82401c81872f1f"
-  integrity sha512-frsB+ZOIRA3I76hcoOIdkKO9kO+ZE9hNVT/Z27Cw6/gv6X3dGzWnSbRZkwCQ9NwGUzFtQugL4AfBBWKU3Uv0bg==
+"@types/circomlibjs@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@types/circomlibjs/-/circomlibjs-0.1.1.tgz#f25748b7cf391fda065fe7456b4f7425f7087b62"
+  integrity sha512-1B44LKMFJ5ul1IXWULfr8VsI/M5YxOT1IZFGLGlR4lkE3nvhUoQ+4Ex/XcDNhQNuCqB2bPaNmXScA5rqgz3tsw==
 
 "@types/connect@*":
   version "3.4.36"
@@ -4600,7 +4600,7 @@
   resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.0.2.tgz#93eb2c243c351f3f17d5c580c7467ae5d686b65f"
   integrity sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg==
 
-"@types/snarkjs@0.7.1":
+"@types/snarkjs@^0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@types/snarkjs/-/snarkjs-0.7.1.tgz#f19957c3d98c590b344a9c67636d49e5a1d66ddd"
   integrity sha512-V7OBbC8GSUax/VKT0qSrFlckhj3jqi6hUs+EKnxkMWjWKzKWipib5LR61hhfLDePx7AMoK8fKfnPUTExv+iNMQ==


### PR DESCRIPTION
Reverts proofcarryingdata/zupass#663

This is causing proving to break locally and on staging. We should re-open when the bug is fixed.

![image](https://github.com/proofcarryingdata/zupass/assets/36896271/87dc900a-199e-4164-bfdd-138539760a9f)
