### PR TITLE
update zuzalu default subscription to match its name from the server

### DIFF
--- a/apps/passport-client/src/defaultSubscriptions.ts
+++ b/apps/passport-client/src/defaultSubscriptions.ts
@@ -70,11 +70,11 @@ const DEFAULT_FEEDS: Feed[] = [
     permissions: [
       {
         type: PCDPermissionType.AppendToFolder,
-        folder: "Zuzalu"
+        folder: "Zuzalu '23"
       } as AppendToFolderPermission,
       {
         type: PCDPermissionType.ReplaceInFolder,
-        folder: "Zuzalu"
+        folder: "Zuzalu '23"
       } as ReplaceInFolderPermission
     ],
     credentialType: SemaphoreSignaturePCDTypeName


### PR DESCRIPTION
otherwise, by default, users spawn into zupass with a red dot on their subscriptions button