### PR TITLE
ZMS/DMS Auth + Anon fixes

### DIFF
--- a/apps/anon-message-client/src/app/page.tsx
+++ b/apps/anon-message-client/src/app/page.tsx
@@ -74,9 +74,7 @@ async function requestProof(
     },
     fieldsToReveal: {
       argumentType: ArgumentTypeName.ToggleList,
-      value: {
-        revealEventId: true
-      },
+      value: {},
       userProvided: false
     },
     externalNullifier: {

--- a/apps/passport-server/migrations/41_chat_topics.sql
+++ b/apps/passport-server/migrations/41_chat_topics.sql
@@ -4,4 +4,4 @@ ALTER TABLE telegram_chat_anon_topics RENAME TO telegram_chat_topics;
 -- Rename the columns
 ALTER TABLE telegram_chat_topics RENAME COLUMN anon_topic_id TO topic_id;
 ALTER TABLE telegram_chat_topics RENAME COLUMN anon_topic_name TO topic_name;
-ALTER TABLE telegram_chat_topics ADD COLUMN is_anon_topic BOOLEAN;
+ALTER TABLE telegram_chat_topics ADD COLUMN is_anon_topic BOOLEAN DEFAULT TRUE;

--- a/apps/passport-server/migrations/41_chat_topics.sql
+++ b/apps/passport-server/migrations/41_chat_topics.sql
@@ -1,0 +1,7 @@
+-- Rename the table
+ALTER TABLE telegram_chat_anon_topics RENAME TO telegram_chat_topics;
+
+-- Rename the columns
+ALTER TABLE telegram_chat_topics RENAME COLUMN anon_topic_id TO topic_id;
+ALTER TABLE telegram_chat_topics RENAME COLUMN anon_topic_name TO topic_name;
+ALTER TABLE telegram_chat_topics ADD COLUMN is_anon_topic BOOLEAN;

--- a/apps/passport-server/src/database/models.ts
+++ b/apps/passport-server/src/database/models.ts
@@ -164,8 +164,8 @@ export interface PretixItemInfo {
 }
 
 export interface TelegramAnonChannel {
-  telegram_chat_id: number;
-  topic_id: number;
+  telegram_chat_id: string;
+  topic_id: string;
   topic_name: string;
   is_anon_topic: boolean;
 }

--- a/apps/passport-server/src/database/models.ts
+++ b/apps/passport-server/src/database/models.ts
@@ -165,6 +165,7 @@ export interface PretixItemInfo {
 
 export interface TelegramAnonChannel {
   telegram_chat_id: number;
-  anon_topic_id: number;
-  anon_topic_name: string;
+  topic_id: number;
+  topic_name: string;
+  is_anon_topic: boolean;
 }

--- a/apps/passport-server/src/database/queries/telegram/deleteTelegramEvent.ts
+++ b/apps/passport-server/src/database/queries/telegram/deleteTelegramEvent.ts
@@ -31,3 +31,18 @@ export async function deleteTelegramChat(
     [telegramChatId]
   );
 }
+
+export async function deleteTelegramChatTopic(
+  client: Pool,
+  telegramChatId: number,
+  telegramTopicId: number
+): Promise<void> {
+  await sqlQuery(
+    client,
+    `\
+    delete from telegram_chat_topics
+    where telegram_chat_id = $1 and topic_id = $2
+    `,
+    [telegramChatId, telegramTopicId]
+  );
+}

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
@@ -106,7 +106,23 @@ export async function fetchTelegramAnonTopicsByChatId(
   const result = await sqlQuery(
     client,
     `\
-    select * from telegram_chat_anon_topics
+    select * from telegram_chat_topics
+    where telegram_chat_id = $1 and is_anon_topic = $2
+    `,
+    // true refers to the is_anon_topic boolean
+    [telegramChatId, true]
+  );
+  return result.rows;
+}
+
+export async function fetchTelegramTopicsByChatId(
+  client: Pool,
+  telegramChatId: number
+): Promise<TelegramAnonChannel[]> {
+  const result = await sqlQuery(
+    client,
+    `\
+    select * from telegram_chat_topics
     where telegram_chat_id = $1
     `,
     [telegramChatId]

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
@@ -81,6 +81,10 @@ export interface ChatIDWithEventIDs {
   telegramChatID: string;
   ticketEventIds: string[];
 }
+export interface UserIDWithChatIDs {
+  telegramUserID: string;
+  telegramChatIDs: string[];
+}
 
 export async function fetchEventsPerChat(
   client: Pool
@@ -128,4 +132,26 @@ export async function fetchTelegramTopicsByChatId(
     [telegramChatId]
   );
   return result.rows;
+}
+
+export async function fetchUserTelegramChats(
+  client: Pool,
+  telegramUserID: number
+): Promise<UserIDWithChatIDs | null> {
+  const result = await sqlQuery(
+    client,
+    `\
+    SELECT 
+      telegram_user_id AS "telegramUserID",
+      ARRAY_AGG(telegram_chat_id) AS "telegramChatIDs"
+    FROM 
+      telegram_bot_conversations
+    WHERE
+      telegram_user_id = $1
+    GROUP BY 
+      telegram_user_id
+    `,
+    [telegramUserID]
+  );
+  return result.rows[0] ?? null;
 }

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
@@ -111,10 +111,9 @@ export async function fetchTelegramAnonTopicsByChatId(
     client,
     `\
     select * from telegram_chat_topics
-    where telegram_chat_id = $1 and is_anon_topic = $2
+    where telegram_chat_id = $1 and is_anon_topic is true
     `,
-    // true refers to the is_anon_topic boolean
-    [telegramChatId, true]
+    [telegramChatId]
   );
   return result.rows;
 }

--- a/apps/passport-server/src/database/queries/telegram/insertTelegramConversation.ts
+++ b/apps/passport-server/src/database/queries/telegram/insertTelegramConversation.ts
@@ -53,20 +53,21 @@ set telegram_chat_id = $2;`,
   return result.rowCount;
 }
 
-export async function insertTelegramAnonTopic(
+export async function insertTelegramTopic(
   client: Pool,
   telegramChatId: number,
   anonTopicId: number,
-  topicName: string
+  topicName: string,
+  isAnon: boolean
 ): Promise<number> {
   const result = await sqlQuery(
     client,
     `\
-insert into telegram_chat_anon_topics (telegram_chat_id, anon_topic_id, anon_topic_name)
-values ($1, $2, $3)
-on conflict (telegram_chat_id, anon_topic_id) do update 
-set anon_topic_name = $3;`,
-    [telegramChatId, anonTopicId, topicName]
+insert into telegram_chat_topics (telegram_chat_id, topic_id, topic_name, is_anon_topic)
+values ($1, $2, $3, $4)
+on conflict (telegram_chat_id, topic_id) do update 
+set topic_name = $3, is_anon_topic = $4;`,
+    [telegramChatId, anonTopicId, topicName, isAnon]
   );
   return result.rowCount;
 }

--- a/apps/passport-server/src/database/queries/telegram/insertTelegramConversation.ts
+++ b/apps/passport-server/src/database/queries/telegram/insertTelegramConversation.ts
@@ -56,7 +56,7 @@ set telegram_chat_id = $2;`,
 export async function insertTelegramTopic(
   client: Pool,
   telegramChatId: number,
-  anonTopicId: number,
+  topicId: number,
   topicName: string,
   isAnon: boolean
 ): Promise<number> {

--- a/apps/passport-server/src/database/queries/telegram/insertTelegramConversation.ts
+++ b/apps/passport-server/src/database/queries/telegram/insertTelegramConversation.ts
@@ -67,7 +67,7 @@ insert into telegram_chat_topics (telegram_chat_id, topic_id, topic_name, is_ano
 values ($1, $2, $3, $4)
 on conflict (telegram_chat_id, topic_id) do update 
 set topic_name = $3, is_anon_topic = $4;`,
-    [telegramChatId, anonTopicId, topicName, isAnon]
+    [telegramChatId, topicId, topicName, isAnon]
   );
   return result.rowCount;
 }

--- a/apps/passport-server/src/routing/routes/telegramRoutes.ts
+++ b/apps/passport-server/src/routing/routes/telegramRoutes.ts
@@ -117,7 +117,7 @@ export function initTelegramRoutes(
         logger("[TELEGRAM] failed to send anonymous message", e);
         rollbarService?.reportError(e);
         res.set("Content-Type", "text/html");
-        res.status(500).sendFile(path.resolve("resources/telegram/error.html"));
+        res.status(500).send(errorHtmlWithDetails(e as string));
       }
     } catch (e) {
       logger("[TELEGRAM] failed to send anonymous message", e);

--- a/apps/passport-server/src/routing/routes/telegramRoutes.ts
+++ b/apps/passport-server/src/routing/routes/telegramRoutes.ts
@@ -108,7 +108,7 @@ export function initTelegramRoutes(
         await telegramService.handleSendAnonymousMessage(
           proof,
           message,
-          parseInt(topicId)
+          topicId
         );
         logger(`[TELEGRAM] Posted anonymous message: ${message}`);
         res.setHeader("Content-Type", "text/html");

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -185,7 +185,7 @@ export class TelegramService {
           const firstName = ctx?.from?.first_name;
           const name = firstName || username;
           await ctx.reply(
-            `Welcome ${name}! 👋\n\nClick below join a TG group via a ZK proof!\n\nYou will sign in to Zupass, then prove you have a ticket for one of the events associated with the group.\n\nSee you soon 😽`,
+            `Welcome ${name}! 👋\n\nClick below join a group via a ZK proof!\n\nYou will sign in to Zupass, then prove you have a ticket for one of the group's events.\n\nSee you soon 😽`,
             { reply_markup: zupassMenu }
           );
         }

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -339,12 +339,9 @@ export class TelegramService {
         return;
       }
 
-      await ctx.reply(
-        "Choose a group. You can only post if you are a ticketed member.",
-        {
-          reply_markup: anonSendMenu
-        }
-      );
+      await ctx.reply("Choose a chat to post in anonymously ⬇", {
+        reply_markup: anonSendMenu
+      });
     });
 
     this.bot.on(":forum_topic_created", async (ctx) => {

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -399,24 +399,26 @@ export class TelegramService {
           topic.is_anon_topic
         );
       }
-      ctx.reply(`<i>[ADMIN]: Updated topic ${topicName} in the db</i>`, {
-        message_thread_id: messageThreadId,
-        parse_mode: "HTML"
-      });
+      logger(`[TELEGRAM] Updated topic ${topicName} in the db`);
     });
 
     this.bot.command("incognito", async (ctx) => {
       const messageThreadId = ctx.message?.message_thread_id;
-      if (!messageThreadId) {
-        logger("[TELEGRAM] message thread id not found");
-        return;
-      }
 
       if (!isGroupWithTopics(ctx)) {
         await ctx.reply(
           "This command only works in a group with Topics enabled.",
           { message_thread_id: messageThreadId }
         );
+        return;
+      }
+
+      if (!messageThreadId) {
+        await ctx.reply("This command only works in a topic", {
+          message_thread_id: messageThreadId
+        });
+        logger("[TELEGRAM] message thread id not found");
+        return;
       }
 
       if (!(await senderIsAdmin(ctx)))

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -444,7 +444,7 @@ export class TelegramService {
         );
 
         const currentAnonTopic = chatAnonTopics.find(
-          (t) => t.topic_id == messageThreadId
+          (t) => t.topic_id == messageThreadId.toString()
         );
 
         if (currentAnonTopic && currentAnonTopic.is_anon_topic) {
@@ -459,10 +459,9 @@ export class TelegramService {
           ctx.chat.id
         );
         const topicToUpdate = topicsForChat.find(
-          (t) => t.topic_id === messageThreadId
+          (t) => t.topic_id === messageThreadId.toString()
         );
 
-        const topicId = topicToUpdate?.topic_id || messageThreadId;
         const topicName =
           topicToUpdate?.topic_name ||
           ctx.message?.reply_to_message?.forum_topic_created?.name;
@@ -471,7 +470,7 @@ export class TelegramService {
         await insertTelegramTopic(
           this.context.dbPool,
           ctx.chat.id,
-          topicId,
+          messageThreadId,
           topicName,
           true
         );
@@ -479,12 +478,12 @@ export class TelegramService {
         const validEventIds = telegramEvents.map((e) => e.ticket_event_id);
         const encodedTopicData = base64EncodeTopicData(
           topicName,
-          topicId,
+          messageThreadId,
           validEventIds
         );
 
         await ctx.reply(
-          `Linked with topic name <b>${topicName}</b>.\nIf this name is incorrect, edit this topic name to update the db`,
+          `Linked with topic name <b>${topicName}</b>.\nIf this name is incorrect, edit this topic name to update`,
           {
             message_thread_id: messageThreadId,
             parse_mode: "HTML"
@@ -736,7 +735,7 @@ export class TelegramService {
   public async handleSendAnonymousMessage(
     serializedZKEdDSATicket: string,
     message: string,
-    topicId: number
+    topicId: string
   ): Promise<void> {
     logger("[TELEGRAM] Verifying anonymous message");
 
@@ -815,7 +814,7 @@ export class TelegramService {
 
     await this.sendToAnonymousChannel(
       chat.id,
-      ticketedAnonEvent.topic_id,
+      parseInt(ticketedAnonEvent.topic_id),
       message
     );
   }

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -356,11 +356,11 @@ export const chatsToJoin = async (
   );
   for (const chat of sortedChats) {
     if (chat.userIsChatMember) {
-      range
-        .text(`${chat.chat?.title} (Joined)`, (ctx) =>
-          ctx.reply(`You've already joined ${chat.chat?.title}!`)
-        )
-        .row();
+      const invite = await ctx.api.createChatInviteLink(chat.telegramChatID, {
+        creates_join_request: true
+      });
+      range.url(`✅ ${chat.chat?.title}`, invite.invite_link).row();
+      range.row();
     } else {
       const proofUrl = generateProofUrl(userId.toString(), chat.ticketEventIds);
       range.webApp(`${chat.chat?.title}`, proofUrl).row();

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -395,21 +395,24 @@ export const chatsToPostIn = async (
       );
       const validEventIds = telegramEvents.map((e) => e.ticket_event_id);
 
-      range.text(`Choose a topic ⬇`).row();
-      for (const topic of topics) {
-        const encodedTopicData = base64EncodeTopicData(
-          topic.topic_name,
-          topic.topic_id,
-          validEventIds
-        );
-        range
-          .webApp(
-            `${topic.topic_name}`,
-            `${process.env.TELEGRAM_ANON_WEBSITE}?tgWebAppStartParam=${encodedTopicData}`
-          )
-          .row();
+      if (topics.length === 0) {
+        range.text(`No topics found`).row();
+      } else {
+        range.text(`Choose a topic ⬇`).row();
+        for (const topic of topics) {
+          const encodedTopicData = base64EncodeTopicData(
+            topic.topic_name,
+            topic.topic_id,
+            validEventIds
+          );
+          range
+            .webApp(
+              `${topic.topic_name}`,
+              `${process.env.TELEGRAM_ANON_WEBSITE}?tgWebAppStartParam=${encodedTopicData}`
+            )
+            .row();
+        }
       }
-
       range.text(`Go back`, async (ctx) => {
         ctx.session.selectedChat = undefined;
         await ctx.menu.update({ immediate: true });

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -18,7 +18,8 @@ import {
   fetchEventsPerChat,
   fetchLinkedPretixAndTelegramEvents,
   fetchTelegramAnonTopicsByChatId,
-  fetchTelegramEventsByChatId
+  fetchTelegramEventsByChatId,
+  fetchUserTelegramChats
 } from "../database/queries/telegram/fetchTelegramEvent";
 import {
   insertTelegramChat,
@@ -336,13 +337,34 @@ export const chatsToJoin = async (
 
   const events = await fetchEventsPerChat(db);
   const eventsWithChats = await chatIDsToChats(db, ctx, events);
-  if (eventsWithChats && eventsWithChats.length === 0) {
+  const userChats = await fetchUserTelegramChats(db, userId);
+
+  const finalEvents = eventsWithChats.map((e) => {
+    return {
+      ...e,
+      userIsChatMember: userChats
+        ? userChats.telegramChatIDs.includes(e.telegramChatID)
+        : false
+    };
+  });
+  if (finalEvents && finalEvents.length === 0) {
     range.text(`No groups to join at this time`);
     return;
   }
-  for (const chat of eventsWithChats) {
-    const proofUrl = generateProofUrl(userId.toString(), chat.ticketEventIds);
-    range.webApp(`${chat.chat?.title}`, proofUrl).row();
+  const sortedChats = finalEvents.sort(
+    (a, b) => +a.userIsChatMember - +b.userIsChatMember
+  );
+  for (const chat of sortedChats) {
+    if (chat.userIsChatMember) {
+      range
+        .text(`${chat.chat?.title} (Joined)`, (ctx) =>
+          ctx.reply(`You've already joined ${chat.chat?.title}!`)
+        )
+        .row();
+    } else {
+      const proofUrl = generateProofUrl(userId.toString(), chat.ticketEventIds);
+      range.webApp(`${chat.chat?.title}`, proofUrl).row();
+    }
   }
 };
 

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -376,13 +376,13 @@ export const chatsToPostIn = async (
       range.text(`Choose a topic ⬇`).row();
       for (const topic of topics) {
         const encodedTopicData = base64EncodeTopicData(
-          topic.anon_topic_name,
-          topic.anon_topic_id,
+          topic.topic_name,
+          topic.topic_id,
           validEventIds
         );
         range
           .webApp(
-            `${topic.anon_topic_name}`,
+            `${topic.topic_name}`,
             `${process.env.TELEGRAM_ANON_WEBSITE}?tgWebAppStartParam=${encodedTopicData}`
           )
           .row();

--- a/apps/passport-server/src/util/telegramWebApp.ts
+++ b/apps/passport-server/src/util/telegramWebApp.ts
@@ -23,24 +23,21 @@ export const errorHtmlWithDetails = (error: string): string => {
     <style></style>
   </head>
   <body>
-    <p>We were unable to verify that you have a ticket for a Telegram group</p>
-    <p>
-      Make sure that the event associated with your ticket has corresponding Telegram group in
-      the list provided by the bot.
-    </p>
-    <p>Type <i>/start</i> again to view the list if needed.</p>
+  <p>The group could not be joined.</p>
+  ${
+    error
+      ? `
+      <p>Here is the error we received:</p>
+      <p>${error}</p>
+      `
+      : ""
+  }
+    <p>Type <i>/start</i> to try again.</p>
     <p>
       If you need help additional help, please email
       <b>passport@0xparc.org</b>.
     </p>
-    ${
-      error
-        ? `
-        <p>Here is the error we received:</p>
-        <p>${error}</p>
-        `
-        : ""
-    }
+
   </body>
 </html>
 `;

--- a/apps/passport-server/src/util/telegramWebApp.ts
+++ b/apps/passport-server/src/util/telegramWebApp.ts
@@ -23,12 +23,12 @@ export const errorHtmlWithDetails = (error: string): string => {
     <style></style>
   </head>
   <body>
-  <p>The group could not be joined.</p>
+  <h3>Action failed</h3>
   ${
     error
       ? `
       <p>Here is the error we received:</p>
-      <p>${error}</p>
+      <p><b>${error}</b></p>
       `
       : ""
   }

--- a/apps/passport-server/test/telegram.spec.ts
+++ b/apps/passport-server/test/telegram.spec.ts
@@ -20,9 +20,9 @@ import {
   fetchTelegramEventByEventId
 } from "../src/database/queries/telegram/fetchTelegramEvent";
 import {
-  insertTelegramAnonTopic,
   insertTelegramChat,
   insertTelegramEvent,
+  insertTelegramTopic,
   insertTelegramVerification
 } from "../src/database/queries/telegram/insertTelegramConversation";
 import { findChatByEventIds } from "../src/util/telegramHelpers";
@@ -272,7 +272,7 @@ describe("telegram bot functionality", function () {
     }
   );
   step("should be able to add multiple anon channels", async function () {
-    await insertTelegramAnonTopic(db, dummyChatId, anonChannelID, "test");
+    await insertTelegramTopic(db, dummyChatId, anonChannelID, "test", true);
     const insertedAnonTopic = await fetchTelegramAnonTopicsByChatId(
       db,
       dummyChatId
@@ -280,9 +280,9 @@ describe("telegram bot functionality", function () {
     expect(insertedAnonTopic[0]?.telegram_chat_id).to.eq(
       dummyChatId.toString()
     );
-    expect(insertedAnonTopic[0]?.anon_topic_id).to.eq(anonChannelID.toString());
-    expect(insertedAnonTopic[0]?.anon_topic_name).to.eq("test");
-    await insertTelegramAnonTopic(db, dummyChatId, anonChannelID_1, "test1");
+    expect(insertedAnonTopic[0]?.topic_id).to.eq(anonChannelID.toString());
+    expect(insertedAnonTopic[0]?.topic_name).to.eq("test");
+    await insertTelegramTopic(db, dummyChatId, anonChannelID_1, "test1", true);
 
     const insertedAnonTopic_1 = await fetchTelegramAnonTopicsByChatId(
       db,
@@ -292,9 +292,7 @@ describe("telegram bot functionality", function () {
     expect(insertedAnonTopic_1[1]?.telegram_chat_id).to.eq(
       dummyChatId.toString()
     );
-    expect(insertedAnonTopic_1[1]?.anon_topic_id).to.eq(
-      anonChannelID_1.toString()
-    );
-    expect(insertedAnonTopic_1[1]?.anon_topic_name).to.eq("test1");
+    expect(insertedAnonTopic_1[1]?.topic_id).to.eq(anonChannelID_1.toString());
+    expect(insertedAnonTopic_1[1]?.topic_name).to.eq("test1");
   });
 });


### PR DESCRIPTION
- [x] Keeps track of topics, with extra flag for anon
- [x] Handle deleting of anon topics (Handle auto-delete if messageThreadId not found)
- [x] Better error messages for anon topics
- [x] Prevents users from joining chats they've already joined and prevent from posting in chats they haven't joined
- [x] ^ Better UX to tell users what chats they have / haven't joined
- [x] Move anon proofs over to eventId

<img width="588" alt="CleanShot 2023-10-10 at 12 22 59@2x" src="https://github.com/proofcarryingdata/zupass/assets/42984734/2ab2d65d-46f7-4922-8e28-e75daa648637">
