### PR TITLE
Cache temporary credentials in local storage

### DIFF
--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -1,4 +1,4 @@
-import { createCredentialCache } from "@pcd/passport-interface";
+import { createStorageBackedCredentialCache } from "@pcd/passport-interface";
 import { Identity } from "@semaphore-protocol/identity";
 import * as React from "react";
 import { createRoot } from "react-dom/client";
@@ -214,7 +214,7 @@ async function loadInitialState(): Promise<AppState> {
     modal = { modalType: "upgrade-account-modal" };
   }
 
-  const credentialCache = createCredentialCache();
+  const credentialCache = createStorageBackedCredentialCache();
 
   return {
     self,

--- a/packages/passport-interface/src/CredentialManager.ts
+++ b/packages/passport-interface/src/CredentialManager.ts
@@ -12,6 +12,7 @@ import {
   createFeedCredentialPayload
 } from "./FeedCredential";
 import { CredentialRequest } from "./SubscriptionManager";
+import { StorageBackedMap } from "./util/StorageBackedMap";
 
 export interface CredentialManagerAPI {
   canGenerateCredential(req: CredentialRequest): boolean;
@@ -29,8 +30,14 @@ interface CacheEntry {
 const CACHE_TTL = ONE_HOUR_MS;
 
 // Creates an in-memory cache with a TTL of one hour.
+// Use this where local storage is not available, e.g. in tests
 export function createCredentialCache(): CredentialCache {
   return new Map();
+}
+
+// Creates an in-memory cache with a TTL of one hour, backed by localStorage
+export function createStorageBackedCredentialCache(): CredentialCache {
+  return new StorageBackedMap("credential-cache");
 }
 
 /**
@@ -89,7 +96,6 @@ export class CredentialManager implements CredentialManagerAPI {
         this.cache.delete(cacheKey);
       }
     }
-
     return undefined;
   }
 

--- a/packages/passport-interface/src/util/StorageBackedMap.ts
+++ b/packages/passport-interface/src/util/StorageBackedMap.ts
@@ -1,0 +1,102 @@
+/**
+ * A JavaScript map which syncs its entries to local storage, and loads them
+ * during construction.
+ */
+export class StorageBackedMap<K, V> extends Map<K, V> {
+  // The local storage key
+  private readonly storageKey: string;
+  // Whether we're currently syncing to local storage
+  private syncing: boolean;
+
+  public constructor(storageKey: string) {
+    // Initializes the base map
+    super();
+    this.storageKey = storageKey;
+    this.syncing = false;
+
+    // Load data into the map
+    this.reloadFromStorage();
+
+    // Set up an event listener so that we get changes to local storage from
+    // other tabs
+    window.addEventListener("storage", (ev) => {
+      // key === null means that storage was cleared
+      // Probably this means that the user was logged out, so let's make sure
+      // we don't keep any credentials in memory
+      if (ev.key === null) {
+        super.clear();
+      } else if (ev.key === this.storageKey) {
+        this.reloadFromStorage();
+      }
+    });
+  }
+
+  // Queues a microtask to sync to local storage once the current event loop
+  // has finished processing
+  private queueSync() {
+    if (!this.syncing) {
+      this.syncing = true;
+      queueMicrotask(() => this.syncToStorage());
+    }
+  }
+
+  // Sync the map entries to local storage
+  private syncToStorage(): void {
+    const data = JSON.stringify(Array.from(this.entries()));
+    if (window.localStorage.getItem(this.storageKey) !== data) {
+      window.localStorage.setItem(this.storageKey, data);
+    }
+    this.syncing = false;
+  }
+
+  // Reloads data from storage, called in response to storage changes that
+  // come from other tabs.
+  private reloadFromStorage() {
+    const storageData = window.localStorage.getItem(this.storageKey);
+    let loadedData = [];
+    if (storageData) {
+      const parsed = JSON.parse(storageData);
+      if (parsed instanceof Array) {
+        loadedData = parsed;
+      }
+    }
+
+    super.clear();
+    loadedData.forEach((entry: [K, V]) => {
+      super.set(entry[0], entry[1]);
+    });
+  }
+
+  // Wraps Map.set(), and queues a sync after the change
+  public set(key: K, value: V) {
+    super.set(key, value);
+    this.queueSync();
+    return this;
+  }
+
+  // Wraps Map.delete(), and queues a sync after the change
+  public delete(key: K) {
+    if (super.delete(key)) {
+      this.queueSync();
+      return true;
+    }
+
+    return false;
+  }
+
+  // Wraps Map.clear(), and queues a sync after the change
+  public clear() {
+    super.clear();
+    this.queueSync();
+  }
+
+  // Wraps Map.forEach(), and queues a sync.
+  // This is necessary because callbackfn can mutate map entries.
+  public forEach(
+    callbackfn: (value: V, key: K, map: Map<K, V>) => void,
+    thisArg?: any
+  ): void {
+    super.forEach(callbackfn, thisArg);
+    this.queueSync();
+  }
+}

--- a/packages/passport-interface/src/util/StorageBackedMap.ts
+++ b/packages/passport-interface/src/util/StorageBackedMap.ts
@@ -3,9 +3,13 @@
  * during construction.
  */
 export class StorageBackedMap<K, V> extends Map<K, V> {
-  // The local storage key
+  /**
+   *  The local storage key
+   */
   private readonly storageKey: string;
-  // Whether we're currently syncing to local storage
+  /**
+   *  Whether we're currently syncing to local storage
+   */
   private syncing: boolean;
 
   public constructor(storageKey: string) {
@@ -31,8 +35,10 @@ export class StorageBackedMap<K, V> extends Map<K, V> {
     });
   }
 
-  // Queues a microtask to sync to local storage once the current event loop
-  // has finished processing
+  /**
+   * Queues a microtask to sync to local storage once the current event loop
+   *  has finished processing
+   */
   private queueSync() {
     if (!this.syncing) {
       this.syncing = true;
@@ -40,7 +46,9 @@ export class StorageBackedMap<K, V> extends Map<K, V> {
     }
   }
 
-  // Sync the map entries to local storage
+  /**
+   * Sync the map entries to local storage
+   */
   private syncToStorage(): void {
     const data = JSON.stringify(Array.from(this.entries()));
     if (window.localStorage.getItem(this.storageKey) !== data) {
@@ -49,15 +57,22 @@ export class StorageBackedMap<K, V> extends Map<K, V> {
     this.syncing = false;
   }
 
-  // Reloads data from storage, called in response to storage changes that
-  // come from other tabs.
+  /**
+   * Reloads data from storage, called in response to storage changes that
+   * come from other tabs.
+   */
   private reloadFromStorage() {
     const storageData = window.localStorage.getItem(this.storageKey);
     let loadedData = [];
     if (storageData) {
-      const parsed = JSON.parse(storageData);
-      if (parsed instanceof Array) {
-        loadedData = parsed;
+      try {
+        const parsed = JSON.parse(storageData);
+        if (parsed instanceof Array) {
+          loadedData = parsed;
+        }
+      } catch (e) {
+        // Local storage had invalid JSON, so proceed without having changed
+        // `loadedData`
       }
     }
 
@@ -67,14 +82,18 @@ export class StorageBackedMap<K, V> extends Map<K, V> {
     });
   }
 
-  // Wraps Map.set(), and queues a sync after the change
+  /**
+   * Wraps Map.set(), and queues a sync after the change
+   */
   public set(key: K, value: V) {
     super.set(key, value);
     this.queueSync();
     return this;
   }
 
-  // Wraps Map.delete(), and queues a sync after the change
+  /**
+   * Wraps Map.delete(), and queues a sync after the change
+   */
   public delete(key: K) {
     if (super.delete(key)) {
       this.queueSync();
@@ -84,14 +103,18 @@ export class StorageBackedMap<K, V> extends Map<K, V> {
     return false;
   }
 
-  // Wraps Map.clear(), and queues a sync after the change
+  /**
+   * Wraps Map.clear(), and queues a sync after the change
+   */
   public clear() {
     super.clear();
     this.queueSync();
   }
 
-  // Wraps Map.forEach(), and queues a sync.
-  // This is necessary because callbackfn can mutate map entries.
+  /**
+   * Wraps Map.forEach(), and queues a sync.
+   * This is necessary because callbackfn can mutate map entries.
+   */
   public forEach(
     callbackfn: (value: V, key: K, map: Map<K, V>) => void,
     thisArg?: any


### PR DESCRIPTION
Closes #639 

This eliminates some instances of expensive `prove` operations during startup.

If the user has generated a feed credential within the last hour, there is no reason for them to generate another one. By persisting the cache to local storage and repopulating the cache from local storage on initialization, we can reuse credentials generated on the previous page load or in another tab.