### PR TITLE
Revision and conflict handling for E2EE storage

### DIFF
--- a/apps/passport-client/src/useSyncE2EEStorage.tsx
+++ b/apps/passport-client/src/useSyncE2EEStorage.tsx
@@ -96,7 +96,10 @@ export async function uploadStorage(): Promise<void> {
  * Given the encryption key in local storage, downloads the e2ee
  * encrypted storage from the server.
  */
-export async function downloadStorage(): Promise<{ pcds: PCDCollection | null, subscriptions: FeedSubscriptionManager | null }> {
+export async function downloadStorage(): Promise<{
+  pcds: PCDCollection | null;
+  subscriptions: FeedSubscriptionManager | null;
+}> {
   console.log("[SYNC] downloading e2ee storage");
 
   const encryptionKey = loadEncryptionKey();
@@ -120,8 +123,10 @@ export async function downloadStorage(): Promise<{ pcds: PCDCollection | null, s
         storageResult.value.pcds
       );
 
-      subscriptions = FeedSubscriptionManager.deserialize(new NetworkFeedApi(), storageResult.value.subscriptions);
-
+      subscriptions = FeedSubscriptionManager.deserialize(
+        new NetworkFeedApi(),
+        storageResult.value.subscriptions
+      );
     } else if (isSyncedEncryptedStorageV2(storageResult.value)) {
       pcds = await PCDCollection.deserialize(
         await getPackages(),

--- a/apps/passport-server/migrations/37_e2ee_revision.sql
+++ b/apps/passport-server/migrations/37_e2ee_revision.sql
@@ -1,0 +1,1 @@
+alter table e2ee add column revision bigint not null default 1;

--- a/apps/passport-server/src/database/models.ts
+++ b/apps/passport-server/src/database/models.ts
@@ -115,6 +115,7 @@ export interface UserRow {
 export interface EncryptedStorageModel {
   blob_key: string;
   encrypted_blob: string;
+  revision: string; // bigint in database returned to JavaScript as string
 }
 
 export interface HistoricSemaphoreGroup {

--- a/apps/passport-server/src/database/sqlQuery.ts
+++ b/apps/passport-server/src/database/sqlQuery.ts
@@ -94,9 +94,7 @@ async function execTransactionWithRetry<T>(
         try {
           await txClient.query("ROLLBACK");
         } catch (rollbackError) {
-          logger(
-            `Rollback for updateEncryptedStorage failed: ${rollbackError}`
-          );
+          logger(`Rollback failed: ${rollbackError}`);
         }
         throw queryError;
       } finally {

--- a/apps/passport-server/src/database/sqlQuery.ts
+++ b/apps/passport-server/src/database/sqlQuery.ts
@@ -1,23 +1,23 @@
 import { getActiveSpan } from "@opentelemetry/api/build/src/trace/context-utils";
 import { getErrorMessage, sleep } from "@pcd/util";
 import { QueryResult } from "pg";
-import { Pool } from "postgres-pool";
+import { Pool, PoolClient } from "postgres-pool";
 import { traced } from "../services/telemetryService";
 import { logger } from "../util/logger";
 
 /**
- * This function executes a sql query against the database, and traces
- * its performance. Retries queries that fail due to a connection error.
+ * Executes a sql query against the database, and traces its performance.
+ * Retries queries that fail due to a connection error.
  */
 export function sqlQuery(
-  client: Pool,
+  pool: Pool,
   query: string,
   args?: any[]
 ): Promise<QueryResult> {
   return traced("DB", "query", async (span) => {
     span?.setAttribute("query", query);
     try {
-      return await execQueryWithRetry(client, query, args);
+      return await execQueryWithRetry(pool, query, args);
     } catch (e) {
       span?.setAttribute("error", e + "");
 
@@ -32,13 +32,76 @@ export function sqlQuery(
 }
 
 async function execQueryWithRetry(
-  client: Pool,
+  pool: Pool,
   query: string,
   args?: any[]
 ): Promise<QueryResult> {
   return execWithRetry(
     () => {
-      return client.query(query, args);
+      return pool.query(query, args);
+    },
+    (e) => {
+      const errorMessage = getErrorMessage(e);
+      return errorMessage.includes("Error: Connection terminated unexpectedly");
+    },
+    3
+  );
+}
+
+/**
+ * Executes a given function inside a transaction against the database, and
+ * traces its performance.  Retries queries that fail due to a connection error.
+ * The transaction will be committed if the txn function returns a value, or
+ * rolled back if it throws/rejects.
+ */
+export function sqlTransaction<T>(
+  pool: Pool,
+  txn_desc: string,
+  txn: (client: PoolClient) => Promise<T>
+): Promise<T> {
+  return traced("DB", "transaction", async (span) => {
+    span?.setAttribute("txn", txn_desc);
+    try {
+      return await execTransactionWithRetry(pool, txn);
+    } catch (e) {
+      span?.setAttribute("error", e + "");
+
+      if ((e as any).code) {
+        span?.setAttribute("code", (e as any).code);
+      }
+
+      logger(`[ERROR] sql transaction\n`, `"${txn_desc}"\n`, e);
+      throw e;
+    }
+  });
+}
+
+async function execTransactionWithRetry<T>(
+  pool: Pool,
+  txn: (client: PoolClient) => Promise<T>
+): Promise<T> {
+  return execWithRetry(
+    async () => {
+      // Based on recommended transaction flow, where queries are isolated to a
+      // particular client: https://node-postgres.com/features/transactions
+      const txClient = await pool.connect();
+      try {
+        await txClient.query("BEGIN");
+        const result = await txn(txClient);
+        await txClient.query("COMMIT");
+        return result;
+      } catch (queryError) {
+        try {
+          await txClient.query("ROLLBACK");
+        } catch (rollbackError) {
+          logger(
+            `Rollback for updateEncryptedStorage failed: ${rollbackError}`
+          );
+        }
+        throw queryError;
+      } finally {
+        txClient.release();
+      }
     },
     (e) => {
       const errorMessage = getErrorMessage(e);

--- a/apps/passport-server/src/routing/params.ts
+++ b/apps/passport-server/src/routing/params.ts
@@ -19,8 +19,33 @@ export function checkQueryParam(req: Request, paramName: string): string {
 }
 
 /**
+ * Extracts an optional string value from the query of an Express
+ * {@link Request}.  If the value is missing, return undefined.  If the value is
+ * the wrong type, throws a {@link PCDHTTPError}.
+ */
+export function checkOptionalQueryParam(
+  req: Request,
+  paramName: string
+): string | undefined {
+  const value = req.query[paramName];
+
+  if (typeof value === "undefined") {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new PCDHTTPError(
+      400,
+      `missing required query parameter '${paramName}' - was ${value}`
+    );
+  }
+
+  return value;
+}
+
+/**
  * Extracts a string value from the url params of an Express {@link Request}.
- * If the value doesn't exist, throws a {@link PCDHTTPError}.
+ * If the value doesn't exist or has the wrong type, throws a
+ * {@link PCDHTTPError}.
  */
 export function checkUrlParam(req: Request, paramName: string): string {
   const value = req.params[paramName];

--- a/apps/passport-server/src/routing/params.ts
+++ b/apps/passport-server/src/routing/params.ts
@@ -21,7 +21,7 @@ export function checkQueryParam(req: Request, paramName: string): string {
 /**
  * Extracts an optional string value from the query of an Express
  * {@link Request}.  If the value is missing, return undefined.  If the value is
- * the wrong type, throws a {@link PCDHTTPError}.
+ * not a string, throws a {@link PCDHTTPError}.
  */
 export function checkOptionalQueryParam(
   req: Request,
@@ -44,7 +44,7 @@ export function checkOptionalQueryParam(
 
 /**
  * Extracts a string value from the url params of an Express {@link Request}.
- * If the value doesn't exist or has the wrong type, throws a
+ * If the value doesn't exist or is not a string, throws a
  * {@link PCDHTTPError}.
  */
 export function checkUrlParam(req: Request, paramName: string): string {

--- a/apps/passport-server/src/services/e2eeService.ts
+++ b/apps/passport-server/src/services/e2eeService.ts
@@ -130,15 +130,12 @@ export class E2EEService {
           error: {
             name: "Conflict",
             detailedMessage: `Can't rekey e2ee due to conflict: expected 
-              revision ${baseRevision}, found ${updateResult.revision}`,
-            success: false
+              revision ${baseRevision}, found ${updateResult.revision}`
           }
         });
         return undefined;
       case "missing":
-        res
-          .status(401)
-          .json({ error: { name: "PasswordIncorrect" }, success: false });
+        res.status(401).json({ error: { name: "PasswordIncorrect" } });
         return undefined;
     }
   }
@@ -168,8 +165,7 @@ export class E2EEService {
       res.status(404).json({
         error: {
           name: "UserNotFound",
-          detailedMessage: "User with this uuid was not found",
-          success: false
+          detailedMessage: "User with this uuid was not found"
         }
       });
       return;
@@ -180,8 +176,7 @@ export class E2EEService {
       res.status(400).json({
         error: {
           name: "RequiresNewSalt",
-          detailedMessage: "Updated salt must be different than existing salt",
-          success: false
+          detailedMessage: "Updated salt must be different than existing salt"
         }
       });
       return;

--- a/apps/passport-server/src/services/e2eeService.ts
+++ b/apps/passport-server/src/services/e2eeService.ts
@@ -8,7 +8,7 @@ import { Response } from "express";
 import {
   fetchEncryptedStorage,
   insertEncryptedStorage,
-  updateEncryptedStorage
+  rekeyEncryptedStorage
 } from "../database/queries/e2ee";
 import { fetchUserByUUID } from "../database/queries/users";
 import { PCDHTTPError } from "../routing/pcdHttpError";
@@ -117,7 +117,7 @@ export class E2EEService {
       return;
     }
 
-    await updateEncryptedStorage(
+    await rekeyEncryptedStorage(
       this.context.dbPool,
       request.oldBlobKey,
       request.newBlobKey,

--- a/apps/passport-server/test/database.spec.ts
+++ b/apps/passport-server/test/database.spec.ts
@@ -368,7 +368,7 @@ describe("database reads and writes", function () {
     expect(rekeyResult2.revision).to.be.undefined;
   });
 
-  step("e2ee rekeying should work with baseRevision", async function () {
+  step("e2ee rekeying should work with knownRevision", async function () {
     const key1 = "rkey1";
     const value1 = "value1";
     const value2 = "value2";

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -102,7 +102,12 @@ import {
 } from "./semaphore/checkSemaphore";
 import { testDeviceLogin, testFailedDeviceLogin } from "./user/testDeviceLogin";
 import { testLogin } from "./user/testLoginPCDPass";
-import { testUserSync } from "./user/testUserSync";
+import {
+  testUserSyncKeyChangeNoRev,
+  testUserSyncKeyChangeWithRev,
+  testUserSyncNoRev,
+  testUserSyncWithRev
+} from "./user/testUserSync";
 import { overrideEnvironment, testingEnv } from "./util/env";
 import { startTestingApp } from "./util/startTestingApplication";
 
@@ -1644,8 +1649,35 @@ describe("devconnect functionality", function () {
   );
 
   step("user should be able to sync end to end encryption", async function () {
-    await testUserSync(application);
+    await testUserSyncNoRev(application);
   });
+
+  step(
+    "user should be able to avoid sync conflicts in end to end encryption",
+    async function () {
+      await testUserSyncWithRev(application);
+    }
+  );
+
+  step(
+    "user should be able to change their synced storage key",
+    async function () {
+      if (!residentUser) {
+        throw new Error("expected user");
+      }
+      await testUserSyncKeyChangeNoRev(application, residentUser);
+    }
+  );
+
+  step(
+    "user should be able to avoid conflicts changing their synced storage key",
+    async function () {
+      if (!residentUser) {
+        throw new Error("expected user");
+      }
+      await testUserSyncKeyChangeWithRev(application, residentUser);
+    }
+  );
 
   step("should have issuance service running", async function () {
     await expectIssuanceServiceToBeRunning(application);

--- a/apps/passport-server/test/user/testUserSync.ts
+++ b/apps/passport-server/test/user/testUserSync.ts
@@ -13,6 +13,8 @@ import "chai-spies";
 import "mocha";
 import { Zupass } from "../../src/types";
 
+// TODO(artwyman): Extend this to test revision and conflict handling.
+
 export async function testUserSync(application: Zupass): Promise<void> {
   const crypto = await PCDCrypto.newInstance();
   const encryptionKey = await crypto.generateRandomKey();

--- a/apps/passport-server/test/user/testUserSync.ts
+++ b/apps/passport-server/test/user/testUserSync.ts
@@ -1,4 +1,5 @@
 import {
+  EncryptedPacket,
   passportDecrypt,
   passportEncrypt,
   PCDCrypto
@@ -43,9 +44,12 @@ export async function testUserSync(application: Zupass): Promise<void> {
   if (secondLoadResult.value == null) {
     throw new Error("expected to be able to load e2ee");
   }
+  if (!secondLoadResult.value.encryptedBlob) {
+    throw new Error("expected value from loading e2ee");
+  }
 
   const decrypted: string = await passportDecrypt(
-    secondLoadResult.value,
+    JSON.parse(secondLoadResult.value.encryptedBlob) as EncryptedPacket,
     encryptionKey
   );
 

--- a/apps/passport-server/test/user/testUserSync.ts
+++ b/apps/passport-server/test/user/testUserSync.ts
@@ -130,7 +130,7 @@ export async function testUserSyncWithRev(application: Zupass): Promise<void> {
   expect(initialLoadResult.success).to.eq(false);
   expect(initialLoadResult.error?.name).to.eq("NotFound");
 
-  // Attempting update with base rev will result in NotFound, not a conflict.
+  // Attempting update with rev will still result in NotFound, not a conflict.
   const notfoundUploadResult = await requestUploadEncryptedStorage(
     application.expressContext.localEndpoint,
     encryptionKey,
@@ -141,7 +141,7 @@ export async function testUserSyncWithRev(application: Zupass): Promise<void> {
   expect(notfoundUploadResult.success).to.eq(false);
   expect(notfoundUploadResult.error?.name).to.eq("NotFound");
 
-  // Create storage with no base rev (required for first write)
+  // Create storage with no rev (required for first write)
   const uploadResult1 = await requestUploadEncryptedStorage(
     application.expressContext.localEndpoint,
     encryptionKey,
@@ -176,7 +176,7 @@ export async function testUserSyncWithRev(application: Zupass): Promise<void> {
     encryptionKey
   );
 
-  // Update storage with base rev
+  // Update storage with rev
   const uploadResult2 = await requestUploadEncryptedStorage(
     application.expressContext.localEndpoint,
     encryptionKey,
@@ -202,7 +202,7 @@ export async function testUserSyncWithRev(application: Zupass): Promise<void> {
     encryptionKey
   );
 
-  // Attempt update with earlier base rev, receiving conflict with no changes
+  // Attempt update with earlier rev, receiving conflict with no changes
   const conflictResult1 = await requestUploadEncryptedStorage(
     application.expressContext.localEndpoint,
     encryptionKey,
@@ -215,7 +215,7 @@ export async function testUserSyncWithRev(application: Zupass): Promise<void> {
 
   await fetchAndCheckStorage(application, encryptionKey, rev2, plaintextData2);
 
-  // Attempt update with proper base rev, which should work after conflict
+  // Attempt update with proper rev, which should work after conflict
   const uploadResult3 = await requestUploadEncryptedStorage(
     application.expressContext.localEndpoint,
     encryptionKey,
@@ -411,7 +411,7 @@ export async function testUserSyncKeyChangeWithRev(
 
   await fetchAndCheckStorage(application, encryptionKey1, rev1, plaintextData1);
 
-  // Update storage with base rev to create rev2
+  // Update storage with rev to create rev2
   const uploadResult2 = await requestUploadEncryptedStorage(
     application.expressContext.localEndpoint,
     encryptionKey1,

--- a/apps/passport-server/test/user/testUserSync.ts
+++ b/apps/passport-server/test/user/testUserSync.ts
@@ -65,7 +65,7 @@ export async function testUserSyncNoRev(application: Zupass): Promise<void> {
     encryptionKey
   );
   expect(initialLoadResult.success).to.eq(false);
-  expect(initialLoadResult.error?.reason).to.eq("notfound");
+  expect(initialLoadResult.error?.name).to.eq("NotFound");
 
   // Create storage
   const uploadResult1 = await requestUploadEncryptedStorage(
@@ -128,9 +128,9 @@ export async function testUserSyncWithRev(application: Zupass): Promise<void> {
     "0"
   );
   expect(initialLoadResult.success).to.eq(false);
-  expect(initialLoadResult.error?.reason).to.eq("notfound");
+  expect(initialLoadResult.error?.name).to.eq("NotFound");
 
-  // Attempting update with base rev will result in notfound, not a conflict.
+  // Attempting update with base rev will result in NotFound, not a conflict.
   const notfoundUploadResult = await requestUploadEncryptedStorage(
     application.expressContext.localEndpoint,
     encryptionKey,
@@ -139,14 +139,14 @@ export async function testUserSyncWithRev(application: Zupass): Promise<void> {
   );
   expect(notfoundUploadResult.value).to.eq(undefined);
   expect(notfoundUploadResult.success).to.eq(false);
-  expect(notfoundUploadResult.error?.reason).to.eq("notfound");
+  expect(notfoundUploadResult.error?.name).to.eq("NotFound");
 
   // Create storage with no base rev (required for first write)
   const uploadResult1 = await requestUploadEncryptedStorage(
     application.expressContext.localEndpoint,
     encryptionKey,
     encryptedData1,
-    undefined /* baseRevision */
+    undefined /* knownRevision */
   );
   expect(uploadResult1.error).to.eq(undefined);
   expect(uploadResult1.success).to.eq(true);
@@ -211,7 +211,7 @@ export async function testUserSyncWithRev(application: Zupass): Promise<void> {
   );
   expect(conflictResult1.success).to.eq(false);
   expect(conflictResult1.value).to.be.undefined;
-  expect(conflictResult1.error?.reason).to.eq("conflict");
+  expect(conflictResult1.error?.name).to.eq("Conflict");
 
   await fetchAndCheckStorage(application, encryptionKey, rev2, plaintextData2);
 
@@ -341,7 +341,7 @@ export async function testUserSyncKeyChangeNoRev(
     encryptionKey1
   );
   expect(oldKeyLoadResult.success).to.eq(false);
-  expect(oldKeyLoadResult.error?.reason).to.eq("notfound");
+  expect(oldKeyLoadResult.error?.name).to.eq("NotFound");
 }
 
 export async function testUserSyncKeyChangeWithRev(
@@ -493,5 +493,5 @@ export async function testUserSyncKeyChangeWithRev(
     encryptionKey1
   );
   expect(oldKeyLoadResult.success).to.eq(false);
-  expect(oldKeyLoadResult.error?.reason).to.eq("notfound");
+  expect(oldKeyLoadResult.error?.name).to.eq("NotFound");
 }

--- a/apps/passport-server/test/user/testUserSync.ts
+++ b/apps/passport-server/test/user/testUserSync.ts
@@ -1,59 +1,497 @@
 import {
+  arrayBufferToHexString,
   EncryptedPacket,
+  HexString,
   passportDecrypt,
   passportEncrypt,
   PCDCrypto
 } from "@pcd/passport-crypto";
 import {
+  requestChangeBlobKey,
   requestEncryptedStorage,
-  requestUploadEncryptedStorage
+  requestUploadEncryptedStorage,
+  User
 } from "@pcd/passport-interface";
 import { expect } from "chai";
 import "chai-spies";
+import { randomBytes } from "crypto";
 import "mocha";
+import { v4 as uuid } from "uuid";
 import { Zupass } from "../../src/types";
 
-// TODO(artwyman): Extend this to test revision and conflict handling.
+async function fetchAndCheckStorage(
+  application: Zupass,
+  encryptionKey: HexString,
+  expectedRevision: string | undefined,
+  expectedPlaintextData: object
+): Promise<void> {
+  // Fetch storage
+  const fetchResult1 = await requestEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey
+  );
+  expect(fetchResult1.success).to.eq(true);
+  expect(fetchResult1.value?.revision).to.eq(expectedRevision);
 
-export async function testUserSync(application: Zupass): Promise<void> {
+  if (!fetchResult1.value?.encryptedBlob) {
+    throw new Error("expected value from loading e2ee");
+  }
+
+  // Decrypt storage
+  const decryptedData1: string = await passportDecrypt(
+    JSON.parse(fetchResult1.value.encryptedBlob) as EncryptedPacket,
+    encryptionKey
+  );
+  expect(JSON.parse(decryptedData1)).to.deep.eq(expectedPlaintextData);
+}
+
+export async function testUserSyncNoRev(application: Zupass): Promise<void> {
   const crypto = await PCDCrypto.newInstance();
   const encryptionKey = await crypto.generateRandomKey();
 
-  const plaintextData = {
+  const plaintextData1 = {
     test: "test",
     one: 1
   };
 
-  const encryptedData = await passportEncrypt(
-    JSON.stringify(plaintextData),
+  const encryptedData1 = await passportEncrypt(
+    JSON.stringify(plaintextData1),
     encryptionKey
   );
 
-  const uploadResult = await requestUploadEncryptedStorage(
+  // Storage shouldn't exist yet.
+  const initialLoadResult = await requestEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey
+  );
+  expect(initialLoadResult.success).to.eq(false);
+  expect(initialLoadResult.error?.reason).to.eq("notfound");
+
+  // Create storage
+  const uploadResult1 = await requestUploadEncryptedStorage(
     application.expressContext.localEndpoint,
     encryptionKey,
-    encryptedData
+    encryptedData1
+  );
+  expect(uploadResult1.error).to.eq(undefined);
+  expect(uploadResult1.success).to.eq(true);
+  expect(uploadResult1.value).to.not.be.undefined;
+  expect(uploadResult1.value?.revision).to.not.be.undefined;
+  const rev1 = uploadResult1.value?.revision;
+
+  await fetchAndCheckStorage(application, encryptionKey, rev1, plaintextData1);
+
+  const plaintextData2 = {
+    test: "test",
+    two: 2
+  };
+
+  const encryptedData2 = await passportEncrypt(
+    JSON.stringify(plaintextData2),
+    encryptionKey
   );
 
-  expect(uploadResult.error).to.eq(undefined);
-  expect(uploadResult.success).to.eq(true);
-
-  const secondLoadResult = await requestEncryptedStorage(
+  // Update storage
+  const uploadResult2 = await requestUploadEncryptedStorage(
     application.expressContext.localEndpoint,
+    encryptionKey,
+    encryptedData2
+  );
+  expect(uploadResult2.error).to.eq(undefined);
+  expect(uploadResult2.success).to.eq(true);
+  expect(uploadResult2.value).to.not.be.undefined;
+  expect(uploadResult2.value?.revision).to.not.be.undefined;
+  const rev2 = uploadResult2.value?.revision;
+  expect(rev2).to.not.eq(rev1);
+
+  await fetchAndCheckStorage(application, encryptionKey, rev2, plaintextData2);
+}
+
+export async function testUserSyncWithRev(application: Zupass): Promise<void> {
+  const crypto = await PCDCrypto.newInstance();
+  const encryptionKey = await crypto.generateRandomKey();
+
+  const plaintextData1 = {
+    test: "test",
+    one: 1
+  };
+
+  const encryptedData1 = await passportEncrypt(
+    JSON.stringify(plaintextData1),
     encryptionKey
   );
 
-  if (secondLoadResult.value == null) {
-    throw new Error("expected to be able to load e2ee");
-  }
-  if (!secondLoadResult.value.encryptedBlob) {
-    throw new Error("expected value from loading e2ee");
-  }
+  // Storage shouldn't exist yet.
+  const initialLoadResult = await requestEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey,
+    "0"
+  );
+  expect(initialLoadResult.success).to.eq(false);
+  expect(initialLoadResult.error?.reason).to.eq("notfound");
 
-  const decrypted: string = await passportDecrypt(
-    JSON.parse(secondLoadResult.value.encryptedBlob) as EncryptedPacket,
+  // Attempting update with base rev will result in notfound, not a conflict.
+  const notfoundUploadResult = await requestUploadEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey,
+    encryptedData1,
+    "0"
+  );
+  expect(notfoundUploadResult.value).to.eq(undefined);
+  expect(notfoundUploadResult.success).to.eq(false);
+  expect(notfoundUploadResult.error?.reason).to.eq("notfound");
+
+  // Create storage with no base rev (required for first write)
+  const uploadResult1 = await requestUploadEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey,
+    encryptedData1,
+    undefined /* baseRevision */
+  );
+  expect(uploadResult1.error).to.eq(undefined);
+  expect(uploadResult1.success).to.eq(true);
+  expect(uploadResult1.value).to.not.be.undefined;
+  expect(uploadResult1.value?.revision).to.not.be.undefined;
+  const rev1 = uploadResult1.value?.revision;
+
+  await fetchAndCheckStorage(application, encryptionKey, rev1, plaintextData1);
+
+  // Fetch with knownRevision should result in empty download
+  const fetchKnown1 = await requestEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey,
+    rev1
+  );
+  expect(fetchKnown1.success).to.eq(true);
+  expect(fetchKnown1.value?.revision).to.eq(rev1);
+  expect(fetchKnown1.value?.encryptedBlob).to.be.undefined;
+
+  const plaintextData2 = {
+    test: "test",
+    two: 2
+  };
+
+  const encryptedData2 = await passportEncrypt(
+    JSON.stringify(plaintextData2),
     encryptionKey
   );
 
-  expect(JSON.parse(decrypted)).to.deep.eq(plaintextData);
+  // Update storage with base rev
+  const uploadResult2 = await requestUploadEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey,
+    encryptedData2,
+    rev1
+  );
+  expect(uploadResult2.error).to.eq(undefined);
+  expect(uploadResult2.success).to.eq(true);
+  expect(uploadResult2.value).to.not.be.undefined;
+  expect(uploadResult2.value?.revision).to.not.be.undefined;
+  const rev2 = uploadResult2.value?.revision;
+  expect(rev2).to.not.eq(rev1);
+
+  await fetchAndCheckStorage(application, encryptionKey, rev2, plaintextData2);
+
+  const plaintextData3 = {
+    test: "test",
+    three: 3
+  };
+
+  const encryptedData3 = await passportEncrypt(
+    JSON.stringify(plaintextData3),
+    encryptionKey
+  );
+
+  // Attempt update with earlier base rev, receiving conflict with no changes
+  const conflictResult1 = await requestUploadEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey,
+    encryptedData3,
+    rev1
+  );
+  expect(conflictResult1.success).to.eq(false);
+  expect(conflictResult1.value).to.be.undefined;
+  expect(conflictResult1.error?.reason).to.eq("conflict");
+
+  await fetchAndCheckStorage(application, encryptionKey, rev2, plaintextData2);
+
+  // Attempt update with proper base rev, which should work after conflict
+  const uploadResult3 = await requestUploadEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey,
+    encryptedData3,
+    rev2
+  );
+  expect(uploadResult3.error).to.eq(undefined);
+  expect(uploadResult3.success).to.eq(true);
+  expect(uploadResult3.value).to.not.be.undefined;
+  expect(uploadResult3.value?.revision).to.not.be.undefined;
+  const rev3 = uploadResult3.value?.revision;
+  expect(rev3).to.not.eq(rev2);
+  expect(rev3).to.not.eq(rev1);
+
+  await fetchAndCheckStorage(application, encryptionKey, rev3, plaintextData3);
+}
+
+export async function testUserSyncKeyChangeNoRev(
+  application: Zupass,
+  user: User
+): Promise<void> {
+  if (!user.salt) {
+    throw new Error("user requires salt for this test");
+  }
+
+  const crypto = await PCDCrypto.newInstance();
+  const encryptionKey1 = await crypto.generateRandomKey();
+
+  const encryptionKey2 = await crypto.generateRandomKey();
+  const newSalt = arrayBufferToHexString(randomBytes(32));
+
+  const plaintextData1 = {
+    test: "test",
+    one: 1
+  };
+
+  const encryptedData1 = await passportEncrypt(
+    JSON.stringify(plaintextData1),
+    encryptionKey1
+  );
+
+  const rekeyedEncryptedData = await passportEncrypt(
+    JSON.stringify(plaintextData1),
+    encryptionKey2
+  );
+
+  // Attempt key change on nonexistant storage.
+  const noKeyResult = await requestChangeBlobKey(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptionKey2,
+    user.uuid,
+    newSalt,
+    rekeyedEncryptedData
+  );
+  expect(noKeyResult.success).to.eq(false);
+  expect(noKeyResult.value).to.be.undefined;
+  expect(noKeyResult.error?.name).to.eq("PasswordIncorrect");
+
+  // Create storage
+  const uploadResult1 = await requestUploadEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptedData1
+  );
+  expect(uploadResult1.error).to.eq(undefined);
+  expect(uploadResult1.success).to.eq(true);
+  expect(uploadResult1.value).to.not.be.undefined;
+  expect(uploadResult1.value?.revision).to.not.be.undefined;
+  const rev1 = uploadResult1.value?.revision;
+
+  await fetchAndCheckStorage(application, encryptionKey1, rev1, plaintextData1);
+
+  // Attempt key change on nonexistant user.
+  const noUserResult = await requestChangeBlobKey(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptionKey2,
+    uuid(),
+    newSalt,
+    rekeyedEncryptedData
+  );
+  expect(noUserResult.success).to.eq(false);
+  expect(noUserResult.value).to.be.undefined;
+  expect(noUserResult.error?.name).to.eq("UserNotFound");
+
+  // Attempt key change with unchanged salt
+  const noSaltResult = await requestChangeBlobKey(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptionKey2,
+    user.uuid,
+    user.salt,
+    rekeyedEncryptedData
+  );
+  expect(noSaltResult.success).to.eq(false);
+  expect(noSaltResult.value).to.be.undefined;
+  expect(noSaltResult.error?.name).to.eq("RequiresNewSalt");
+
+  // Successful key change.
+  const rekeyResult1 = await requestChangeBlobKey(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptionKey2,
+    user.uuid,
+    newSalt,
+    rekeyedEncryptedData
+  );
+  expect(rekeyResult1.success).to.eq(true);
+  expect(rekeyResult1.error).to.be.undefined;
+  expect(rekeyResult1.value?.revision).to.not.be.undefined;
+  expect(rekeyResult1.value?.revision).to.not.eq(rev1);
+  const rev2 = rekeyResult1.value?.revision;
+
+  // Update salt in user object.
+  user.salt = newSalt;
+
+  await fetchAndCheckStorage(application, encryptionKey2, rev2, plaintextData1);
+
+  // Storage shouldn't exist anymore under old key.
+  const oldKeyLoadResult = await requestEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey1
+  );
+  expect(oldKeyLoadResult.success).to.eq(false);
+  expect(oldKeyLoadResult.error?.reason).to.eq("notfound");
+}
+
+export async function testUserSyncKeyChangeWithRev(
+  application: Zupass,
+  user: User
+): Promise<void> {
+  if (!user.salt) {
+    throw new Error("user requires salt for this test");
+  }
+
+  const crypto = await PCDCrypto.newInstance();
+  const encryptionKey1 = await crypto.generateRandomKey();
+
+  const encryptionKey2 = await crypto.generateRandomKey();
+  const newSalt = arrayBufferToHexString(randomBytes(32));
+
+  const plaintextData1 = {
+    test: "test",
+    one: 1
+  };
+
+  const encryptedData1 = await passportEncrypt(
+    JSON.stringify(plaintextData1),
+    encryptionKey1
+  );
+
+  const plaintextData2 = {
+    test: "test",
+    two: 2
+  };
+
+  const encryptedData2 = await passportEncrypt(
+    JSON.stringify(plaintextData2),
+    encryptionKey1
+  );
+
+  const rekeyedEncryptedData = await passportEncrypt(
+    JSON.stringify(plaintextData2),
+    encryptionKey2
+  );
+
+  // Attempt key change on nonexistant storage.
+  const noKeyResult = await requestChangeBlobKey(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptionKey2,
+    user.uuid,
+    newSalt,
+    rekeyedEncryptedData,
+    "0"
+  );
+  expect(noKeyResult.success).to.eq(false);
+  expect(noKeyResult.value).to.be.undefined;
+  expect(noKeyResult.error?.name).to.eq("PasswordIncorrect");
+
+  // Create storage (no rev for initial creation)
+  const uploadResult1 = await requestUploadEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptedData1
+  );
+  expect(uploadResult1.error).to.eq(undefined);
+  expect(uploadResult1.success).to.eq(true);
+  expect(uploadResult1.value).to.not.be.undefined;
+  expect(uploadResult1.value?.revision).to.not.be.undefined;
+  const rev1 = uploadResult1.value?.revision;
+
+  await fetchAndCheckStorage(application, encryptionKey1, rev1, plaintextData1);
+
+  // Update storage with base rev to create rev2
+  const uploadResult2 = await requestUploadEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptedData2,
+    rev1
+  );
+  expect(uploadResult2.error).to.eq(undefined);
+  expect(uploadResult2.success).to.eq(true);
+  expect(uploadResult2.value).to.not.be.undefined;
+  expect(uploadResult2.value?.revision).to.not.be.undefined;
+  const rev2 = uploadResult2.value?.revision;
+  expect(rev2).to.not.eq(rev1);
+
+  await fetchAndCheckStorage(application, encryptionKey1, rev2, plaintextData2);
+
+  // Attempt key change on previous rev.
+  const conflictResult = await requestChangeBlobKey(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptionKey2,
+    user.uuid,
+    newSalt,
+    rekeyedEncryptedData,
+    rev1
+  );
+  expect(conflictResult.success).to.eq(false);
+  expect(conflictResult.value).to.be.undefined;
+  expect(conflictResult.error?.name).to.eq("Conflict");
+
+  // Attempt key change on nonexistant user.
+  const noUserResult = await requestChangeBlobKey(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptionKey2,
+    uuid(),
+    newSalt,
+    rekeyedEncryptedData,
+    rev2
+  );
+  expect(noUserResult.success).to.eq(false);
+  expect(noUserResult.value).to.be.undefined;
+  expect(noUserResult.error?.name).to.eq("UserNotFound");
+
+  // Attempt key change with unchanged salt
+  const noSaltResult = await requestChangeBlobKey(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptionKey2,
+    user.uuid,
+    user.salt,
+    rekeyedEncryptedData,
+    rev2
+  );
+  expect(noSaltResult.success).to.eq(false);
+  expect(noSaltResult.value).to.be.undefined;
+  expect(noSaltResult.error?.name).to.eq("RequiresNewSalt");
+
+  // Successful key change.
+  const rekeyResult1 = await requestChangeBlobKey(
+    application.expressContext.localEndpoint,
+    encryptionKey1,
+    encryptionKey2,
+    user.uuid,
+    newSalt,
+    rekeyedEncryptedData,
+    rev2
+  );
+  expect(rekeyResult1.success).to.eq(true);
+  expect(rekeyResult1.error).to.be.undefined;
+  expect(rekeyResult1.value?.revision).to.not.be.undefined;
+  expect(rekeyResult1.value?.revision).to.not.eq(rev1);
+  const rev3 = rekeyResult1.value?.revision;
+
+  await fetchAndCheckStorage(application, encryptionKey2, rev3, plaintextData2);
+
+  // Storage shouldn't exist anymore under old key.
+  const oldKeyLoadResult = await requestEncryptedStorage(
+    application.expressContext.localEndpoint,
+    encryptionKey1
+  );
+  expect(oldKeyLoadResult.success).to.eq(false);
+  expect(oldKeyLoadResult.error?.reason).to.eq("notfound");
 }

--- a/packages/passport-interface/src/RequestTypes.ts
+++ b/packages/passport-interface/src/RequestTypes.ts
@@ -4,6 +4,7 @@ import { ArgsOf, PCDOf, PCDPackage, SerializedPCD } from "@pcd/pcd-types";
 import { SemaphoreSignaturePCD } from "@pcd/semaphore-signature-pcd";
 import { PendingPCDStatus } from "./PendingPCDUtils";
 import { Feed } from "./SubscriptionManager";
+import { NamedAPIError } from "./api/apiResult";
 
 /**
  * Ask the server to prove a PCD. The server reponds with a {@link PendingPCD}
@@ -177,15 +178,13 @@ export interface ChangeBlobKeyResponseValue {
 }
 
 /**
- * A {@link ChangeBlobKeyRequest} can fail for a number of reasons.
+ * A {@link ChangeBlobKeyRequest} can fail with a few non-standard named errors:
+ * PasswordIncorrect if there is no blob for the given key
+ * UserNotFound if the user does not exist
+ * RequiresNewSalt if the given salt is the same as the old salt
+ * Conflict if knownRevision is specified and doesn't match
  */
-export type ChangeBlobKeyError = { detailedMessage?: string } & (
-  | { name: "PasswordIncorrect" }
-  | { name: "UserNotFound" }
-  | { name: "RequiresNewSalt" }
-  | { name: "Conflict" }
-  | { name: "ServerError" }
-);
+export type ChangeBlobKeyError = NamedAPIError;
 
 /**
  * Ask the server to check whether this ticket is still eligible to be checked in.

--- a/packages/passport-interface/src/RequestTypes.ts
+++ b/packages/passport-interface/src/RequestTypes.ts
@@ -64,14 +64,14 @@ export interface UploadEncryptedStorageRequest {
    * updates.
    *
    * If specified, this is the previous revision of stored data which the
-   * client is aware of and included in its updates.  If this does not match
+   * client is aware of and has included in its updates.  If this does not match
    * the latest revision available on the server, the request will fail without
    * making any changes.
    *
    * If this field is absent, the new blob is always saved, overwriting any
    * existing revision.
    */
-  baseRevision?: string;
+  knownRevision?: string;
 }
 
 /**
@@ -155,14 +155,14 @@ export interface ChangeBlobKeyRequest {
    * updates.
    *
    * If specified, this is the previous revision of stored data which the
-   * client is aware of and included in its updates.  If this does not match
+   * client is aware of and has included in its updates.  If this does not match
    * the latest revision available on the server, the request will fail without
    * making any changes.
    *
    * If this field is absent, the new blob is always saved, overwriting any
    * existing revision.
    */
-  baseRevision?: string;
+  knownRevision?: string;
 }
 
 /**

--- a/packages/passport-interface/src/RequestTypes.ts
+++ b/packages/passport-interface/src/RequestTypes.ts
@@ -1,5 +1,4 @@
 import { EdDSATicketPCD } from "@pcd/eddsa-ticket-pcd";
-import { EncryptedPacket } from "@pcd/passport-crypto";
 import { PCDAction } from "@pcd/pcd-collection";
 import { ArgsOf, PCDOf, PCDPackage, SerializedPCD } from "@pcd/pcd-types";
 import { SemaphoreSignaturePCD } from "@pcd/semaphore-signature-pcd";
@@ -59,12 +58,32 @@ export interface UploadEncryptedStorageRequest {
    * An encrypted and stringified version of {@link EncryptedStorage}
    */
   encryptedBlob: string;
+
+  /**
+   * Optional field allowing the client to detect and avoid conflicting
+   * updates.
+   *
+   * If specified, this is the previous revision of stored data which the
+   * client is aware of and included in its updates.  If this does not match
+   * the latest revision available on the server, the request will fail without
+   * making any changes.
+   *
+   * If this field is absent, the new blob is always saved, overwriting any
+   * existing revision.
+   */
+  baseRevision?: string;
 }
 
 /**
  * Response to {@link UploadEncryptedStorageRequest}
  */
-export type UploadEncryptedStorageResponseValue = undefined;
+export interface UploadEncryptedStorageResponseValue {
+  /**
+   * The revision assigned to identify the stored blob.  Revision is assigned by
+   * the server and can be used later to identify this blob and avoid conflicts.
+   */
+  revision: string;
+}
 
 /**
  * Ask the server for an e2ee backup of a user's data given a `blobKey`.
@@ -75,6 +94,30 @@ export interface DownloadEncryptedStorageRequest {
    * the encryption key.
    */
   blobKey: string;
+
+  /**
+   * Optional field indicating the revision of the latest blob already known to
+   * the client.  If this matches the latest blob stored on the server, the
+   * request will succeed, but the result will not contain any blob.
+   */
+  knownRevision?: string;
+}
+
+/**
+ * Response to {@link DownloadEncryptedStorageRequest}
+ */
+export interface DownloadEncryptedStorageResponseValue {
+  /**
+   * The retrieved blob for the given key.  This will be absent if the request
+   * included a `knownRevision` which matched the latest revision.
+   */
+  encryptedBlob?: string;
+
+  /**
+   * The revision identifying this blob on the server.  Revision is assigned by
+   * the server and can be used later to identify this blob and avoid conflicts.
+   */
+  revision: string;
 }
 
 /**
@@ -86,28 +129,52 @@ export interface ChangeBlobKeyRequest {
    * The original hashed encryption key to be deleted.
    */
   oldBlobKey: string;
+
   /**
    * The new hashed encryption key to be added.
    */
   newBlobKey: string;
+
   /**
    * UUID of the user making the request.
    */
   uuid: string;
+
   /**
    * The salt used in generating the new blob key.
    */
   newSalt: string;
+
   /**
    * The encrypted and stringified version of {@link EncryptedStorage} to save
    */
   encryptedBlob: string;
+
+  /**
+   * Optional field allowing the client to detect and avoid conflicting
+   * updates.
+   *
+   * If specified, this is the previous revision of stored data which the
+   * client is aware of and included in its updates.  If this does not match
+   * the latest revision available on the server, the request will fail without
+   * making any changes.
+   *
+   * If this field is absent, the new blob is always saved, overwriting any
+   * existing revision.
+   */
+  baseRevision?: string;
 }
 
 /**
  * Response to {@link ChangeBlobKeyRequest}
  */
-export type ChangeBlobKeyResponseValue = undefined;
+export interface ChangeBlobKeyResponseValue {
+  /**
+   * The revision assigned to identify the stored blob.  Revision is assigned by
+   * the server and can be used later to identify this blob and avoid conflicts.
+   */
+  revision: string;
+}
 
 /**
  * A {@link ChangeBlobKeyRequest} can fail for a number of reasons.
@@ -319,12 +386,6 @@ export type CreateNewUserRequest = {
    */
   salt: string | null;
 };
-
-/**
- * Zupass responds with this when you ask to load an end-to-end
- * encrypted blob.
- */
-export type EncryptedStorageResultValue = EncryptedPacket;
 
 /**
  * Zupass responds with this when you ask it if it is able to

--- a/packages/passport-interface/src/RequestTypes.ts
+++ b/packages/passport-interface/src/RequestTypes.ts
@@ -183,6 +183,7 @@ export type ChangeBlobKeyError = { detailedMessage?: string } & (
   | { name: "PasswordIncorrect" }
   | { name: "UserNotFound" }
   | { name: "RequiresNewSalt" }
+  | { name: "Conflict" }
   | { name: "ServerError" }
 );
 

--- a/packages/passport-interface/src/api/apiResult.ts
+++ b/packages/passport-interface/src/api/apiResult.ts
@@ -44,7 +44,7 @@ export type ResultMapper<T extends APIResult<unknown, unknown>> = {
  * Convenience type for errors which have a reason interpreted by the API
  * layer, as well as error text.
  */
-export interface ErrorWithReason<TReason> {
+export interface ErrorWithReason<TReason = string> {
   reason: TReason;
   errText: string;
 }

--- a/packages/passport-interface/src/api/apiResult.ts
+++ b/packages/passport-interface/src/api/apiResult.ts
@@ -41,10 +41,126 @@ export type ResultMapper<T extends APIResult<unknown, unknown>> = {
 };
 
 /**
- * Convenience type for errors which have a reason interpreted by the API
- * layer, as well as error text.
+ * Convenience type for errors which have a machine-readable name which
+ * can be provided by the server, or produced by the API layer
  */
-export interface ErrorWithReason<TReason = string> {
-  reason: TReason;
-  errText: string;
+export interface NamedAPIError {
+  name: string;
+  detailedMessage?: string;
+  code?: number;
+}
+
+/**
+ * Default value for `APIErrorWithReason.name` for cases when a more
+ * specific name cannot be determined.
+ */
+const ERROR_REASON_UNKNOWN = "Unknown";
+
+/**
+ * Helper function which can be used directly in the `onError` field of a
+ * ResultMapper to produce an error type of APIErrorWithReason.  This
+ * can handle server-provided errors which conform to the right type, as well
+ * as server or local errors which do not.
+ *
+ * This function will allow the server to specify error contents via
+ * an `error` field in the resulting JSON.  Fields which aren't provided
+ * by the server (or which aren't the expected type) will be filled in by
+ * this function instead.  Unknown fields from the server will be passed
+ * through unmodified.
+ *
+ * The APIResult returned is always an error with `success===false`.  The
+ * result type here is only a placeholder.
+ */
+export async function onNamedAPIError<TResult>(
+  resText: string,
+  errorCode: number | undefined
+): Promise<APIResult<TResult, NamedAPIError>> {
+  // If server gives us valid JSON, parse it for potential encoded error.
+  let apiError: any = {};
+  let serverProvidedError = false;
+  console.log(resText);
+  try {
+    const resJSON = JSON.parse(resText);
+    // Server must at least specify error.name for us to take its other
+    // fields.  If so, we take all fields, but delete any with the wrong type.
+    if (resJSON.error?.name && typeof resJSON.error.name == "string") {
+      serverProvidedError = true;
+      apiError = resJSON.error;
+      if (
+        "detailedMessage" in apiError &&
+        typeof apiError.detailedMessage != "string"
+      ) {
+        delete apiError.detailedMessage;
+      }
+      if ("code" in apiError && typeof apiError.code != "number") {
+        delete apiError.code;
+      }
+    } else {
+      // If server didn't provide a pre-filled error object, we take the full
+      // server text as detailedMessage.
+      apiError.detailedMessage = resText;
+    }
+  } catch (e) {
+    // Just continue with serverProvidedError===false
+  }
+
+  // If server didn't provide a pre-filled error object, we take the full
+  // server text as detailedMessage.
+  if (!serverProvidedError) {
+    apiError.detailedMessage = resText;
+  }
+
+  // If server hasn't already given us an error code, use the local one,
+  // which may or may not be an HTTP status code.
+  if (apiError.code === undefined && errorCode !== undefined) {
+    apiError.code = errorCode;
+  }
+
+  // If we got a code (likely HTTP status), we can use it to fill in a missing
+  // "name".
+  console.log(apiError);
+  if (apiError.name === undefined && apiError.code !== undefined) {
+    apiError.name = apiErrorReasonFromCode(apiError.code);
+  }
+
+  // If we still haven't figured out a name, it is unknown.
+  if (apiError.name === undefined) {
+    apiError.name = ERROR_REASON_UNKNOWN;
+  }
+
+  console.log(apiError);
+  return { success: false, error: apiError satisfies NamedAPIError };
+}
+
+/**
+ * Makes a best effort to pick a useful name code for a given error code.
+ * The code is assumed to be an HTTP status code if it matches a known status.
+ * This isn't intended to be an exhaustive list of possible code, just
+ * a few codes known to be used in our API, which can be extended later.
+ */
+export function apiErrorReasonFromCode(code: number): string | undefined {
+  switch (code) {
+    case 400:
+      return "BadRequest";
+    case 401:
+      return "Unauthorized";
+    case 403:
+      return "Forbidden";
+    case 404:
+      return "NotFound";
+    case 409:
+      return "Conflict";
+    case 410:
+      return "Gone";
+
+    case 500:
+      return "InternalServerError";
+    case 501:
+      return "NotImplemented";
+    case 503:
+      return "ServiceUnavailable";
+
+    default:
+      return undefined;
+  }
 }

--- a/packages/passport-interface/src/api/apiResult.ts
+++ b/packages/passport-interface/src/api/apiResult.ts
@@ -39,3 +39,12 @@ export type ResultMapper<T extends APIResult<unknown, unknown>> = {
   onValue: GetResultValue<T>;
   onError: GetError<T>;
 };
+
+/**
+ * Convenience type for errors which have a reason interpreted by the API
+ * layer, as well as error text.
+ */
+export interface ErrorWithReason<TReason> {
+  reason: TReason;
+  errText: string;
+}

--- a/packages/passport-interface/src/api/requestChangeBlobKey.ts
+++ b/packages/passport-interface/src/api/requestChangeBlobKey.ts
@@ -23,7 +23,7 @@ export async function requestChangeBlobKey(
   uuid: string,
   newSalt: string,
   encryptedStorage: EncryptedPacket,
-  baseRevision?: string
+  knownRevision?: string
 ): Promise<ChangeBlobKeyResult> {
   return httpPost<ChangeBlobKeyResult>(
     urlJoin(zupassServerUrl, `/sync/changeBlobKey`),
@@ -65,7 +65,7 @@ export async function requestChangeBlobKey(
       newSalt,
       encryptedBlob: JSON.stringify(encryptedStorage),
       uuid,
-      baseRevision
+      knownRevision
     } satisfies ChangeBlobKeyRequest
   );
 }

--- a/packages/passport-interface/src/api/requestChangeBlobKey.ts
+++ b/packages/passport-interface/src/api/requestChangeBlobKey.ts
@@ -27,7 +27,10 @@ export async function requestChangeBlobKey(
   return httpPost(
     urlJoin(zupassServerUrl, `/sync/changeBlobKey`),
     {
-      onValue: async () => ({ value: undefined, success: true }),
+      onValue: async (resText) => ({
+        value: JSON.parse(resText) as ChangeBlobKeyResponseValue,
+        success: true
+      }),
       onError: async (resText) => JSON.parse(resText)
     },
     {

--- a/packages/passport-interface/src/api/requestChangeBlobKey.ts
+++ b/packages/passport-interface/src/api/requestChangeBlobKey.ts
@@ -5,7 +5,7 @@ import {
   ChangeBlobKeyRequest,
   ChangeBlobKeyResponseValue
 } from "../RequestTypes";
-import { APIResult } from "./apiResult";
+import { APIResult, onNamedAPIError } from "./apiResult";
 import { httpPost } from "./makeRequest";
 
 /**
@@ -32,32 +32,7 @@ export async function requestChangeBlobKey(
         value: JSON.parse(resText) as ChangeBlobKeyResponseValue,
         success: true
       }),
-      onError: async (resText: string) => {
-        // TODO(atwyman): Clean up this inconsistent client/server error handling pattern.
-        const res = JSON.parse(resText);
-        if (res.error?.name) {
-          return {
-            error: res.error satisfies ChangeBlobKeyError,
-            success: false
-          };
-        } else if (res.error?.detailedMessage) {
-          return {
-            error: {
-              ...res.error,
-              name: "ServerError"
-            },
-            success: false
-          };
-        } else {
-          return {
-            error: {
-              name: "ServerError",
-              detailedMessage: resText
-            },
-            success: false
-          };
-        }
-      }
+      onError: onNamedAPIError
     },
     {
       oldBlobKey,

--- a/packages/passport-interface/src/api/requestDownloadAndDecryptStorage.ts
+++ b/packages/passport-interface/src/api/requestDownloadAndDecryptStorage.ts
@@ -31,7 +31,8 @@ export async function requestDownloadAndDecryptStorage(
       return { error: "couldn't download e2ee data", success: false };
     }
 
-    // TODO(artwyman): Add and implement revision handling.
+    // TODO(artwyman): Add and implement revision handling.  Also propagate
+    // different types of errors so they're not all incorrect password.
     if (!storageResult.value.encryptedBlob) {
       console.error("unexpectedly missing e2ee data");
       return { error: "unexpectedly missing e2ee data", success: false };

--- a/packages/passport-interface/src/api/requestDownloadAndDecryptStorage.ts
+++ b/packages/passport-interface/src/api/requestDownloadAndDecryptStorage.ts
@@ -1,4 +1,8 @@
-import { getHash, passportDecrypt } from "@pcd/passport-crypto";
+import {
+  EncryptedPacket,
+  getHash,
+  passportDecrypt
+} from "@pcd/passport-crypto";
 import { getErrorMessage } from "@pcd/util";
 import { SyncedEncryptedStorage } from "../EncryptedStorage";
 import { APIResult } from "./apiResult";
@@ -27,7 +31,16 @@ export async function requestDownloadAndDecryptStorage(
       return { error: "couldn't download e2ee data", success: false };
     }
 
-    const decrypted = await passportDecrypt(storageResult.value, encryptionKey);
+    // TODO(artwyman): Add and implement revision handling.
+    if (!storageResult.value.encryptedBlob) {
+      console.error("unexpectedly missing e2ee data");
+      return { error: "unexpectedly missing e2ee data", success: false };
+    }
+    const encryptedStorage = JSON.parse(
+      storageResult.value.encryptedBlob
+    ) as EncryptedPacket;
+
+    const decrypted = await passportDecrypt(encryptedStorage, encryptionKey);
     return {
       value: JSON.parse(decrypted) as SyncedEncryptedStorage,
       success: true

--- a/packages/passport-interface/src/api/requestEncryptedStorage.ts
+++ b/packages/passport-interface/src/api/requestEncryptedStorage.ts
@@ -1,7 +1,7 @@
 import urlJoin from "url-join";
 import {
   DownloadEncryptedStorageRequest,
-  EncryptedStorageResultValue
+  DownloadEncryptedStorageResponseValue
 } from "../RequestTypes";
 import { APIResult } from "./apiResult";
 import { httpGetSimple } from "./makeRequest";
@@ -15,16 +15,18 @@ import { httpGetSimple } from "./makeRequest";
  */
 export async function requestEncryptedStorage(
   zupassServerUrl: string,
-  blobKey: string
+  blobKey: string,
+  knownRevision?: string
 ): Promise<EncryptedStorageResult> {
   return httpGetSimple(
     urlJoin(zupassServerUrl, "/sync/load"),
     async (resText) => ({
-      value: JSON.parse(resText) as EncryptedStorageResultValue,
+      value: JSON.parse(resText) as DownloadEncryptedStorageResponseValue,
       success: true
     }),
-    { blobKey } satisfies DownloadEncryptedStorageRequest
+    { blobKey, knownRevision } satisfies DownloadEncryptedStorageRequest
   );
 }
 
-export type EncryptedStorageResult = APIResult<EncryptedStorageResultValue>;
+export type EncryptedStorageResult =
+  APIResult<DownloadEncryptedStorageResponseValue>;

--- a/packages/passport-interface/src/api/requestEncryptedStorage.ts
+++ b/packages/passport-interface/src/api/requestEncryptedStorage.ts
@@ -3,7 +3,7 @@ import {
   DownloadEncryptedStorageRequest,
   DownloadEncryptedStorageResponseValue
 } from "../RequestTypes";
-import { APIResult, ErrorWithReason } from "./apiResult";
+import { APIResult, NamedAPIError, onNamedAPIError } from "./apiResult";
 import { httpGet } from "./makeRequest";
 
 /**
@@ -25,13 +25,7 @@ export async function requestEncryptedStorage(
         value: JSON.parse(resText) as DownloadEncryptedStorageResponseValue,
         success: true
       }),
-      onError: async (resText: string, statusCode: number | undefined) => ({
-        error: {
-          reason: statusCode === 404 ? "notfound" : undefined,
-          errText: resText
-        },
-        success: false
-      })
+      onError: onNamedAPIError
     },
     { blobKey, knownRevision } satisfies DownloadEncryptedStorageRequest
   );
@@ -39,5 +33,5 @@ export async function requestEncryptedStorage(
 
 export type EncryptedStorageResult = APIResult<
   DownloadEncryptedStorageResponseValue,
-  ErrorWithReason<"notfound" | undefined>
+  NamedAPIError
 >;

--- a/packages/passport-interface/src/api/requestUploadEncryptedStorage.ts
+++ b/packages/passport-interface/src/api/requestUploadEncryptedStorage.ts
@@ -4,7 +4,7 @@ import {
   UploadEncryptedStorageRequest,
   UploadEncryptedStorageResponseValue
 } from "../RequestTypes";
-import { APIResult, ErrorWithReason } from "./apiResult";
+import { APIResult, NamedAPIError, onNamedAPIError } from "./apiResult";
 import { httpPost } from "./makeRequest";
 
 /**
@@ -26,18 +26,7 @@ export async function requestUploadEncryptedStorage(
         value: JSON.parse(resText) as UploadEncryptedStorageResponseValue,
         success: true
       }),
-      onError: async (resText: string, statusCode: number | undefined) => ({
-        error: {
-          reason:
-            statusCode === 404
-              ? "notfound"
-              : statusCode === 409
-              ? "conflict"
-              : undefined,
-          errText: resText
-        },
-        success: false
-      })
+      onError: onNamedAPIError
     },
     {
       blobKey,
@@ -49,5 +38,5 @@ export async function requestUploadEncryptedStorage(
 
 export type UploadEncryptedStorageResult = APIResult<
   UploadEncryptedStorageResponseValue,
-  ErrorWithReason<"notfound" | "conflict" | undefined>
+  NamedAPIError
 >;

--- a/packages/passport-interface/src/api/requestUploadEncryptedStorage.ts
+++ b/packages/passport-interface/src/api/requestUploadEncryptedStorage.ts
@@ -16,14 +16,19 @@ import { httpPostSimple } from "./makeRequest";
 export async function requestUploadEncryptedStorage(
   zupassServerUrl: string,
   blobKey: string,
-  encryptedStorage: EncryptedPacket
+  encryptedStorage: EncryptedPacket,
+  baseRevision?: string
 ): Promise<UploadEncryptedStorageResult> {
   return httpPostSimple(
     urlJoin(zupassServerUrl, `/sync/save`),
-    async () => ({ value: undefined, success: true }),
+    async (resText: string) => ({
+      value: JSON.parse(resText) as UploadEncryptedStorageResponseValue,
+      success: true
+    }),
     {
       blobKey,
-      encryptedBlob: JSON.stringify(encryptedStorage)
+      encryptedBlob: JSON.stringify(encryptedStorage),
+      baseRevision
     } satisfies UploadEncryptedStorageRequest
   );
 }

--- a/packages/passport-interface/src/api/requestUploadEncryptedStorage.ts
+++ b/packages/passport-interface/src/api/requestUploadEncryptedStorage.ts
@@ -17,7 +17,7 @@ export async function requestUploadEncryptedStorage(
   zupassServerUrl: string,
   blobKey: string,
   encryptedStorage: EncryptedPacket,
-  baseRevision?: string
+  knownRevision?: string
 ): Promise<UploadEncryptedStorageResult> {
   return httpPost<UploadEncryptedStorageResult>(
     urlJoin(zupassServerUrl, `/sync/save`),
@@ -42,7 +42,7 @@ export async function requestUploadEncryptedStorage(
     {
       blobKey,
       encryptedBlob: JSON.stringify(encryptedStorage),
-      baseRevision
+      knownRevision
     } satisfies UploadEncryptedStorageRequest
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3107,69 +3107,6 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz#fe2aa90e6df050a11cd57f5c0f47b0641fd2cad3"
   integrity sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==
 
-"@pcd/passport-ui@0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@pcd/passport-ui/-/passport-ui-0.6.2.tgz#6ff846106503bf183b2267d1cb82a83c0298b7ce"
-  integrity sha512-2i2eAKgDzFbAfHzwT7J13zZth3fQx5s7imCCvs2d1Q3QPJ4bbRQEawdYciuyjJHZQkejoDp04JxpfAJx4iZimw==
-  dependencies:
-    "@pcd/pcd-types" "0.6.3"
-    pako "^2.1.0"
-    qr-image "^3.2.0"
-    react "^18.2.0"
-    styled-components "^5.3.9"
-
-"@pcd/pcd-types@0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@pcd/pcd-types/-/pcd-types-0.6.3.tgz#d7dad707807c99c89104312ddea3daad448e7dbd"
-  integrity sha512-uGbE5T7aY9j/dlwWc5WhXN6iWwNYXjWVDzUc1enno+vFJSG1tjY7Eqwoq57OlLMykEjRmEvNkeWtTSO4hWoxBQ==
-
-"@pcd/rsa-pcd@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@pcd/rsa-pcd/-/rsa-pcd-0.1.2.tgz#41d4b6046f901431b0cd110326e319b54a201390"
-  integrity sha512-sxFoU2vMZihZZrz6mtD+KUYndUElv2KFBV+U9VYoTVEveaGZ8w7/Ov2p0SFARKiH0VfTh+WNcM64g92W5FOZfQ==
-  dependencies:
-    "@pcd/passport-ui" "0.6.2"
-    "@pcd/pcd-types" "0.6.3"
-    chai "^4.3.7"
-    js-sha256 "^0.9.0"
-    json-bigint "^1.0.0"
-    node-rsa "^1.1.1"
-    react "^18.2.0"
-    styled-components "^5.3.9"
-    uuid "^9.0.0"
-
-"@pcd/rsa-ticket-pcd@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@pcd/rsa-ticket-pcd/-/rsa-ticket-pcd-0.1.2.tgz#57e4c81f9eb51c07e489f3aaa87099e68c113f50"
-  integrity sha512-kUQUhpqAXw1hdI+sxsHrddg1h3qKKyLBwDAhOo4C56TeHXGcwXnNkNA7RoHivlCcSKLrXrzQwE7SiTQHqsa7qQ==
-  dependencies:
-    "@pcd/passport-ui" "0.6.2"
-    "@pcd/pcd-types" "0.6.3"
-    "@pcd/rsa-pcd" "0.1.2"
-    chai "^4.3.7"
-    js-sha256 "^0.9.0"
-    json-bigint "^1.0.0"
-    node-rsa "^1.1.1"
-    react "^18.2.0"
-    styled-components "^5.3.9"
-    uuid "^9.0.0"
-
-"@pcd/webauthn-pcd@0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@pcd/webauthn-pcd/-/webauthn-pcd-0.6.2.tgz#f59f349935e0ddf9aec1a44000e20c0717ec9803"
-  integrity sha512-9zLrjv6C/75ZBT/isi/SlugVzazejXKsKHr+2qDmRGE2TogjKy2PQYBB2X2AbXCv3l/izy0dB5Cwh+65jT4VzQ==
-  dependencies:
-    "@pcd/pcd-types" "0.6.3"
-    "@simplewebauthn/browser" "^7.2.0"
-    "@simplewebauthn/server" "^7.2.0"
-    "@simplewebauthn/typescript-types" "^7.0.0"
-    "@types/expect" "^24.3.0"
-    "@types/jest" "^29.5.0"
-    "@types/json-bigint" "^1.0.1"
-    json-bigint "^1.0.0"
-    typescript "^4.5.2"
-    uuid "^9.0.0"
-
 "@peculiar/asn1-android@^2.3.3":
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-android/-/asn1-android-2.3.6.tgz#20363c23bc5b9a91f7ffd80d7c3842dccff8c20b"
@@ -4123,13 +4060,6 @@
   dependencies:
     email-validator "*"
 
-"@types/expect@^24.3.0":
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/@types/expect/-/expect-24.3.0.tgz#d7cab8b3c10c2d92a0cbb31981feceb81d3486f1"
-  integrity sha512-aq5Z+YFBz5o2b6Sp1jigx5nsmoZMK5Ceurjwy6PZmRv7dEi1jLtkARfvB1ME+OXJUG+7TZUDcv3WoCr/aor6dQ==
-  dependencies:
-    expect "*"
-
 "@types/express-serve-static-core@^4.17.18", "@types/express-serve-static-core@^4.17.33":
   version "4.17.36"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz#baa9022119bdc05a4adfe740ffc97b5f9360e545"
@@ -4528,28 +4458,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.22", "@types/react@^18.2.6":
+"@types/react@*", "@types/react@18.0.22", "@types/react@18.2.20", "@types/react@^18.0.22", "@types/react@^18.2.6":
   version "18.2.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
   integrity sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@18.0.22":
-  version "18.0.22"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.22.tgz#97782d995d999617de116cf61f437f1351036fc7"
-  integrity sha512-4yWc5PyCkZN8ke8K9rQHkTXxHIWHxLzzW6RI1kXVoepkD3vULpKzC2sDtAMKn78h92BRYuzf+7b/ms7ajE6hFw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@18.2.20":
-  version "18.2.20"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.20.tgz#1605557a83df5c8a2cc4eeb743b3dfc0eb6aaeb2"
-  integrity sha512-WKNtmsLWJM/3D5mG4U84cysVY31ivmyw85dE84fOCk5Hx78wezB/XEjVPWl2JTZ5FkEeaTJf+VgUAUn3PE7Isw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -7768,7 +7680,7 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@*, expect@^29.0.0, expect@^29.7.0:
+expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
   integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
@@ -13905,12 +13817,7 @@ typedoc@^0.25.1:
     minimatch "^9.0.3"
     shiki "^0.14.1"
 
-typescript@5.1.6:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
-
-typescript@^4.5.2, typescript@^4.9.5:
+typescript@5.1.6, typescript@^4.5.2, typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
Part of Phase 1 of safer sync of user's PCDs.  Added `revision` field to E2EE storage, incremented on every update and returned by all requests.  Users can use it in 2 ways:

- Set knownRevision when downloading in order to skip the download if there aren't any updates.
- Set baseRevision when mutating and the update will signal a conflict rather than clobbering.

The revision field is plumbed through the API at all levels, but not used in any of the client code yet.  That will be a separate PR.  This PR needs some more tests before I finalize it, but is functionally complete.

Note that this PR does change the return type of some client requests, so will cause clients with stale code to get errors.  Those errors should clear up after a page reload, and shouldn't cause anything to get permanently stuck.
