### PR TITLE
Add zuzalu and zuconnect events to enable zms

### DIFF
--- a/apps/passport-server/migrations/45_known_events.sql
+++ b/apps/passport-server/migrations/45_known_events.sql
@@ -1,0 +1,35 @@
+CREATE TABLE known_events (
+  event_id UUID NOT NULL PRIMARY KEY
+);
+
+-- Populate known_events table with current state of known_ticket_types
+INSERT INTO known_events (event_id)
+SELECT DISTINCT event_id::UUID FROM known_ticket_types;
+
+-- We cannot directly cast VARCHAR to UUID, so we must create a temporary column,
+-- copy over values, drop the old column, and rename
+ALTER TABLE known_ticket_types
+ADD COLUMN event_id_uuid UUID;
+
+UPDATE known_ticket_types
+SET event_id_uuid = event_id::UUID;
+
+ALTER TABLE known_ticket_types
+DROP COLUMN event_id;
+
+ALTER TABLE known_ticket_types
+RENAME COLUMN event_id_uuid TO event_id;
+
+-- Add foreign key constraint between known_ticket_types(event_id)
+-- and known_events(event_id)
+ALTER TABLE known_ticket_types
+ADD CONSTRAINT known_ticket_types_event_id_key
+FOREIGN KEY (event_id)
+REFERENCES known_events(event_id);
+
+ALTER TABLE telegram_bot_events
+DROP CONSTRAINT fk_telegram_bot_events_ticket_event_id;
+
+ALTER TABLE telegram_bot_events
+ADD FOREIGN KEY (ticket_event_id)
+REFERENCES known_events(event_id);

--- a/apps/passport-server/src/database/models.ts
+++ b/apps/passport-server/src/database/models.ts
@@ -187,6 +187,12 @@ export interface KnownPublicKeyDB {
   public_key: string;
 }
 
+// A known event as represented in the DB. All possible event IDs for all possible
+// ticket types are listed here.
+export interface KnownEvent {
+  event_id: string;
+}
+
 // A known ticket type as represented in the DB. Allows us to match tickets to
 // known combinations of event ID, product ID, and public key.
 export interface KnownTicketType {

--- a/apps/passport-server/src/database/queries/knownEvents.ts
+++ b/apps/passport-server/src/database/queries/knownEvents.ts
@@ -1,0 +1,16 @@
+import { Pool } from "postgres-pool";
+import { KnownEvent } from "../models";
+import { sqlQuery } from "../sqlQuery";
+
+export async function setKnownEvent(
+  client: Pool,
+  eventId: string
+): Promise<KnownEvent> {
+  const result = await sqlQuery(
+    client,
+    `INSERT INTO known_events VALUES($1::UUID)
+    ON CONFLICT DO NOTHING`,
+    [eventId]
+  );
+  return result.rows[0];
+}

--- a/apps/passport-server/src/database/queries/knownTicketTypes.ts
+++ b/apps/passport-server/src/database/queries/knownTicketTypes.ts
@@ -96,9 +96,11 @@ export async function setKnownTicketType(
 ): Promise<KnownTicketType> {
   const result = await sqlQuery(
     client,
-    `INSERT INTO known_ticket_types VALUES($1, $2, $3, $4, $5, $6)
+    `INSERT INTO known_ticket_types
+    (identifier, event_id, product_id, known_public_key_name, known_public_key_type, ticket_group)
+    VALUES($1, $2::UUID, $3, $4, $5, $6)
     ON CONFLICT (identifier) DO UPDATE 
-    SET event_id = $2, product_id = $3, known_public_key_name = $4,
+    SET event_id = $2::UUID, product_id = $3, known_public_key_name = $4,
     known_public_key_type = $5, ticket_group = $6`,
     [
       identifier,

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
@@ -72,7 +72,7 @@ export async function fetchLinkedTelegramEvents(
       dpe.event_name AS "eventName"
     FROM known_events ke
     LEFT JOIN devconnect_pretix_events_info dpe ON dpe.pretix_events_config_id = ke.event_id
-    LEFT JOIN telegram_bot_events tbe ON dpe.pretix_events_config_id = tbe.ticket_event_id;
+    LEFT JOIN telegram_bot_events tbe ON ke.event_id = tbe.ticket_event_id;
     `
   );
 

--- a/apps/passport-server/src/services/devconnectPretixSyncService.ts
+++ b/apps/passport-server/src/services/devconnectPretixSyncService.ts
@@ -6,6 +6,7 @@ import {
   getDevconnectPretixConfig
 } from "../apis/devconnect/organizer";
 import { fetchDevconnectProducts } from "../database/queries/devconnect_pretix_tickets/fetchDevconnectPretixTicket";
+import { setKnownEvent } from "../database/queries/knownEvents";
 import {
   deleteKnownTicketType,
   fetchKnownTicketTypesByGroup,
@@ -214,6 +215,7 @@ export class DevconnectPretixSyncService {
     const savedProductIds = [];
 
     for (const product of products) {
+      await setKnownEvent(this.db, product.event_id);
       await setKnownTicketType(
         this.db,
         `sync-${product.product_id}`,

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -69,6 +69,7 @@ import {
   fetchDevconnectSuperusersForEmail
 } from "../database/queries/devconnect_pretix_tickets/fetchDevconnectPretixTicket";
 import { consumeDevconnectPretixTicket } from "../database/queries/devconnect_pretix_tickets/updateDevconnectPretixTicket";
+import { setKnownEvent } from "../database/queries/knownEvents";
 import {
   fetchKnownPublicKeys,
   fetchKnownTicketByEventAndProductId,
@@ -1369,6 +1370,9 @@ async function setupKnownTicketTypes(
     KnownPublicKeyType.EdDSA,
     JSON.stringify(eddsaPubKey)
   );
+
+  await setKnownEvent(db, ZUZALU_23_EVENT_ID);
+  await setKnownEvent(db, ZUCONNECT_23_EVENT_ID);
 
   await setKnownTicketType(
     db,

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -17,7 +17,7 @@ import {
 } from "../database/queries/telegram/fetchTelegramConversation";
 import {
   fetchEventsPerChat,
-  fetchLinkedPretixAndTelegramEvents,
+  fetchLinkedTelegramEvents,
   fetchTelegramAnonTopicsByChatId,
   fetchTelegramEventsByChatId,
   fetchTelegramTopicsByChatId
@@ -290,9 +290,7 @@ export class TelegramService {
         { parse_mode: "HTML", reply_to_message_id: messageThreadId }
       );
       const msg = await ctx.reply(`Loading tickets and events...`);
-      const events = await fetchLinkedPretixAndTelegramEvents(
-        this.context.dbPool
-      );
+      const events = await fetchLinkedTelegramEvents(this.context.dbPool);
       const eventsWithChats = await chatIDsToChats(
         this.context.dbPool,
         ctx,

--- a/apps/passport-server/src/util/constants.ts
+++ b/apps/passport-server/src/util/constants.ts
@@ -16,3 +16,8 @@ export const ZUCONNECT_23_VISITOR_PRODUCT_ID =
   "98437d28-0a39-4f40-9f2a-b38bf04cb55d";
 export const ZUCONNECT_23_ORGANIZER_PRODUCT_ID =
   "0179ed5b-f265-417c-aeaa-ac61a525c6b0";
+
+export const FALLBACK_EVENT_IDS_TO_EVENT_NAME: Record<string, string> = {
+  [ZUCONNECT_23_EVENT_ID]: "Zuconnect",
+  [ZUZALU_23_EVENT_ID]: "Zuzalu"
+};

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -16,7 +16,7 @@ import {
   ChatIDWithEventIDs,
   LinkedPretixTelegramEvent,
   fetchEventsPerChat,
-  fetchLinkedPretixAndTelegramEvents,
+  fetchLinkedTelegramEvents,
   fetchTelegramAnonTopicsByChatId,
   fetchTelegramEventsByChatId,
   fetchUserTelegramChats
@@ -281,11 +281,11 @@ export const dynamicEvents = async (
           if (!event.isLinked) {
             replyText = `<i>Added ${event.eventName} from chat</i>`;
             await insertTelegramChat(db, ctx.chat.id);
-            await insertTelegramEvent(db, event.configEventID, ctx.chat.id);
+            await insertTelegramEvent(db, event.eventID, ctx.chat.id);
             await editOrSendMessage(ctx, replyText);
           } else {
             replyText = `<i>Removed ${event.eventName} to chat</i>`;
-            await deleteTelegramEvent(db, event.configEventID);
+            await deleteTelegramEvent(db, event.eventID);
           }
         }
         ctx.session.selectedEvent = undefined;
@@ -303,7 +303,7 @@ export const dynamicEvents = async (
   }
   // Otherwise, display all events to manage.
   else {
-    const events = await fetchLinkedPretixAndTelegramEvents(db);
+    const events = await fetchLinkedTelegramEvents(db);
     const eventsWithGateStatus = events.map((e) => {
       return { ...e, isLinked: e.telegramChatID === ctx.chat?.id.toString() };
     });

--- a/apps/passport-server/test/database.spec.ts
+++ b/apps/passport-server/test/database.spec.ts
@@ -37,6 +37,7 @@ import {
   fetchEmailToken,
   insertEmailToken
 } from "../src/database/queries/emailToken";
+import { setKnownEvent } from "../src/database/queries/knownEvents";
 import {
   deleteKnownTicketType,
   fetchKnownTicketByEventAndProductId,
@@ -656,45 +657,50 @@ describe("database reads and writes", function () {
   const knownProductId = randomUUID();
   const ticketTypeIdentifier = "ZUCONNECT_TEST";
 
-  step("should be able to insert known ticket type", async function () {
-    const eddsaPubKey = await eddsaPubKeyPromise;
+  step(
+    "should be able to insert known event and ticket type",
+    async function () {
+      const eddsaPubKey = await eddsaPubKeyPromise;
 
-    await setKnownTicketType(
-      db,
-      ticketTypeIdentifier,
-      knownEventId,
-      knownProductId,
-      testPublicKeyName,
-      KnownPublicKeyType.EdDSA,
-      KnownTicketGroup.Zuconnect23
-    );
+      await setKnownEvent(db, knownEventId);
+      await setKnownTicketType(
+        db,
+        ticketTypeIdentifier,
+        knownEventId,
+        knownProductId,
+        testPublicKeyName,
+        KnownPublicKeyType.EdDSA,
+        KnownTicketGroup.Zuconnect23
+      );
 
-    const knownTicketType = (await fetchKnownTicketByEventAndProductId(
-      db,
-      knownEventId,
-      knownProductId
-    )) as KnownTicketTypeWithKey;
+      const knownTicketType = (await fetchKnownTicketByEventAndProductId(
+        db,
+        knownEventId,
+        knownProductId
+      )) as KnownTicketTypeWithKey;
 
-    expect(knownTicketType.event_id).to.eq(knownEventId);
-    expect(knownTicketType.product_id).to.eq(knownProductId);
-    expect(knownTicketType.known_public_key_name).to.eq(testPublicKeyName);
-    expect(knownTicketType.known_public_key_type).to.eq(
-      KnownPublicKeyType.EdDSA
-    );
-    expect(JSON.parse(knownTicketType.public_key)).to.deep.eq(eddsaPubKey);
-    expect(
-      isEqualEdDSAPublicKey(
-        JSON.parse(knownTicketType.public_key) as EdDSAPublicKey,
-        eddsaPubKey
-      )
-    );
-  });
+      expect(knownTicketType.event_id).to.eq(knownEventId);
+      expect(knownTicketType.product_id).to.eq(knownProductId);
+      expect(knownTicketType.known_public_key_name).to.eq(testPublicKeyName);
+      expect(knownTicketType.known_public_key_type).to.eq(
+        KnownPublicKeyType.EdDSA
+      );
+      expect(JSON.parse(knownTicketType.public_key)).to.deep.eq(eddsaPubKey);
+      expect(
+        isEqualEdDSAPublicKey(
+          JSON.parse(knownTicketType.public_key) as EdDSAPublicKey,
+          eddsaPubKey
+        )
+      );
+    }
+  );
 
   step("should be able to replace known ticket type", async function () {
     const eddsaPubKey = await eddsaPubKeyPromise;
     const newProductId = randomUUID(),
       newEventId = randomUUID();
 
+    await setKnownEvent(db, newEventId);
     // Change the ticket type created in the previous test
     await setKnownTicketType(
       db,


### PR DESCRIPTION
Ensured staging does not break by copying current staging db state into local and restarting server.

https://github.com/proofcarryingdata/zupass/assets/36896271/7ff843d2-64c5-45fc-920c-808dfd24d01c

