### PR TITLE
Delete folder action

### DIFF
--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -8,6 +8,7 @@ import {
 import {
   PCDPermission,
   isAppendToFolderPermission,
+  isDeleteFolderPermission,
   isReplaceInFolderPermission
 } from "@pcd/pcd-collection";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -311,6 +312,12 @@ function SinglePermission({ permission }: { permission: PCDPermission }) {
     return (
       <PermissionListItem>
         Replace in folder <strong>{permission.folder}</strong>
+      </PermissionListItem>
+    );
+  } else if (isDeleteFolderPermission(permission)) {
+    return (
+      <PermissionListItem>
+        Delete folder <strong>{permission.folder}</strong>
       </PermissionListItem>
     );
   } else {

--- a/apps/passport-client/src/defaultSubscriptions.ts
+++ b/apps/passport-client/src/defaultSubscriptions.ts
@@ -1,7 +1,8 @@
 import {
   FeedSubscriptionManager,
   Subscription,
-  ZupassFeedIds
+  ZupassFeedIds,
+  zupassDefaultSubscriptions
 } from "@pcd/passport-interface";
 import { appConfig } from "../src/appConfig";
 
@@ -25,27 +26,12 @@ export async function addDefaultSubscriptions(
     subscriptions.addProvider(DEFAULT_FEED_URL, DEFAULT_FEED_PROVIDER_NAME);
   }
 
-  const subscribedFeedIds = new Set(
-    subscriptions
-      .getSubscriptionsForProvider(DEFAULT_FEED_URL)
-      .map((s) => s.feed.id)
-  );
-
-  const difference = [...DEFAULT_FEEDS].filter(
-    (id) => !subscribedFeedIds.has(id)
-  );
-
-  if (difference.length > 0) {
-    try {
-      const list = await subscriptions.listFeeds(DEFAULT_FEED_URL);
-
-      for (const feed of list.feeds) {
-        if (DEFAULT_FEEDS.has(feed.id)) {
-          subscriptions.subscribe(DEFAULT_FEED_URL, feed);
-        }
-      }
-    } catch (e) {
-      console.log("Could not add default subscriptions due to error:", e);
-    }
+  for (const id in zupassDefaultSubscriptions) {
+    subscriptions.subscribe(
+      DEFAULT_FEED_URL,
+      zupassDefaultSubscriptions[id],
+      // Replace the existing subscription if it already exists
+      true
+    );
   }
 }

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -40,6 +40,8 @@ import {
 import {
   AppendToFolderAction,
   AppendToFolderPermission,
+  DeleteFolderAction,
+  DeleteFolderPermission,
   PCDAction,
   PCDActionType,
   PCDPermissionType,
@@ -162,15 +164,13 @@ export class IssuanceService {
               );
 
               actions.push({
-                type: PCDActionType.ReplaceInFolder,
-                folder: "SBC SRW",
-                pcds: []
+                type: PCDActionType.DeleteFolder,
+                folder: "SBC SRW"
               });
 
               actions.push({
-                type: PCDActionType.ReplaceInFolder,
-                folder: "Devconnect",
-                pcds: []
+                type: PCDActionType.DeleteFolder,
+                folder: "Devconnect"
               });
 
               actions.push(
@@ -178,9 +178,8 @@ export class IssuanceService {
                   await Promise.all(
                     devconnectTickets.map(async ([eventName, tickets]) => [
                       {
-                        type: PCDActionType.ReplaceInFolder,
-                        folder: joinPath("Devconnect", eventName),
-                        pcds: []
+                        type: PCDActionType.DeleteFolder,
+                        folder: joinPath("Devconnect", eventName)
                       },
                       {
                         type: PCDActionType.ReplaceInFolder,
@@ -233,13 +232,21 @@ export class IssuanceService {
                 type: PCDPermissionType.ReplaceInFolder
               } as ReplaceInFolderPermission,
               {
+                folder: "Devconnect",
+                type: PCDPermissionType.DeleteFolder
+              } as DeleteFolderPermission,
+              {
                 folder: "SBC SRW",
                 type: PCDPermissionType.AppendToFolder
               } as AppendToFolderPermission,
               {
                 folder: "SBC SRW",
                 type: PCDPermissionType.ReplaceInFolder
-              } as ReplaceInFolderPermission
+              } as ReplaceInFolderPermission,
+              {
+                folder: "SBC SRW",
+                type: PCDPermissionType.DeleteFolder
+              } as DeleteFolderPermission
             ]
           }
         },
@@ -305,10 +312,9 @@ export class IssuanceService {
 
               // Clear out the folder
               actions.push({
-                type: PCDActionType.ReplaceInFolder,
-                folder: "Email",
-                pcds: []
-              } as ReplaceInFolderAction);
+                type: PCDActionType.DeleteFolder,
+                folder: "Email"
+              } as DeleteFolderAction);
 
               actions.push({
                 type: PCDActionType.ReplaceInFolder,
@@ -336,8 +342,8 @@ export class IssuanceService {
             permissions: [
               {
                 folder: "Email",
-                type: PCDPermissionType.AppendToFolder
-              } as AppendToFolderPermission,
+                type: PCDPermissionType.DeleteFolder
+              } as DeleteFolderPermission,
               {
                 folder: "Email",
                 type: PCDPermissionType.ReplaceInFolder
@@ -362,10 +368,9 @@ export class IssuanceService {
 
               // Clear out the folder
               actions.push({
-                type: PCDActionType.ReplaceInFolder,
-                folder: "Zuzalu '23",
-                pcds: []
-              } as ReplaceInFolderAction);
+                type: PCDActionType.DeleteFolder,
+                folder: "Zuzalu '23"
+              } as DeleteFolderAction);
 
               actions.push({
                 type: PCDActionType.ReplaceInFolder,
@@ -393,8 +398,8 @@ export class IssuanceService {
             permissions: [
               {
                 folder: "Zuzalu '23",
-                type: PCDPermissionType.AppendToFolder
-              } as AppendToFolderPermission,
+                type: PCDPermissionType.DeleteFolder
+              } as DeleteFolderPermission,
               {
                 folder: "Zuzalu '23",
                 type: PCDPermissionType.ReplaceInFolder

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -164,22 +164,20 @@ export class IssuanceService {
 
               actions.push({
                 type: PCDActionType.DeleteFolder,
-                folder: "SBC SRW"
+                folder: "SBC SRW",
+                recursive: false
               });
 
               actions.push({
                 type: PCDActionType.DeleteFolder,
-                folder: "Devconnect"
+                folder: "Devconnect",
+                recursive: true
               });
 
               actions.push(
                 ...(
                   await Promise.all(
                     devconnectTickets.map(async ([eventName, tickets]) => [
-                      {
-                        type: PCDActionType.DeleteFolder,
-                        folder: joinPath("Devconnect", eventName)
-                      },
                       {
                         type: PCDActionType.ReplaceInFolder,
                         folder: joinPath("Devconnect", eventName),
@@ -277,7 +275,8 @@ export class IssuanceService {
               // Clear out the folder
               actions.push({
                 type: PCDActionType.DeleteFolder,
-                folder: "Email"
+                folder: "Email",
+                recursive: false
               } as DeleteFolderAction);
 
               actions.push({
@@ -314,7 +313,8 @@ export class IssuanceService {
               // Clear out the folder
               actions.push({
                 type: PCDActionType.DeleteFolder,
-                folder: "Zuzalu '23"
+                folder: "Zuzalu '23",
+                recursive: false
               } as DeleteFolderAction);
 
               actions.push({

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -35,18 +35,17 @@ import {
   VerifyTicketResult,
   ZupassFeedIds,
   ZuzaluUserRole,
-  verifyFeedCredential
+  verifyFeedCredential,
+  zupassDefaultSubscriptions
 } from "@pcd/passport-interface";
 import {
   AppendToFolderAction,
   AppendToFolderPermission,
   DeleteFolderAction,
-  DeleteFolderPermission,
   PCDAction,
   PCDActionType,
   PCDPermissionType,
   ReplaceInFolderAction,
-  ReplaceInFolderPermission,
   joinPath
 } from "@pcd/pcd-collection";
 import { ArgumentTypeName, SerializedPCD } from "@pcd/pcd-types";
@@ -213,42 +212,7 @@ export class IssuanceService {
 
             return { actions };
           },
-          feed: {
-            id: ZupassFeedIds.Devconnect,
-            name: "Devconnect Tickets",
-            description: "Get your Devconnect tickets here!",
-            inputPCDType: EdDSATicketPCDPackage.name,
-            partialArgs: undefined,
-            credentialRequest: {
-              signatureType: "sempahore-signature-pcd"
-            },
-            permissions: [
-              {
-                folder: "Devconnect",
-                type: PCDPermissionType.AppendToFolder
-              } as AppendToFolderPermission,
-              {
-                folder: "Devconnect",
-                type: PCDPermissionType.ReplaceInFolder
-              } as ReplaceInFolderPermission,
-              {
-                folder: "Devconnect",
-                type: PCDPermissionType.DeleteFolder
-              } as DeleteFolderPermission,
-              {
-                folder: "SBC SRW",
-                type: PCDPermissionType.AppendToFolder
-              } as AppendToFolderPermission,
-              {
-                folder: "SBC SRW",
-                type: PCDPermissionType.ReplaceInFolder
-              } as ReplaceInFolderPermission,
-              {
-                folder: "SBC SRW",
-                type: PCDPermissionType.DeleteFolder
-              } as DeleteFolderPermission
-            ]
-          }
+          feed: zupassDefaultSubscriptions[ZupassFeedIds.Devconnect]
         },
         {
           handleRequest: async (
@@ -330,26 +294,7 @@ export class IssuanceService {
 
             return { actions };
           },
-          feed: {
-            id: ZupassFeedIds.Email,
-            name: "Zupass Verified Emails",
-            description: "Emails verified by Zupass",
-            inputPCDType: EmailPCDPackage.name,
-            partialArgs: undefined,
-            credentialRequest: {
-              signatureType: "sempahore-signature-pcd"
-            },
-            permissions: [
-              {
-                folder: "Email",
-                type: PCDPermissionType.DeleteFolder
-              } as DeleteFolderPermission,
-              {
-                folder: "Email",
-                type: PCDPermissionType.ReplaceInFolder
-              } as ReplaceInFolderPermission
-            ]
-          }
+          feed: zupassDefaultSubscriptions[ZupassFeedIds.Email]
         },
         {
           handleRequest: async (
@@ -386,26 +331,7 @@ export class IssuanceService {
 
             return { actions };
           },
-          feed: {
-            id: ZupassFeedIds.Zuzalu_1,
-            name: "Zuzalu tickets",
-            description: "Your Zuzalu Tickets",
-            inputPCDType: EdDSATicketPCD.name,
-            partialArgs: undefined,
-            credentialRequest: {
-              signatureType: "sempahore-signature-pcd"
-            },
-            permissions: [
-              {
-                folder: "Zuzalu '23",
-                type: PCDPermissionType.DeleteFolder
-              } as DeleteFolderPermission,
-              {
-                folder: "Zuzalu '23",
-                type: PCDPermissionType.ReplaceInFolder
-              } as ReplaceInFolderPermission
-            ]
-          }
+          feed: zupassDefaultSubscriptions[ZupassFeedIds.Zuzalu_1]
         }
       ],
       `${process.env.PASSPORT_SERVER_URL}/feeds`,

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -1748,17 +1748,11 @@ describe("devconnect functionality", function () {
         throw new Error("expected to be able to get a feed response");
       }
 
-      expect(response.value?.actions?.length).to.eq(4);
+      expect(response.value?.actions?.length).to.eq(3);
 
-      // First action for a subfolder is to clear it
-      const clearAction = response.value?.actions?.[2] as ReplaceInFolderAction;
-
-      expect(clearAction.type).to.eq(PCDActionType.DeleteFolder);
-      expect(clearAction.folder).to.eq("Devconnect/Event A");
-
-      // Second action is to populate it
+      // Now we have an action to populate the folder
       const populateAction = response.value
-        ?.actions?.[3] as ReplaceInFolderAction;
+        ?.actions?.[2] as ReplaceInFolderAction;
 
       expect(populateAction.type).to.eq(PCDActionType.ReplaceInFolder);
       expect(populateAction.folder).to.eq("Devconnect/Event A");
@@ -1799,8 +1793,8 @@ describe("devconnect functionality", function () {
     MockDate.reset();
     const response1 = expressResponse1.value as PollFeedResponseValue;
     const response2 = expressResponse2.value as PollFeedResponseValue;
-    const action1 = response1.actions[3] as ReplaceInFolderAction;
-    const action2 = response2.actions[3] as ReplaceInFolderAction;
+    const action1 = response1.actions[2] as ReplaceInFolderAction;
+    const action2 = response2.actions[2] as ReplaceInFolderAction;
 
     const pcds1 = await Promise.all(
       action1.pcds.map((pcd) => EdDSATicketPCDPackage.deserialize(pcd.pcd))
@@ -1851,9 +1845,9 @@ describe("devconnect functionality", function () {
       );
       MockDate.reset();
       const responseBody = response.value as PollFeedResponseValue;
-      expect(responseBody.actions.length).to.eq(4);
+      expect(responseBody.actions.length).to.eq(3);
 
-      const devconnectAction = responseBody.actions[3] as ReplaceInFolderAction;
+      const devconnectAction = responseBody.actions[2] as ReplaceInFolderAction;
       expect(isReplaceInFolderAction(devconnectAction)).to.be.true;
       expect(devconnectAction.folder).to.eq("Devconnect/New name");
 
@@ -1901,8 +1895,8 @@ describe("devconnect functionality", function () {
       );
       MockDate.reset();
       const responseBody = response.value as PollFeedResponseValue;
-      expect(responseBody.actions.length).to.eq(4);
-      const devconnectAction = responseBody.actions[3] as ReplaceInFolderAction;
+      expect(responseBody.actions.length).to.eq(3);
+      const devconnectAction = responseBody.actions[2] as ReplaceInFolderAction;
       expect(devconnectAction.folder).to.eq("Devconnect/Event A");
 
       expect(Array.isArray(devconnectAction.pcds)).to.eq(true);
@@ -1952,7 +1946,7 @@ describe("devconnect functionality", function () {
       );
       MockDate.reset();
       const issueResponseBody = issueResponse.value as PollFeedResponseValue;
-      const action = issueResponseBody.actions[3] as ReplaceInFolderAction;
+      const action = issueResponseBody.actions[2] as ReplaceInFolderAction;
 
       const serializedTicket = action.pcds[1] as SerializedPCD<EdDSATicketPCD>;
       ticketPCD = await EdDSATicketPCDPackage.deserialize(serializedTicket.pcd);
@@ -1983,7 +1977,7 @@ describe("devconnect functionality", function () {
       MockDate.reset();
       const issueResponseBody = issueResponse.value as PollFeedResponseValue;
 
-      const action = issueResponseBody.actions[3] as ReplaceInFolderAction;
+      const action = issueResponseBody.actions[2] as ReplaceInFolderAction;
       const serializedTicket = action.pcds[2] as SerializedPCD<EdDSATicketPCD>;
       ticketPCD = await EdDSATicketPCDPackage.deserialize(serializedTicket.pcd);
 
@@ -2125,8 +2119,16 @@ describe("devconnect functionality", function () {
 
       const response = expressResponse.value as PollFeedResponseValue;
       expect(response.actions).to.deep.eq([
-        { type: PCDActionType.DeleteFolder, folder: "SBC SRW" },
-        { type: PCDActionType.DeleteFolder, folder: "Devconnect" }
+        {
+          type: PCDActionType.DeleteFolder,
+          folder: "SBC SRW",
+          recursive: false
+        },
+        {
+          type: PCDActionType.DeleteFolder,
+          folder: "Devconnect",
+          recursive: true
+        }
       ]);
     }
   );

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -26,7 +26,6 @@ import {
   requestVerifyTicket
 } from "@pcd/passport-interface";
 import {
-  AppendToFolderAction,
   PCDActionType,
   ReplaceInFolderAction,
   isReplaceInFolderAction
@@ -1754,11 +1753,8 @@ describe("devconnect functionality", function () {
       // First action for a subfolder is to clear it
       const clearAction = response.value?.actions?.[2] as ReplaceInFolderAction;
 
-      expect(clearAction.type).to.eq(PCDActionType.ReplaceInFolder);
+      expect(clearAction.type).to.eq(PCDActionType.DeleteFolder);
       expect(clearAction.folder).to.eq("Devconnect/Event A");
-
-      expect(Array.isArray(clearAction.pcds)).to.eq(true);
-      expect(clearAction.pcds.length).to.eq(0);
 
       // Second action is to populate it
       const populateAction = response.value
@@ -1803,8 +1799,8 @@ describe("devconnect functionality", function () {
     MockDate.reset();
     const response1 = expressResponse1.value as PollFeedResponseValue;
     const response2 = expressResponse2.value as PollFeedResponseValue;
-    const action1 = response1.actions[0] as AppendToFolderAction;
-    const action2 = response2.actions[0] as AppendToFolderAction;
+    const action1 = response1.actions[3] as ReplaceInFolderAction;
+    const action2 = response2.actions[3] as ReplaceInFolderAction;
 
     const pcds1 = await Promise.all(
       action1.pcds.map((pcd) => EdDSATicketPCDPackage.deserialize(pcd.pcd))
@@ -1814,6 +1810,7 @@ describe("devconnect functionality", function () {
     );
 
     expect(pcds1.length).to.eq(pcds2.length);
+    expect(pcds1.length).to.not.eq(0);
 
     pcds1.forEach((_, i) => {
       expect(pcds1[i].id).to.eq(pcds2[i].id);
@@ -2128,12 +2125,9 @@ describe("devconnect functionality", function () {
 
       const response = expressResponse.value as PollFeedResponseValue;
       expect(response.actions).to.deep.eq([
-        { type: PCDActionType.ReplaceInFolder, folder: "SBC SRW", pcds: [] },
-        { type: PCDActionType.ReplaceInFolder, folder: "Devconnect", pcds: [] }
+        { type: PCDActionType.DeleteFolder, folder: "SBC SRW" },
+        { type: PCDActionType.DeleteFolder, folder: "Devconnect" }
       ]);
-
-      const action = response.actions[0] as ReplaceInFolderAction;
-      expect(action.pcds).to.deep.eq([]);
     }
   );
 

--- a/packages/passport-interface/src/ZupassDefaultSubscriptions.ts
+++ b/packages/passport-interface/src/ZupassDefaultSubscriptions.ts
@@ -1,0 +1,86 @@
+import {
+  AppendToFolderPermission,
+  DeleteFolderPermission,
+  PCDPermissionType,
+  ReplaceInFolderPermission
+} from "@pcd/pcd-collection";
+import { Feed, ZupassFeedIds } from "./SubscriptionManager";
+
+export const zupassDefaultSubscriptions: Record<
+  ZupassFeedIds.Devconnect | ZupassFeedIds.Email | ZupassFeedIds.Zuzalu_1,
+  Feed
+> = {
+  [ZupassFeedIds.Zuzalu_1]: {
+    id: ZupassFeedIds.Zuzalu_1,
+    name: "Zuzalu tickets",
+    description: "Your Zuzalu Tickets",
+    partialArgs: undefined,
+    credentialRequest: {
+      signatureType: "sempahore-signature-pcd"
+    },
+    permissions: [
+      {
+        folder: "Zuzalu '23",
+        type: PCDPermissionType.DeleteFolder
+      } as DeleteFolderPermission,
+      {
+        folder: "Zuzalu '23",
+        type: PCDPermissionType.ReplaceInFolder
+      } as ReplaceInFolderPermission
+    ]
+  },
+  [ZupassFeedIds.Devconnect]: {
+    id: ZupassFeedIds.Devconnect,
+    name: "Devconnect Tickets",
+    description: "Get your Devconnect tickets here!",
+    partialArgs: undefined,
+    credentialRequest: {
+      signatureType: "sempahore-signature-pcd"
+    },
+    permissions: [
+      {
+        folder: "Devconnect",
+        type: PCDPermissionType.AppendToFolder
+      } as AppendToFolderPermission,
+      {
+        folder: "Devconnect",
+        type: PCDPermissionType.ReplaceInFolder
+      } as ReplaceInFolderPermission,
+      {
+        folder: "Devconnect",
+        type: PCDPermissionType.DeleteFolder
+      } as DeleteFolderPermission,
+      {
+        folder: "SBC SRW",
+        type: PCDPermissionType.AppendToFolder
+      } as AppendToFolderPermission,
+      {
+        folder: "SBC SRW",
+        type: PCDPermissionType.ReplaceInFolder
+      } as ReplaceInFolderPermission,
+      {
+        folder: "SBC SRW",
+        type: PCDPermissionType.DeleteFolder
+      } as DeleteFolderPermission
+    ]
+  },
+  [ZupassFeedIds.Email]: {
+    id: ZupassFeedIds.Email,
+    name: "Zupass Verified Emails",
+    description: "Emails verified by Zupass",
+    partialArgs: undefined,
+    credentialRequest: {
+      signatureType: "sempahore-signature-pcd"
+    },
+    permissions: [
+      {
+        folder: "Email",
+        type: PCDPermissionType.DeleteFolder
+      } as DeleteFolderPermission,
+      {
+        folder: "Email",
+        type: PCDPermissionType.ReplaceInFolder
+      } as ReplaceInFolderPermission
+    ]
+  }
+};

--- a/packages/passport-interface/src/index.ts
+++ b/packages/passport-interface/src/index.ts
@@ -12,6 +12,7 @@ export * from "./SemaphoreSignatureIntegration";
 export * from "./SerializedPCDIntegration";
 export * from "./SubscriptionManager";
 export * from "./User";
+export * from "./ZupassDefaultSubscriptions";
 export * from "./api/apiResult";
 export * from "./api/constants";
 export * from "./api/makeRequest";

--- a/packages/pcd-collection/src/PCDCollection.ts
+++ b/packages/pcd-collection/src/PCDCollection.ts
@@ -3,23 +3,28 @@ import { getHash } from "@pcd/passport-crypto";
 import { PCD, PCDPackage, SerializedPCD } from "@pcd/pcd-types";
 import {
   AppendToFolderAction,
+  DeleteFolderAction,
   PCDAction,
   ReplaceInFolderAction,
   isAppendToFolderAction,
+  isDeleteFolderAction,
   isReplaceInFolderAction
 } from "./actions";
 import {
   AppendToFolderPermission,
+  DeleteFolderPermission,
   PCDPermission,
   ReplaceInFolderPermission,
   isAppendToFolderPermission,
+  isDeleteFolderPermission,
   isReplaceInFolderPermission
 } from "./permissions";
 import { getFoldersInFolder, isFolderAncestor, isRootFolder } from "./util";
 
 export type MatchingActionPermission =
   | { permission: ReplaceInFolderPermission; action: ReplaceInFolderAction }
-  | { permission: AppendToFolderPermission; action: AppendToFolderAction };
+  | { permission: AppendToFolderPermission; action: AppendToFolderAction }
+  | { permission: DeleteFolderPermission; action: DeleteFolderAction };
 
 type AddPCDOptions = { upsert?: boolean };
 
@@ -40,6 +45,15 @@ export function matchActionToPermission(
     if (
       isReplaceInFolderAction(action) &&
       isReplaceInFolderPermission(permission) &&
+      (action.folder === permission.folder ||
+        isFolderAncestor(action.folder, permission.folder))
+    ) {
+      return { action, permission };
+    }
+
+    if (
+      isDeleteFolderAction(action) &&
+      isDeleteFolderPermission(permission) &&
       (action.folder === permission.folder ||
         isFolderAncestor(action.folder, permission.folder))
     ) {
@@ -182,6 +196,19 @@ export class PCDCollection {
       return true;
     }
 
+    if (isDeleteFolderAction(action) && isDeleteFolderPermission(permission)) {
+      if (
+        action.folder !== permission.folder &&
+        !isFolderAncestor(action.folder, permission.folder)
+      ) {
+        return false;
+      }
+
+      this.deleteFolder(action.folder);
+
+      return true;
+    }
+
     return false;
   }
 
@@ -250,6 +277,10 @@ export class PCDCollection {
     this.removeAllPCDsInFolder(folder);
     this.addAll(pcds, { upsert: true });
     pcds.forEach((pcd) => this.setPCDFolder(pcd.id, folder));
+  }
+
+  private deleteFolder(folder: string): void {
+    this.removeAllPCDsInFolder(folder);
   }
 
   public getPackage<T extends PCDPackage = PCDPackage>(

--- a/packages/pcd-collection/src/actions.ts
+++ b/packages/pcd-collection/src/actions.ts
@@ -37,6 +37,7 @@ export function isAppendToFolderAction(
 export interface DeleteFolderAction {
   type: PCDActionType.DeleteFolder;
   folder: string;
+  recursive: boolean;
 }
 
 export function isDeleteFolderAction(

--- a/packages/pcd-collection/src/actions.ts
+++ b/packages/pcd-collection/src/actions.ts
@@ -2,7 +2,8 @@ import { SerializedPCD } from "@pcd/pcd-types";
 
 export enum PCDActionType {
   ReplaceInFolder = "ReplaceInFolder_action",
-  AppendToFolder = "AppendToFolder_action"
+  AppendToFolder = "AppendToFolder_action",
+  DeleteFolder = "DeleteFolder_action"
 }
 
 export interface PCDAction {
@@ -31,4 +32,15 @@ export function isAppendToFolderAction(
   action: PCDAction
 ): action is AppendToFolderAction {
   return action.type === PCDActionType.AppendToFolder;
+}
+
+export interface DeleteFolderAction {
+  type: PCDActionType.DeleteFolder;
+  folder: string;
+}
+
+export function isDeleteFolderAction(
+  action: PCDAction
+): action is DeleteFolderAction {
+  return action.type === PCDActionType.DeleteFolder;
 }

--- a/packages/pcd-collection/src/permissions.ts
+++ b/packages/pcd-collection/src/permissions.ts
@@ -3,7 +3,8 @@
 // types or vice-versa" in permissions.spec.ts
 export enum PCDPermissionType {
   ReplaceInFolder = "ReplaceInFolder_permission",
-  AppendToFolder = "AppendToFolder_permission"
+  AppendToFolder = "AppendToFolder_permission",
+  DeleteFolder = "DeleteFolder_permission"
 }
 
 export interface PCDPermission {
@@ -25,12 +26,18 @@ export interface ReplaceInFolderPermission extends PCDPermission {
   folder: string;
 }
 
+export interface DeleteFolderPermission extends PCDPermission {
+  type: PCDPermissionType.DeleteFolder;
+  folder: string;
+}
+
 export function isPCDFolderPermission(
   permission: PCDPermission
 ): permission is PCDFolderPermission {
   return [
     PCDPermissionType.AppendToFolder,
-    PCDPermissionType.ReplaceInFolder
+    PCDPermissionType.ReplaceInFolder,
+    PCDPermissionType.DeleteFolder
   ].includes(permission.type);
 }
 
@@ -44,4 +51,10 @@ export function isReplaceInFolderPermission(
   permission: PCDPermission
 ): permission is ReplaceInFolderPermission {
   return permission.type === PCDPermissionType.ReplaceInFolder;
+}
+
+export function isDeleteFolderPermission(
+  permission: PCDPermission
+): permission is DeleteFolderPermission {
+  return permission.type === PCDPermissionType.DeleteFolder;
 }

--- a/packages/pcd-collection/src/util.ts
+++ b/packages/pcd-collection/src/util.ts
@@ -66,12 +66,16 @@ export function isChild(parent: string, child: string): boolean {
 }
 
 /**
- * Checks if a particular path has {@link folderPath} as a descendant.
+ * Checks if {@link possibleAncestor} has {@link possibleDescendant} as a
+ * descendant.
  * eg. a/b/c/d is a descendant of a/b, but not of a/q.
  */
-export function isFolderAncestor(path: string, folderPath: string): boolean {
-  const pathParts = splitPath(path);
-  const folderParts = splitPath(folderPath);
+export function isFolderAncestor(
+  possibleDescendant: string,
+  possibleAncestor: string
+): boolean {
+  const pathParts = splitPath(possibleDescendant);
+  const folderParts = splitPath(possibleAncestor);
 
   if (folderParts.length >= pathParts.length) {
     return false;

--- a/packages/pcd-collection/test/permissions.spec.ts
+++ b/packages/pcd-collection/test/permissions.spec.ts
@@ -326,7 +326,8 @@ describe("Permissions", async function () {
 
     const deleteAction: DeleteFolderAction = {
       type: PCDActionType.DeleteFolder,
-      folder: "test"
+      folder: "test",
+      recursive: false
     };
 
     const deletePermission: DeleteFolderPermission = {
@@ -366,7 +367,8 @@ describe("Permissions", async function () {
 
     const deleteAction: DeleteFolderAction = {
       type: PCDActionType.DeleteFolder,
-      folder: "test"
+      folder: "test",
+      recursive: false
     };
 
     const deletePermission: DeleteFolderPermission = {

--- a/packages/pcd-collection/test/permissions.spec.ts
+++ b/packages/pcd-collection/test/permissions.spec.ts
@@ -7,6 +7,8 @@ import { v4 as uuid } from "uuid";
 import {
   AppendToFolderAction,
   AppendToFolderPermission,
+  DeleteFolderAction,
+  DeleteFolderPermission,
   PCDActionType,
   PCDCollection,
   PCDPermissionType,
@@ -300,5 +302,85 @@ describe("Permissions", async function () {
     // This means that the string representations of action types should
     // never overlap with the string representations of permission types.
     expect(intersection).to.be.empty;
+  });
+
+  it("deleting should succeed with right permission", async function () {
+    const collection = new PCDCollection(packages);
+
+    const action: AppendToFolderAction = {
+      type: PCDActionType.AppendToFolder,
+      folder: "test",
+      pcds: [serializedPcd]
+    };
+
+    const permission: AppendToFolderPermission = {
+      type: PCDPermissionType.AppendToFolder,
+      folder: "test"
+    };
+
+    expect(
+      await collection.tryExecutingActionWithPermission(action, permission)
+    ).to.be.true;
+
+    expect(collection.getSize()).to.eq(1);
+
+    const deleteAction: DeleteFolderAction = {
+      type: PCDActionType.DeleteFolder,
+      folder: "test"
+    };
+
+    const deletePermission: DeleteFolderPermission = {
+      type: PCDPermissionType.DeleteFolder,
+      folder: "test"
+    };
+
+    expect(
+      await collection.tryExecutingActionWithPermission(
+        deleteAction,
+        deletePermission
+      )
+    ).to.be.true;
+
+    expect(collection.getSize()).to.eq(0);
+  });
+
+  it("deleting should fail without right permission", async function () {
+    const collection = new PCDCollection(packages);
+
+    const action: AppendToFolderAction = {
+      type: PCDActionType.AppendToFolder,
+      folder: "test",
+      pcds: [serializedPcd]
+    };
+
+    const permission: AppendToFolderPermission = {
+      type: PCDPermissionType.AppendToFolder,
+      folder: "test"
+    };
+
+    expect(
+      await collection.tryExecutingActionWithPermission(action, permission)
+    ).to.be.true;
+
+    expect(collection.getSize()).to.eq(1);
+
+    const deleteAction: DeleteFolderAction = {
+      type: PCDActionType.DeleteFolder,
+      folder: "test"
+    };
+
+    const deletePermission: DeleteFolderPermission = {
+      type: PCDPermissionType.DeleteFolder,
+      folder: "other"
+    };
+
+    expect(
+      await collection.tryExecutingActionWithPermission(
+        deleteAction,
+        deletePermission
+      )
+    ).to.be.false;
+
+    expect(collection.getSize()).to.eq(1);
   });
 });


### PR DESCRIPTION
Adds a new "Delete folder" action and matching permission, and switches the feeds that were previously using an empty "Replace in folder" action for clearing out folders to use "Delete folder" instead.

After merging, this will require you to approve the new permissions for each feed in the Subscriptions screen.