### PR TITLE
Zupass fixes for ZMS/DMS demos

### DIFF
--- a/apps/passport-client/components/screens/EnterConfirmationCodeScreen.tsx
+++ b/apps/passport-client/components/screens/EnterConfirmationCodeScreen.tsx
@@ -85,6 +85,7 @@ export function EnterConfirmationCodeScreen() {
           <BigInput value={email} disabled />
           <Spacer h={8} />
           <BigInput
+            type="number"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="confirmation code"

--- a/apps/passport-client/components/screens/LoginScreens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/CreatePasswordScreen.tsx
@@ -6,7 +6,7 @@ import { appConfig } from "../../../src/appConfig";
 import { useDispatch, useQuery, useSelf } from "../../../src/appHooks";
 import { hasPendingRequest } from "../../../src/sessionStorage";
 import { validateEmail } from "../../../src/util";
-import { BigInput, CenterColumn, H2, HR, Spacer, TextCenter } from "../../core";
+import { CenterColumn, H2, HR, Spacer, TextCenter } from "../../core";
 import { Button } from "../../core/Button";
 import { MaybeModal } from "../../modals/Modal";
 import { AppContainer } from "../../shared/AppContainer";
@@ -120,15 +120,11 @@ export function CreatePasswordScreen() {
           <H2>Choose a Password</H2>
           <Spacer h={24} />
           This password will be used to generate an encryption key that secures
-          your data. Save your password somewhere you'll be able to find it
-          later. If you skip this now, you will be asked to set a password on
-          adding your first PCD.
+          your data. Save your password somewhere you'll be able to find later.
         </TextCenter>
         <Spacer h={24} />
 
         <CenterColumn>
-          <BigInput value={email} disabled={true} />
-          <Spacer h={8} />
           <NewPasswordForm
             error={error}
             setError={setError}

--- a/apps/passport-client/components/screens/LoginScreens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/CreatePasswordScreen.tsx
@@ -123,6 +123,7 @@ export function CreatePasswordScreen() {
           your data. Save your password somewhere you'll be able to find later.
         </TextCenter>
         <Spacer h={24} />
+        {/* TODO: Add back disabled BigInput */}
 
         <CenterColumn>
           <NewPasswordForm

--- a/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
@@ -139,6 +139,7 @@ export function LoginScreen() {
       <CenterColumn>
         <form onSubmit={onGenPass}>
           <BigInput
+            autoCapitalize="off"
             type="text"
             autoFocus
             placeholder="email address"

--- a/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
@@ -90,13 +90,14 @@ export function LoginScreen() {
   const onGenPass = useCallback(
     function (e: FormEvent<HTMLFormElement>) {
       e.preventDefault();
+      const trimmedEmail = email.trim();
 
-      if (email === "" || validateEmail(email) === false) {
+      if (trimmedEmail === "" || validateEmail(trimmedEmail) === false) {
         setError("Enter a valid email address");
       } else {
         dispatch({
           type: "new-passport",
-          email: email.toLocaleLowerCase("en-US")
+          email: trimmedEmail.toLocaleLowerCase("en-US")
         });
       }
     },

--- a/apps/passport-client/components/screens/LoginScreens/NewPassportScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/NewPassportScreen.tsx
@@ -180,7 +180,12 @@ function SendEmailVerification({ email }: { email: string }) {
           <form onSubmit={onSubmit}>
             <BigInput value={email} disabled={true} />
             <Spacer h={8} />
-            <BigInput ref={inRef} autoFocus placeholder="code from email" />
+            <BigInput
+              type="number"
+              ref={inRef}
+              autoFocus
+              placeholder="code from email"
+            />
             <InlineError error={error} />
             <Spacer h={8} />
             <Button type="submit">Verify</Button>

--- a/apps/passport-client/components/shared/AppContainer.tsx
+++ b/apps/passport-client/components/shared/AppContainer.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useCallback } from "react";
 import styled, { createGlobalStyle } from "styled-components";
 import { useAppError, useDispatch } from "../../src/appHooks";
+import { RippleLoader } from "../core/RippleLoader";
 import { ErrorPopup } from "../modals/ErrorPopup";
 
 // Wrapper for all screens.
@@ -25,7 +26,7 @@ export function AppContainer({
       <GlobalBackground color={col} />
       <Background>
         <Container>
-          {children}
+          {children ?? <RippleLoader />}
           {error && <ErrorPopup error={error} onClose={onClose} />}
         </Container>
       </Background>

--- a/apps/passport-client/components/shared/AppContainer.tsx
+++ b/apps/passport-client/components/shared/AppContainer.tsx
@@ -1,8 +1,8 @@
 import { ReactNode, useCallback } from "react";
 import styled, { createGlobalStyle } from "styled-components";
 import { useAppError, useDispatch } from "../../src/appHooks";
-import { RippleLoader } from "../core/RippleLoader";
 import { ErrorPopup } from "../modals/ErrorPopup";
+import { ScreenLoader } from "./ScreenLoader";
 
 // Wrapper for all screens.
 export function AppContainer({
@@ -26,7 +26,7 @@ export function AppContainer({
       <GlobalBackground color={col} />
       <Background>
         <Container>
-          {children ?? <RippleLoader />}
+          {children ?? <ScreenLoader />}
           {error && <ErrorPopup error={error} onClose={onClose} />}
         </Container>
       </Background>

--- a/apps/passport-client/components/shared/AppContainer.tsx
+++ b/apps/passport-client/components/shared/AppContainer.tsx
@@ -26,7 +26,7 @@ export function AppContainer({
       <GlobalBackground color={col} />
       <Background>
         <Container>
-          {children ?? <ScreenLoader />}
+          {children ?? <ScreenLoader text="Zupass" />}
           {error && <ErrorPopup error={error} onClose={onClose} />}
         </Container>
       </Background>

--- a/apps/passport-client/components/shared/NewPasswordForm.tsx
+++ b/apps/passport-client/components/shared/NewPasswordForm.tsx
@@ -1,7 +1,7 @@
-import { Dispatch, FormEvent, SetStateAction } from "react";
+import { Dispatch, SetStateAction, UIEvent, useRef } from "react";
 import {
-  checkPasswordStrength,
-  PASSWORD_MINIMUM_LENGTH
+  PASSWORD_MINIMUM_LENGTH,
+  checkPasswordStrength
 } from "../../src/password";
 import { Button, Spacer } from "../core";
 import { InlineError } from "./InlineError";
@@ -38,7 +38,9 @@ export function NewPasswordForm({
   setError,
   error
 }: NewPasswordForm) {
-  const checkPasswordAndSubmit = async (e: FormEvent<HTMLFormElement>) => {
+  const confirmPasswordRef = useRef<HTMLInputElement>(null);
+
+  const checkPasswordAndSubmit = async (e: UIEvent) => {
     e.preventDefault();
     if (password === "") {
       setError("Enter a password");
@@ -63,7 +65,7 @@ export function NewPasswordForm({
   };
 
   return (
-    <form onSubmit={checkPasswordAndSubmit}>
+    <form>
       {/* For password manager autofill */}
       <input hidden readOnly value={email} />
       <PasswordInput
@@ -73,12 +75,18 @@ export function NewPasswordForm({
           setPassword(value);
         }}
         placeholder={passwordInputPlaceholder || "Password"}
+        onEnter={(e) => {
+          e.preventDefault();
+          confirmPasswordRef.current.focus();
+        }}
         autoFocus={autoFocus}
         revealPassword={revealPassword}
         setRevealPassword={setRevealPassword}
       />
       <Spacer h={8} />
       <PasswordInput
+        inputRef={confirmPasswordRef}
+        onEnter={checkPasswordAndSubmit}
         value={confirmPassword}
         setValue={(value) => {
           setError("");
@@ -90,7 +98,7 @@ export function NewPasswordForm({
       />
       <InlineError error={error} />
       <Spacer h={8} />
-      <Button style="primary" type="submit">
+      <Button style="primary" onClick={checkPasswordAndSubmit}>
         {submitButtonText}
       </Button>
     </form>

--- a/apps/passport-client/components/shared/PasswordInput.tsx
+++ b/apps/passport-client/components/shared/PasswordInput.tsx
@@ -1,4 +1,9 @@
-import { Dispatch, SetStateAction } from "react";
+import {
+  Dispatch,
+  KeyboardEvent,
+  MutableRefObject,
+  SetStateAction
+} from "react";
 import styled from "styled-components";
 import { BigInput } from "../core";
 import { icons } from "../icons";
@@ -9,6 +14,8 @@ interface SetPasswordInputProps {
   revealPassword: boolean;
   setRevealPassword: Dispatch<SetStateAction<boolean>>;
   placeholder: string;
+  onEnter?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  inputRef?: MutableRefObject<HTMLInputElement>;
   autoFocus?: boolean;
 }
 
@@ -18,11 +25,19 @@ export function PasswordInput({
   revealPassword,
   autoFocus,
   setRevealPassword,
-  placeholder
+  placeholder,
+  inputRef,
+  onEnter
 }: SetPasswordInputProps) {
   return (
     <Container>
       <PasswordBigInput
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            onEnter(e);
+          }
+        }}
+        ref={inputRef}
         autoFocus={autoFocus}
         type={revealPassword ? "text" : "password"}
         placeholder={placeholder}


### PR DESCRIPTION
These misc changes are primarily to unblock ZMS/DMS during demos this week.
- trim email on login page
- cut down copy from Create Password page, and ensure that pressing "return" on password input takes you to next component
  - follow-up is to automatically add spacing when keyboard is up, to be done in #865
- add fallback loader from blank <AppContainer /> (green screen)