### PR TITLE
[probably don't merge this] Faster ZKEdDSAEventTicketPCD initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "typecheck": "turbo run typecheck --parallel",
     "clean": "turbo run clean --parallel && yarn clean:root",
     "clean:root": "rm -rf node_modules",
-    "knip": "knip --no-gitignore"
+    "knip": "knip --no-gitignore",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "@types/circomlibjs": "0.1.4",
@@ -41,6 +42,8 @@
   "dependencies": {
     "@changesets/cli": "^2.26.0",
     "@types/react": "^18.0.22",
+    "patch-package": "^8.0.0",
+    "postinstall-postinstall": "^2.1.0",
     "turbo": "^1.8.5"
   },
   "resolutions": {

--- a/packages/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCD.ts
+++ b/packages/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCD.ts
@@ -176,6 +176,7 @@ export async function init(args: ZKEdDSAEventTicketPCDInitArgs) {
 async function ensureDepsInitialized(): Promise<void> {
   if (!depsInitializedPromise) {
     depsInitializedPromise = (async () => {
+      const start = performance.now();
       const bn128 = await getCurveFromName("bn128", true, null);
       babyJub = new BabyJub(bn128.Fr);
       const pedersenHash = new PedersenHash(babyJub);
@@ -184,6 +185,7 @@ async function ensureDepsInitialized(): Promise<void> {
       const mimcSponge = new MimcSponge(bn128.Fr);
 
       eddsa = new Eddsa(babyJub, pedersenHash, mimc7, poseidon, mimcSponge);
+      console.log(`Initialization took ${performance.now() - start} ms`);
     })();
   }
 

--- a/patches/@types+circomlibjs+0.1.4.patch
+++ b/patches/@types+circomlibjs+0.1.4.patch
@@ -1,0 +1,90 @@
+diff --git a/node_modules/@types/circomlibjs/index.d.cts b/node_modules/@types/circomlibjs/index.d.cts
+index 1ead68c..99205da 100644
+--- a/node_modules/@types/circomlibjs/index.d.cts
++++ b/node_modules/@types/circomlibjs/index.d.cts
+@@ -56,7 +56,7 @@ export class SMTMemDb {
+     setRoot(root: BigNumberish): void;
+ }
+ 
+-export interface BabyJub {
++export class BabyJub {
+     F: any; // https://github.com/iden3/ffjavascript/blob/master/src/wasm_field1.js
+     p: bigint;
+     pm1d2: bigint;
+@@ -67,6 +67,8 @@ export interface BabyJub {
+     A: Uint8Array;
+     D: Uint8Array;
+ 
++    constructor(F: any);
++
+     addPoint(a: Point, b: Point): Point;
+ 
+     mulPointEscalar(base: Point, e: BigNumberish): Point;
+@@ -80,10 +82,12 @@ export interface BabyJub {
+     unpackPoint(buff: Uint8Array): Point;
+ }
+ 
+-export interface Mimc7 {
++export class Mimc7 {
+     F: any; // https://github.com/iden3/ffjavascript/blob/master/src/wasm_field1.js
+     cts: Uint8Array[];
+ 
++    constructor(F: any);
++
+     getIV(seed?: string): bigint;
+ 
+     getConstants(seed?: string, nRounds?: number): Uint8Array[];
+@@ -93,10 +97,12 @@ export interface Mimc7 {
+     multiHash(arr: BigNumberish[], key?: BigNumberish): Uint8Array;
+ }
+ 
+-export interface MimcSponge {
++export class MimcSponge {
+     F: any; // https://github.com/iden3/ffjavascript/blob/master/src/wasm_field1.js
+     cts: Uint8Array[];
+ 
++    constructor(F: any);
++
+     getIV(seed?: string): bigint;
+ 
+     getConstants(seed?: string, nRounds?: number): Uint8Array[];
+@@ -106,10 +112,12 @@ export interface MimcSponge {
+     multiHash(arr: BigNumberish[], key?: BigNumberish, numOutputs?: number): Uint8Array;
+ }
+ 
+-export interface PedersenHash {
++export class PedersenHash {
+     babyJub: BabyJub;
+     bases: any[];
+ 
++    constructor(F: any);
++
+     baseHash(type: "blake" | "blake2b", S: any): any;
+ 
+     hash(msg: Uint8Array, options?: { baseHash?: "blake" | "blake2b" }): Uint8Array;
+@@ -121,7 +129,7 @@ export interface PedersenHash {
+     buffer2bits(buff: Uint8Array): boolean[];
+ }
+ 
+-export interface Eddsa {
++export class Eddsa {
+     F: any; // https://github.com/iden3/ffjavascript/blob/master/src/wasm_field1.js
+     babyJub: BabyJub;
+     pedersenHash: PedersenHash;
+@@ -129,6 +137,9 @@ export interface Eddsa {
+     poseidon: Poseidon;
+     mimcSponge: MimcSponge;
+ 
++    constructor(babyJub: BabyJub, pedersenHash: PedersenHash, mimc7: Mimc7,
++        poseidon: Poseidon, mimcSponge: MimcSponge);
++
+     pruneBuffer(buff: Uint8Array): Uint8Array;
+ 
+     prv2pub(prv: any): Point;
+@@ -377,3 +388,5 @@ export namespace poseidonContract {
+ 
+     function generateABI(nInputs: number): any;
+ }
++
++export function getCurveFromName(name: any, singleThread: any, plugins: any): any;
+\ No newline at end of file

--- a/patches/circomlibjs+0.1.7.patch
+++ b/patches/circomlibjs+0.1.7.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/circomlibjs/build/main.cjs b/node_modules/circomlibjs/build/main.cjs
+index 41b3edb..d81c710 100644
+--- a/node_modules/circomlibjs/build/main.cjs
++++ b/node_modules/circomlibjs/build/main.cjs
+@@ -1,5 +1,7 @@
+ 'use strict';
+ 
++import { getCurveFromName } from 'ffjavascript';
++
+ Object.defineProperty(exports, '__esModule', { value: true });
+ 
+ var ffjavascript = require('ffjavascript');
+@@ -27388,3 +27390,9 @@ exports.mimc7Contract = mimc7Contract;
+ exports.mimcSpongecontract = mimcSpongecontract;
+ exports.newMemEmptyTrie = newMemEmptyTrie;
+ exports.poseidonContract = poseidonContract;
++exports.BabyJub = BabyJub;
++exports.PedersenHash = PedersenHash;
++exports.Mimc7 = Mimc7;
++exports.MimcSponge = MimcSponge;
++exports.Eddsa = Eddsa;
++exports.getCurveFromName = getCurveFromName;
+\ No newline at end of file

--- a/patches/circomlibjs+0.1.7.patch
+++ b/patches/circomlibjs+0.1.7.patch
@@ -1,16 +1,8 @@
 diff --git a/node_modules/circomlibjs/build/main.cjs b/node_modules/circomlibjs/build/main.cjs
-index 41b3edb..d81c710 100644
+index 41b3edb..e788e64 100644
 --- a/node_modules/circomlibjs/build/main.cjs
 +++ b/node_modules/circomlibjs/build/main.cjs
-@@ -1,5 +1,7 @@
- 'use strict';
- 
-+import { getCurveFromName } from 'ffjavascript';
-+
- Object.defineProperty(exports, '__esModule', { value: true });
- 
- var ffjavascript = require('ffjavascript');
-@@ -27388,3 +27390,9 @@ exports.mimc7Contract = mimc7Contract;
+@@ -27388,3 +27388,9 @@ exports.mimc7Contract = mimc7Contract;
  exports.mimcSpongecontract = mimcSpongecontract;
  exports.newMemEmptyTrie = newMemEmptyTrie;
  exports.poseidonContract = poseidonContract;
@@ -19,5 +11,5 @@ index 41b3edb..d81c710 100644
 +exports.Mimc7 = Mimc7;
 +exports.MimcSponge = MimcSponge;
 +exports.Eddsa = Eddsa;
-+exports.getCurveFromName = getCurveFromName;
++exports.getCurveFromName = ffjavascript.getCurveFromName;
 \ No newline at end of file

--- a/yarn.lock
+++ b/yarn.lock
@@ -4846,6 +4846,11 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 "@zk-kit/groth16@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@zk-kit/groth16/-/groth16-0.3.0.tgz#74240beb26e98e4ea3546159108ca968ed7c019b"
@@ -5255,6 +5260,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 atomically@^2.0.0:
   version "2.0.2"
@@ -6015,6 +6025,11 @@ ci-info@^3.1.0, ci-info@^3.2.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
+
+ci-info@^3.7.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 cids@^0.7.1:
   version "0.7.5"
@@ -8214,6 +8229,13 @@ find-yarn-workspace-root2@1.2.16:
     micromatch "^4.0.2"
     pkg-dir "^4.2.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 find@^0.2.4:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/find/-/find-0.2.9.tgz#4b73f1ff9e56ad91b76e716407fe5ffe6554bb8c"
@@ -8353,6 +8375,16 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-minipass@^1.2.7:
   version "1.2.7"
@@ -9192,6 +9224,11 @@ is-date-object@^1.0.1, is-date-object@^1.0.5:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -9402,6 +9439,13 @@ is-windows@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -10006,6 +10050,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json-stable-stringify@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz#e06f23128e0bbe342dc996ed5a19e28b57b580e0"
+  integrity sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==
+  dependencies:
+    jsonify "^0.0.1"
+
 json-stringify-safe@~5.0.0, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -10034,6 +10085,20 @@ jsonfile@^4.0.0:
   integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
 jsonpath@^1.1.1:
   version "1.1.1"
@@ -10091,6 +10156,13 @@ kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -11127,6 +11199,14 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opentracing@^0.14.4:
   version "0.14.7"
   resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.7.tgz#25d472bd0296dc0b64d7b94cbc995219031428f5"
@@ -11359,6 +11439,27 @@ parseurl@^1.3.3, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+patch-package@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
+  integrity sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    json-stable-stringify "^1.0.2"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^7.5.3"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^2.2.2"
 
 path-browserify@^1.0.1:
   version "1.0.1"
@@ -11721,6 +11822,11 @@ postgres-range@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/postgres-range/-/postgres-range-1.1.3.tgz#9ccd7b01ca2789eb3c2e0888b3184225fa859f76"
   integrity sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 preferred-pm@^3.0.0:
   version "3.1.2"
@@ -12416,7 +12522,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^2.6.1:
+rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -12817,6 +12923,11 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -14038,6 +14149,11 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
 unload@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/unload/-/unload-2.4.1.tgz#b0c5b7fb44e17fcbf50dcb8fb53929c59dd226a5"
@@ -14787,6 +14903,11 @@ yaml@^2.1.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.2.tgz#f522db4313c671a0ca963a75670f1c12ea909144"
   integrity sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==
+
+yaml@^2.2.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.3.tgz#01f6d18ef036446340007db8e016810e5d64aad9"
+  integrity sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==
 
 yargs-parser@20.2.4:
   version "20.2.4"


### PR DESCRIPTION
As part of proving/verifying, ZKEdDSAEventTicketPCD calls `ensureDepsInitialized`. I've timed this as taking about 2 seconds on my MBA M1.

However, most of the work being done here is repetition!

We call `buildBabyJub()`, which calls `getCurveFromName("bn128", true)`, which takes around 300ms. But then we call `buildEddsa`, which _also_ calls `buildBabyJub()`. Even worse, `buildEddsa()` calls other functions that also call `getCurveFromName("bn128", true)`, each time taking 300ms to do something that has already been done.

Unfortunately there's no API that allows for a more sensible approach, so we have to patch `circomlibjs`. This PR takes a simple approach to patching the library and its type definitions, with the effect that `ensureDepsInitialized` ends up taking about 800ms in total, rather than 2000ms. I think this is pretty important as this is required before we can generate ZK QR codes (required for #772) and also before anyone can use `ZKEdDSAEventTicketPCD` for authentication (if that is the approach we go with).