### PR TITLE
don't save userInvalid/userChangedPassword in localstorage

### DIFF
--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -37,7 +37,6 @@ import {
 } from "../src/dispatch";
 import { Emitter } from "../src/emitter";
 import {
-  loadAnotherDeviceChangedPassword,
   loadEncryptionKey,
   loadIdentity,
   loadPCDs,
@@ -186,8 +185,6 @@ async function loadInitialState(): Promise<AppState> {
   const self = loadSelf();
   const pcds = await loadPCDs();
   const encryptionKey = loadEncryptionKey();
-
-  const anotherDeviceChangedPassword = loadAnotherDeviceChangedPassword();
   const subscriptions = await loadSubscriptions();
 
   subscriptions.updatedEmitter.listen(() => saveSubscriptions(subscriptions));
@@ -213,7 +210,6 @@ async function loadInitialState(): Promise<AppState> {
     pcds,
     identity,
     modal,
-    anotherDeviceChangedPassword,
     subscriptions,
     resolvingSubscriptionId: undefined
   };

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -31,9 +31,9 @@ import {
 import { addDefaultSubscriptions } from "../src/defaultSubscriptions";
 import {
   Action,
+  dispatch,
   StateContext,
-  StateContextState,
-  dispatch
+  StateContextState
 } from "../src/dispatch";
 import { Emitter } from "../src/emitter";
 import {
@@ -43,7 +43,6 @@ import {
   loadPCDs,
   loadSelf,
   loadSubscriptions,
-  loadUserInvalid,
   saveIdentity,
   saveSubscriptions
 } from "../src/localstorage";
@@ -188,7 +187,6 @@ async function loadInitialState(): Promise<AppState> {
   const pcds = await loadPCDs();
   const encryptionKey = loadEncryptionKey();
 
-  const userInvalid = loadUserInvalid();
   const anotherDeviceChangedPassword = loadAnotherDeviceChangedPassword();
   const subscriptions = await loadSubscriptions();
 
@@ -200,9 +198,7 @@ async function loadInitialState(): Promise<AppState> {
 
   let modal = "" as AppState["modal"];
 
-  if (userInvalid) {
-    modal = "invalid-participant";
-  } else if (
+  if (
     // If on Zupass legacy login, ask user to set passwrod
     self != null &&
     self.salt == null
@@ -217,7 +213,6 @@ async function loadInitialState(): Promise<AppState> {
     pcds,
     identity,
     modal,
-    userInvalid: userInvalid,
     anotherDeviceChangedPassword,
     subscriptions,
     resolvingSubscriptionId: undefined

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -33,8 +33,7 @@ import {
   saveIdentity,
   savePCDs,
   saveSelf,
-  saveSubscriptions,
-  saveUserInvalid
+  saveSubscriptions
 } from "./localstorage";
 import { getPackages } from "./pcdPackages";
 import { hasPendingRequest } from "./sessionStorage";
@@ -497,7 +496,6 @@ async function saveNewPasswordAndBroadcast(
 }
 
 function userInvalid(update: ZuUpdate) {
-  saveUserInvalid(true);
   update({
     userInvalid: true,
     modal: "invalid-participant"

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -28,7 +28,6 @@ import { addDefaultSubscriptions } from "./defaultSubscriptions";
 import {
   loadEncryptionKey,
   loadSelf,
-  saveAnotherDeviceChangedPassword,
   saveEncryptionKey,
   saveIdentity,
   savePCDs,
@@ -503,7 +502,6 @@ function userInvalid(update: ZuUpdate) {
 }
 
 function anotherDeviceChangedPassword(update: ZuUpdate) {
-  saveAnotherDeviceChangedPassword(true);
   update({
     anotherDeviceChangedPassword: true,
     modal: "another-device-changed-password"

--- a/apps/passport-client/src/localstorage.ts
+++ b/apps/passport-client/src/localstorage.ts
@@ -68,16 +68,3 @@ export function loadIdentity(): Identity | null {
 export function saveIdentity(identity: Identity): void {
   window.localStorage["identity"] = identity.toString();
 }
-
-export function saveAnotherDeviceChangedPassword(
-  anotherDeviceChangedPassword: boolean
-) {
-  window.localStorage["anotherDeviceChangedPassword"] =
-    anotherDeviceChangedPassword;
-}
-
-export function loadAnotherDeviceChangedPassword(): boolean {
-  return JSON.parse(
-    window.localStorage["anotherDeviceChangedPassword"] ?? "false"
-  );
-}

--- a/apps/passport-client/src/localstorage.ts
+++ b/apps/passport-client/src/localstorage.ts
@@ -69,19 +69,11 @@ export function saveIdentity(identity: Identity): void {
   window.localStorage["identity"] = identity.toString();
 }
 
-export function saveUserInvalid(userInvalid: boolean) {
-  window.localStorage["participantInvalid"] = userInvalid;
-}
-
 export function saveAnotherDeviceChangedPassword(
   anotherDeviceChangedPassword: boolean
 ) {
   window.localStorage["anotherDeviceChangedPassword"] =
     anotherDeviceChangedPassword;
-}
-
-export function loadUserInvalid(): boolean {
-  return JSON.parse(window.localStorage["participantInvalid"] ?? "false");
 }
 
 export function loadAnotherDeviceChangedPassword(): boolean {


### PR DESCRIPTION
calculate it each time by downloading the user. this has been a painpoint for multiple members of the dev team, so I'm just removing it.