### PR TITLE
disable prove button if missing pcd

### DIFF
--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -3,9 +3,15 @@ import {
   ProveOptions,
   requestProveOnServer
 } from "@pcd/passport-interface";
-import { ArgsOf, PCDOf, PCDPackage, SerializedPCD } from "@pcd/pcd-types";
+import {
+  ArgsOf,
+  PCDOf,
+  PCDPackage,
+  SerializedPCD,
+  isPCDArgument
+} from "@pcd/pcd-types";
 import { getErrorMessage } from "@pcd/util";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";
 import { usePCDCollection } from "../../../src/appHooks";
@@ -36,7 +42,9 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
 }) {
   const rollbar = useAppRollbar();
   const pcds = usePCDCollection();
-  const [args, setArgs] = useState(JSON.parse(JSON.stringify(initialArgs)));
+  const [args, setArgs] = useState<ArgsOf<T>>(
+    JSON.parse(JSON.stringify(initialArgs))
+  );
   const [error, setError] = useState<string | undefined>();
   const [proving, setProving] = useState(false);
   const pcdPackage = pcds.getPackage<T>(pcdType);
@@ -44,6 +52,16 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
   useEffect(() => {
     setError(undefined);
   }, [args]);
+
+  const isProveReady = useMemo(
+    () =>
+      !Object.entries(args).find(
+        ([_, arg]) =>
+          // only PCD arguments are required
+          arg.value || !isPCDArgument(arg)
+      ),
+    [args]
+  );
 
   const onProveClick = useCallback(async () => {
     setProving(true);
@@ -102,7 +120,9 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
       {proving ? (
         <RippleLoader />
       ) : (
-        <Button onClick={onProveClick}>Prove</Button>
+        <Button disabled={!isProveReady} onClick={onProveClick}>
+          Prove
+        </Button>
       )}
     </Container>
   );

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -58,7 +58,7 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
       !Object.entries(args).find(
         ([_, arg]) =>
           // only PCD arguments are required
-          arg.value || !isPCDArgument(arg)
+          isPCDArgument(arg) && !arg.value
       ),
     [args]
   );


### PR DESCRIPTION
Closes https://github.com/proofcarryingdata/zupass/issues/862

<img width="429" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/69628afe-94e4-4f42-8d3e-818af1ab37d1">

The disabled button also shows a corresponding cursor that is not captured in the screenshot.


This PR simply disables prove button if PCD argument value is missing. I believe this is a safe assumption where PCD argument is always required for all PCDs. We could go the extra mile by adding a `required` prop to the argument. Let me know if we want to do that here.