### PR TITLE
[DMS/ZMS] add viewport meta tag for mobile

### DIFF
--- a/apps/passport-server/src/util/telegramWebApp.ts
+++ b/apps/passport-server/src/util/telegramWebApp.ts
@@ -31,6 +31,7 @@ export const errorHtmlWithDetails = (error: Error): string => {
   <html>
     <head>
       <title>Error</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
       <style>
         body {
           background-color: white;


### PR DESCRIPTION
Makes the error page responsive on mobile