### PR TITLE
anon zucat copy

### DIFF
--- a/apps/anon-message-client/src/app/page.tsx
+++ b/apps/anon-message-client/src/app/page.tsx
@@ -73,6 +73,7 @@ async function requestProof(
       userProvided: true
     },
     fieldsToReveal: {
+      description: "...without revealing any of the ticket information.",
       argumentType: ArgumentTypeName.ToggleList,
       value: {},
       userProvided: false
@@ -105,9 +106,9 @@ async function requestProof(
     typeof ZKEdDSAEventTicketPCDPackage
   >(passportOrigin, returnUrl, ZKEdDSAEventTicketPCDPackage.name, args, {
     genericProveScreen: true,
-    title: "ZK Ticket Proof",
+    title: "",
     description:
-      "Generate a zero-knowledge proof that you have an EdDSA ticket for a conference event! Select your ticket from the dropdown below."
+      "Zucat would like to send an anonymous message for you and requested a zero-knowledge proof."
   });
 
   window.location.href = proofUrl;


### PR DESCRIPTION
Make anonsend prove screen message better. 

p.s. I'm having trouble setting up local testing. will pair with @cha0sg0d later


This is how it looks currently

<img width="405" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/8bcaca6a-ae85-4eee-8b15-58ce2d776d0a">
