### PR TITLE
prevent NPE in sync code

### DIFF
--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -549,7 +549,7 @@ async function sync(state: AppState, update: ZuUpdate) {
      * */
     const downloaded = await downloadStorage();
 
-    if (downloaded != null) {
+    if (downloaded != null && downloaded.pcds != null) {
       const { pcds, subscriptions } = downloaded;
 
       if (subscriptions) {

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -547,13 +547,15 @@ async function sync(state: AppState, update: ZuUpdate) {
      * downloading from a pre-v3 version of encrypted storage
      * {@link SyncedEncryptedStorageV3}
      * */
-    const { pcds, subscriptions } = await downloadStorage();
+    const downloaded = await downloadStorage();
 
-    if (subscriptions) {
-      addDefaultSubscriptions(state.identity, subscriptions);
-    }
+    if (downloaded != null) {
+      const { pcds, subscriptions } = downloaded;
 
-    if (pcds != null) {
+      if (subscriptions) {
+        addDefaultSubscriptions(state.identity, subscriptions);
+      }
+
       update({
         downloadedPCDs: true,
         downloadingPCDs: false,

--- a/apps/passport-client/src/useSyncE2EEStorage.tsx
+++ b/apps/passport-client/src/useSyncE2EEStorage.tsx
@@ -2,13 +2,13 @@ import { getHash, passportEncrypt } from "@pcd/passport-crypto";
 import {
   ChangeBlobKeyResult,
   FeedSubscriptionManager,
-  SyncedEncryptedStorageV2,
-  SyncedEncryptedStorageV3,
   isSyncedEncryptedStorageV2,
   isSyncedEncryptedStorageV3,
   requestChangeBlobKey,
   requestDownloadAndDecryptStorage,
-  requestUploadEncryptedStorage
+  requestUploadEncryptedStorage,
+  SyncedEncryptedStorageV2,
+  SyncedEncryptedStorageV3
 } from "@pcd/passport-interface";
 import { NetworkFeedApi } from "@pcd/passport-interface/src/FeedAPI";
 import { PCDCollection } from "@pcd/pcd-collection";
@@ -99,7 +99,7 @@ export async function uploadStorage(): Promise<void> {
 export async function downloadStorage(): Promise<{
   pcds: PCDCollection | null;
   subscriptions: FeedSubscriptionManager | null;
-}> {
+} | null> {
   console.log("[SYNC] downloading e2ee storage");
 
   const encryptionKey = loadEncryptionKey();


### PR DESCRIPTION
https://github.com/proofcarryingdata/zupass/issues/642 would have caught this. I think we should do it before zuconnect.

the way this bug manifested for me is that when I logged in with a new email, or reset an existing account, the app would not finish going through the sync process, because we had never saved the e2ee storage for the user. refreshing would then load it properly.
