### PR TITLE
Auto-set Bot Commands and Scope Them

### DIFF
--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -175,6 +175,7 @@ function RouterImpl() {
           <Route path="device-login" element={<DeviceLoginScreen />} />
           <Route path="subscriptions" element={<SubscriptionsScreen />} />
           <Route path="add-subscription" element={<AddSubscriptionScreen />} />
+          <Route path="telegram" element={<HomeScreen />} />
           <Route path="*" element={<MissingScreen />} />
         </Route>
       </Routes>

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -42,7 +42,8 @@ import {
   getSessionKey,
   isDirectMessage,
   isGroupWithTopics,
-  senderIsAdmin
+  senderIsAdmin,
+  setBotInfo
 } from "../util/telegramHelpers";
 import { checkSlidingWindowRateLimit } from "../util/util";
 import { RollbarService } from "./rollbarService";
@@ -71,13 +72,7 @@ export class TelegramService {
     this.rollbarService = rollbarService;
     this.bot = bot;
 
-    this.bot.api.setMyDescription(
-      "I'm Zucat 🐱 ! I manage fun events with zero-knowledge proofs. Press START to get started!"
-    );
-
-    this.bot.api.setMyShortDescription(
-      "Zucat manages events and groups with zero-knowledge proofs"
-    );
+    setBotInfo(bot);
 
     const zupassMenu = new Menu<BotContext>("zupass");
     const eventsMenu = new Menu<BotContext>("events");
@@ -321,6 +316,13 @@ export class TelegramService {
       await ctx.api.editMessageText(userId, msg.message_id, eventsHtml, {
         parse_mode: "HTML"
       });
+    });
+
+    this.bot.command("help", async (ctx) => {
+      // TODO: Link to troubleshooting guide
+      await ctx.reply(
+        `Please email passport@0xparc.org if you have any additional issues`
+      );
     });
 
     this.bot.command("anonsend", async (ctx) => {
@@ -923,7 +925,6 @@ export async function startTelegramService(
   };
 
   bot.use(session({ initial, getSessionKey }));
-  await bot.init();
 
   const service = new TelegramService(context, rollbarService, bot);
   bot.catch((error) => {

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -180,19 +180,6 @@ export class TelegramService {
     // The "start" command initiates the process of invitation and approval.
     this.bot.command("start", async (ctx) => {
       const userId = ctx?.from?.id;
-      const startParam = ctx.match;
-      if (
-        startParam &&
-        startParam === "zupass" &&
-        process.env.PASSPORT_CLIENT_URL
-      ) {
-        return ctx.reply(`Log in to Zupass`, {
-          reply_markup: new InlineKeyboard().webApp(
-            "Zupass",
-            process.env.PASSPORT_CLIENT_URL + "/#telegram"
-          )
-        });
-      }
       try {
         // Only process the command if it comes as a private message.
         if (isDirectMessage(ctx) && userId) {

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -189,7 +189,7 @@ export class TelegramService {
         return ctx.reply(`Log in to Zupass`, {
           reply_markup: new InlineKeyboard().webApp(
             "Zupass",
-            process.env.PASSPORT_CLIENT_URL + "/telegram"
+            process.env.PASSPORT_CLIENT_URL + "/#telegram"
           )
         });
       }

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -89,14 +89,14 @@ export const setBotInfo = async (
     "Zucat manages events and groups with zero-knowledge proofs"
   );
 
-  const commands: BotCommand[] = [
+  const privateChatCommands: BotCommand[] = [
     {
       command: "/start",
-      description: "[DM only] join a group with a proof of ticket"
+      description: "join a group with a proof of ticket"
     },
     {
       command: "/anonsend",
-      description: "[DM only] Send an anonymous message"
+      description: "Send an anonymous message"
     },
     {
       command: "/help",
@@ -104,7 +104,33 @@ export const setBotInfo = async (
     }
   ];
 
-  bot.api.setMyCommands(commands);
+  bot.api.setMyCommands(privateChatCommands, {
+    scope: { type: "all_private_chats" }
+  });
+
+  const adminGroupChatCommands: BotCommand[] = [
+    {
+      command: "/incognito",
+      description: "Set a topic for anonymous posting"
+    },
+    {
+      command: "/manage",
+      description: "Link this chat to events"
+    },
+    {
+      command: "/setup",
+      description:
+        "Initialize a group chat with an Admin and Announcements topic"
+    },
+    {
+      command: "/adminhelp",
+      description: "Get info in a DM about the group and linked events"
+    }
+  ];
+
+  bot.api.setMyCommands(adminGroupChatCommands, {
+    scope: { type: "all_chat_administrators" }
+  });
 };
 
 /**

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -8,8 +8,13 @@ import {
   ZKEdDSAEventTicketPCDArgs,
   ZKEdDSAEventTicketPCDPackage
 } from "@pcd/zk-eddsa-event-ticket-pcd";
-import { Context, SessionFlavor } from "grammy";
-import { Chat, ChatMemberAdministrator, ChatMemberOwner } from "grammy/types";
+import { Api, Bot, Context, RawApi, SessionFlavor } from "grammy";
+import {
+  BotCommand,
+  Chat,
+  ChatMemberAdministrator,
+  ChatMemberOwner
+} from "grammy/types";
 import { Pool } from "postgres-pool";
 import { deleteTelegramEvent } from "../database/queries/telegram/deleteTelegramEvent";
 import {
@@ -72,6 +77,35 @@ function isFulfilled<T>(
 ): promiseSettledResult is PromiseFulfilledResult<T> {
   return promiseSettledResult.status === "fulfilled";
 }
+
+export const setBotInfo = async (
+  bot: Bot<BotContext, Api<RawApi>>
+): Promise<void> => {
+  bot.api.setMyDescription(
+    "I'm Zucat 🐱 ! I manage fun events with zero-knowledge proofs. Press START to get started!"
+  );
+
+  bot.api.setMyShortDescription(
+    "Zucat manages events and groups with zero-knowledge proofs"
+  );
+
+  const commands: BotCommand[] = [
+    {
+      command: "/start",
+      description: "[DM only] join a group with a proof of ticket"
+    },
+    {
+      command: "/anonsend",
+      description: "[DM only] Send an anonymous message"
+    },
+    {
+      command: "/help",
+      description: "Get help"
+    }
+  ];
+
+  bot.api.setMyCommands(commands);
+};
 
 /**
  * Fetches the chat object for a list contaning a telegram chat id

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -81,6 +81,15 @@ function isFulfilled<T>(
 export const setBotInfo = async (
   bot: Bot<BotContext, Api<RawApi>>
 ): Promise<void> => {
+  if (process.env.PASSPORT_CLIENT_URL) {
+    bot.api.setChatMenuButton({
+      menu_button: {
+        web_app: { url: process.env.PASSPORT_CLIENT_URL + "/telegram" },
+        type: "web_app",
+        text: "Zupass"
+      }
+    });
+  }
   bot.api.setMyDescription(
     "I'm Zucat 🐱 ! I manage fun events with zero-knowledge proofs. Press START to get started!"
   );

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -91,7 +91,7 @@ export const setBotInfo = async (
     });
   }
   bot.api.setMyDescription(
-    "I'm Zucat 🐱 ! I manage fun events with zero-knowledge proofs. Press START to get started!"
+    "I'm Zucat! I manage fun events with zero-knowledge proofs. Press START to begin 😽"
   );
 
   bot.api.setMyShortDescription(

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -84,7 +84,7 @@ export const setBotInfo = async (
   if (process.env.PASSPORT_CLIENT_URL) {
     bot.api.setChatMenuButton({
       menu_button: {
-        web_app: { url: process.env.PASSPORT_CLIENT_URL + "/telegram" },
+        web_app: { url: process.env.PASSPORT_CLIENT_URL + "/#telegram" },
         type: "web_app",
         text: "Zupass"
       }

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -101,7 +101,7 @@ export const setBotInfo = async (
   const privateChatCommands: BotCommand[] = [
     {
       command: "/start",
-      description: "join a group with a proof of ticket"
+      description: "Join a group with a proof of ticket"
     },
     {
       command: "/anonsend",


### PR DESCRIPTION
Closes #882 

Adds a `/help` command as well.

Zupass Menu for easy access:
<img width="282" alt="CleanShot 2023-10-13 at 15 23 28@2x" src="https://github.com/proofcarryingdata/zupass/assets/42984734/5c2670a8-0557-4038-9d37-f3fc4c92cabb">


Users in a DM:
<img width="318" alt="CleanShot 2023-10-13 at 15 22 15@2x" src="https://github.com/proofcarryingdata/zupass/assets/42984734/e72c28af-d16f-4d40-a940-1158dec16640">

Admins only in a group chat:
<img width="463" alt="CleanShot 2023-10-13 at 15 22 38@2x" src="https://github.com/proofcarryingdata/zupass/assets/42984734/e567d4e6-daa8-4631-9d02-147a166e7be9">
