### PR TITLE
DMS/ZMS Fix Message on Verify Error 

### DIFF
--- a/apps/anon-message-client/src/app/page.tsx
+++ b/apps/anon-message-client/src/app/page.tsx
@@ -68,7 +68,7 @@ function requestProof(message: string) {
     genericProveScreen: true,
     title: "ZK-EdDSA Ticket Request",
     description:
-      "Generate a ZK proof that you have a ticket for the research workshop! Select your ticket from the dropdown below."
+      "Generate a ZK proof that you have a ticket for a conference event! Select your ticket from the dropdown below."
   });
 
   window.location.href = proofUrl;

--- a/apps/passport-server/resources/telegram/error.html
+++ b/apps/passport-server/resources/telegram/error.html
@@ -4,13 +4,15 @@
     <style></style>
   </head>
   <body>
+    <p>We were unable to verify that you have a ticket for a Telegram group</p>
     <p>
-      We were unable to verify that you have a Stanford Research Workshop
-      ticket. Make sure that you selected "SBC SRW" ticket in the dropdown!
+      Make sure the event you have a ticket has corresponding Telegram group in
+      the list provided by the bot.
     </p>
+    <p>Type <i>/start</i> again to view the list if needed.</p>
     <p>
-      If you need help getting added to the telegram group, please email
-      <b>passport@0xparc.org</b> for help.
+      If you need help additional help, please email
+      <b>passport@0xparc.org</b>.
     </p>
   </body>
 </html>

--- a/apps/passport-server/resources/telegram/error.html
+++ b/apps/passport-server/resources/telegram/error.html
@@ -6,7 +6,7 @@
   <body>
     <p>We were unable to verify that you have a ticket for a Telegram group</p>
     <p>
-      Make sure the event you have a ticket has corresponding Telegram group in
+      Make sure that the event associated with your ticket has corresponding Telegram group in
       the list provided by the bot.
     </p>
     <p>Type <i>/start</i> again to view the list if needed.</p>

--- a/apps/passport-server/src/routing/routes/telegramRoutes.ts
+++ b/apps/passport-server/src/routing/routes/telegramRoutes.ts
@@ -58,8 +58,7 @@ export function initTelegramRoutes(
         logger("[TELEGRAM] failed to verify", e);
         rollbarService?.reportError(e);
         res.set("Content-Type", "text/html");
-        res.sendFile(path.resolve("resources/telegram/error.html"));
-        res.sendStatus(500);
+        res.status(500).sendFile(path.resolve("resources/telegram/error.html"));
       }
     } catch (e) {
       logger("[TELEGRAM] failed to verify", e);

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -503,7 +503,7 @@ export class TelegramService {
       genericProveScreen: true,
       title: "ZK Ticket Proof",
       description:
-        "Generate a zero-knowledge proof that you have a ZK-EdDSA ticket for a conference event! Select your ticket from the dropdown below."
+        "Generate a zero-knowledge proof that you have an EdDSA ticket for a conference event! Select your ticket from the dropdown below."
     });
     return proofUrl;
   }

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -503,7 +503,7 @@ export class TelegramService {
       genericProveScreen: true,
       title: "ZK Ticket Proof",
       description:
-        "Generate a zero-knowledge proof that you have a ZK-EdDSA ticket for the research workshop! Select your ticket from the dropdown below."
+        "Generate a zero-knowledge proof that you have a ZK-EdDSA ticket for a conference event! Select your ticket from the dropdown below."
     });
     return proofUrl;
   }


### PR DESCRIPTION
- This PR makes the error message no longer SBC specific and fixes a bug where the error message was not being sent because the 500 error was arriving first.

Closes #791 