### PR TITLE
show valid event ids in zkticket prove screen

### DIFF
--- a/apps/anon-message-client/src/app/page.tsx
+++ b/apps/anon-message-client/src/app/page.tsx
@@ -37,7 +37,6 @@ async function requestProof(
 ) {
   const watermark = getMessageWatermark(message).toString();
   console.log("WATERMARK", watermark);
-  const revealedFields = {};
 
   const args: ZKEdDSAEventTicketPCDArgs = {
     ticket: {
@@ -45,15 +44,11 @@ async function requestProof(
       pcdType: EdDSATicketPCDPackage.name,
       value: undefined,
       userProvided: true,
-      displayName: "Ticket",
-      description: "",
       validatorParams: {
         eventIds: validEventIds,
         productIds: [],
-        // TODO: surface which event ticket we are looking for
-        notFoundMessage: "You don't have a ticket for this event."
-      },
-      hideIcon: true
+        notFoundMessage: "You don't have an eligible ticket."
+      }
     },
     identity: {
       argumentType: ArgumentTypeName.PCD,
@@ -63,13 +58,12 @@ async function requestProof(
     },
     fieldsToReveal: {
       argumentType: ArgumentTypeName.ToggleList,
-      value: revealedFields,
-      userProvided: false,
-      description: Object.keys(revealedFields).length
-        ? "The following fields will be revealed"
-        : "No information will be revealed"
+      value: {},
+      userProvided: false
     },
     externalNullifier: {
+      description:
+        "This is a hash that encodes the chatId and topicId of the message you are posting.",
       argumentType: ArgumentTypeName.BigInt,
       value: getAnonTopicNullifier(
         parseInt(chatId),
@@ -83,6 +77,8 @@ async function requestProof(
       userProvided: false
     },
     watermark: {
+      description:
+        "This is the hash of the message you are posting. Zucat uses this to make sure the same proof cannot be used to post other messages.",
       argumentType: ArgumentTypeName.BigInt,
       value: watermark,
       userProvided: false

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -112,7 +112,7 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
       <PCDArgs
         args={args}
         setArgs={setArgs}
-        options={pcdPackage.getProveDisplayOptions?.()?.defaultArgs}
+        options={pcdPackage.getProveDisplayOptions?.(args)?.defaultArgs}
       />
 
       {error && <ErrorContainer>{error}</ErrorContainer>}

--- a/apps/passport-client/components/shared/PCDArgs.tsx
+++ b/apps/passport-client/components/shared/PCDArgs.tsx
@@ -53,7 +53,10 @@ export function PCDArgs<T extends PCDPackage>({
 }) {
   const [showAll, setShowAll] = useState(false);
   const [visible, hidden] = _.partition(
-    Object.entries(args),
+    _.orderBy(Object.entries(args), [
+      ([key]) => options?.[key]?.displayOrder ?? Number.MAX_VALUE,
+      ([key]) => key
+    ]),
     ([key]) => options?.[key]?.defaultVisible ?? true
   );
 

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -267,15 +267,11 @@ const generateProofUrl = (
       pcdType: EdDSATicketPCDPackage.name,
       value: undefined,
       userProvided: true,
-      displayName: "Your Ticket",
-      description: "",
       validatorParams: {
         eventIds: validEventIds,
         productIds: [],
-        // TODO: surface which event ticket we are looking for
-        notFoundMessage: "You don't have a ticket to this event."
-      },
-      hideIcon: true
+        notFoundMessage: "You don't have an eligible ticket."
+      }
     },
     identity: {
       argumentType: ArgumentTypeName.PCD,
@@ -286,8 +282,7 @@ const generateProofUrl = (
     fieldsToReveal: {
       argumentType: ArgumentTypeName.ToggleList,
       value: fieldsToReveal,
-      userProvided: false,
-      hideIcon: true
+      userProvided: false
     },
     externalNullifier: {
       argumentType: ArgumentTypeName.BigInt,
@@ -303,7 +298,8 @@ const generateProofUrl = (
       argumentType: ArgumentTypeName.BigInt,
       value: telegramUserId.toString(),
       userProvided: false,
-      description: `This encodes your Telegram user ID so that the proof can grant only you access to the TG group.`
+      description:
+        "This encodes your Telegram user ID so that the proof can grant only you access to the TG group."
     }
   };
 
@@ -320,7 +316,7 @@ const generateProofUrl = (
     genericProveScreen: true,
     title: "",
     description:
-      "Zucat requests a zero-knowledge proof of your ticket to join a Telegram group."
+      "Zucat requests a zero-knowledge proof of your ticket for Telegram group invitation. Only specific details are revealed while personal information like ticket ID and email remains confidential, viewable only by you."
   });
   return proofUrl;
 };

--- a/packages/pcd-types/src/pcd.ts
+++ b/packages/pcd-types/src/pcd.ts
@@ -110,7 +110,7 @@ export interface PCDPackage<
    * Given the arguments passed into {@link PCDPackage#prove}, returns options on how
    * to render the Prove Screen for this {@link PCDPackage}.
    */
-  getProveDisplayOptions?: () => ProveDisplayOptions<A>;
+  getProveDisplayOptions?: (args: A) => ProveDisplayOptions<A>;
 
   /**
    * This is effectively a factory for instances of the {@link PCD} that this {@link PCDPackage}
@@ -232,6 +232,10 @@ export interface Argument<
    * proactive filtering of options, such as PCDs, in the UI.
    */
   validatorParams?: ValidatorParams;
+  /**
+   * Order of the argument in the UI. Lower numbers are displayed first. If two arguments have the same order, they are displayed in alphabetical order. Unspecified arguments are displayed last.
+   */
+  displayOrder?: number;
 }
 
 /**


### PR DESCRIPTION
[0/n] https://github.com/proofcarryingdata/zupass/issues/944

* show valid event ids by default
* move ticket to the bottom based on feedback 
    1. it logically flows better by explaining what are being requested before asking you to present/select the ticket 
    2. when no ticket is found, the error message makes more sense to be after the requirements and next to the Prove button.
* add a new optional `displayOrder` field to `Argument<>` to control the display order of argument on proof screen. Currently, arguments are always alphabetically ordered.
* make `defaultArgs` aware of the argument value. This makes argument description more expressive and communicates only relevant information with user, especially for complex one like `validEventIds`
* based on feedback "what is the value of zero knowledge proof" and "what is so private about my ticket / why should i care", update the Zucat Telegram invite message to 1/ clarify what potential personally identified information is not included in the proof 2/ consistently reassure the user about the privacy of their data.

Note: follow up PRs will address
* validEventIds are ugly af and should show event names instead
* potentially restyle the field containers to look nicer
* make appHeader look nice

tested with consumer client examples

Zucat Auth

<img width="398" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/e1ebe007-4041-42d7-ac0f-4c20a9a1d0fb">

Zucat anonsend

<img width="400" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/512bc4b9-7f55-4007-a51a-d5d751a4c451">

No ticket error

<img width="403" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/e7111601-d628-441b-b007-e23b6c5303f4">


Multiple events

<img width="421" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/c8eb1b5c-c683-4257-93be-2b864d161af9">

Empty valid event ids list hides the input by default

<img width="427" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/441f1d55-d57f-4f6f-8626-d70959142804">


