### PR TITLE
fix frog styling

### DIFF
--- a/packages/rsa-image-pcd/src/CardBody.tsx
+++ b/packages/rsa-image-pcd/src/CardBody.tsx
@@ -11,12 +11,14 @@ export function RSAImageCardBody({ pcd }: { pcd: RSAImagePCD }) {
   );
 }
 
-const Container = styled.span`
+const Container = styled.div`
   padding: 16px;
   overflow: hidden;
   width: 100%;
 
   img {
-    max-width: 100%;
+    box-sizing: border-box;
+    border-radius: 16px;
+    overflow: hidden;
   }
 `;


### PR DESCRIPTION
#### before
<img width="415" alt="Screenshot 2023-10-06 at 2 16 53 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/3bf4f49b-43df-43eb-8cc7-c7d49bc497e1">

#### after
<img width="431" alt="Screenshot 2023-10-06 at 2 16 20 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/aa82bcfc-bf94-4ce3-aee3-fe7357ee408f">

#### comment
it's just been bothering me. i know we're going to be changing this for frog crypto but cmon.
