### PR TITLE
http fetch retry

### DIFF
--- a/apps/passport-server/.eslintrc.js
+++ b/apps/passport-server/.eslintrc.js
@@ -13,18 +13,25 @@ module.exports = {
           constructors: "explicit",
           methods: "explicit",
           properties: "explicit",
-          parameterProperties: "explicit",
-        },
-      },
+          parameterProperties: "explicit"
+        }
+      }
     ],
+    "no-restricted-globals": [
+      "error",
+      {
+        name: "fetch",
+        message: "Use instrumentedFetch instead"
+      }
+    ]
   },
   overrides: [
     {
       // enable the rule specifically for TypeScript files
       files: ["*.ts", "*.mts", "*.cts", "*.tsx"],
       rules: {
-        "@typescript-eslint/explicit-function-return-type": "error",
-      },
-    },
-  ],
+        "@typescript-eslint/explicit-function-return-type": "error"
+      }
+    }
+  ]
 };

--- a/apps/passport-server/src/apis/fetch.ts
+++ b/apps/passport-server/src/apis/fetch.ts
@@ -16,7 +16,10 @@ export function instrumentedFetch(
 
     try {
       const result = await execWithRetry(
-        () => fetch(input, init),
+        () => {
+          // eslint-disable-next-line no-restricted-globals
+          return fetch(input, init);
+        },
         (e) => {
           const errorMessage = getErrorMessage(e);
           return errorMessage.includes("other side closed");

--- a/apps/passport-server/src/apis/fetch.ts
+++ b/apps/passport-server/src/apis/fetch.ts
@@ -1,5 +1,7 @@
+import { getErrorMessage } from "@pcd/util";
 import { setError, traced } from "../services/telemetryService";
 import { logger } from "../util/logger";
+import { execWithRetry } from "../util/retry";
 
 export function instrumentedFetch(
   input: RequestInfo | URL,
@@ -13,7 +15,15 @@ export function instrumentedFetch(
     span?.setAttribute("method", init?.method ?? "GET");
 
     try {
-      const result = await fetch(input, init);
+      const result = await execWithRetry(
+        () => fetch(input, init),
+        (e) => {
+          const errorMessage = getErrorMessage(e);
+          return errorMessage.includes("other side closed");
+        },
+        3
+      );
+
       span?.setAttribute("ok", result.ok);
       span?.setAttribute("statusCode", result.status);
       return result;

--- a/apps/passport-server/src/apis/fetch.ts
+++ b/apps/passport-server/src/apis/fetch.ts
@@ -22,6 +22,8 @@ export function instrumentedFetch(
         },
         (e) => {
           const errorMessage = getErrorMessage(e);
+          // some endpoints sometimes close our connection from their end
+          // which is a case we want to retry.
           return errorMessage.includes("other side closed");
         },
         3

--- a/apps/passport-server/src/apis/zuconnect/zuconnectTripshaAPI.ts
+++ b/apps/passport-server/src/apis/zuconnect/zuconnectTripshaAPI.ts
@@ -3,6 +3,7 @@ import _ from "lodash";
 import urljoin from "url-join";
 import { z } from "zod";
 import { logger } from "../../util/logger";
+import { instrumentedFetch } from "../fetch";
 
 /**
  * A schema for validating the API response from Tripsha.
@@ -66,7 +67,14 @@ export class ZuconnectTripshaAPI {
    */
   public async fetchTickets(): Promise<ZuconnectTicket[]> {
     const url = urljoin(this.baseUrl, "tickets", this.authKey);
-    const fetchResult = await fetch(url);
+    const fetchResult = await instrumentedFetch(url);
+
+    if (fetchResult.status !== 200) {
+      throw new Error(
+        `Tripsha API responded with not-ok status code ${fetchResult.status}`
+      );
+    }
+
     const data = await fetchResult.json();
 
     if (_.isArray(data.tickets)) {

--- a/apps/passport-server/src/database/sqlQuery.ts
+++ b/apps/passport-server/src/database/sqlQuery.ts
@@ -1,9 +1,9 @@
-import { getActiveSpan } from "@opentelemetry/api/build/src/trace/context-utils";
-import { getErrorMessage, sleep } from "@pcd/util";
+import { getErrorMessage } from "@pcd/util";
 import { QueryResult } from "pg";
 import { Pool, PoolClient } from "postgres-pool";
 import { traced } from "../services/telemetryService";
 import { logger } from "../util/logger";
+import { execWithRetry } from "../util/retry";
 
 /**
  * Executes a sql query against the database, and traces its performance.
@@ -107,36 +107,4 @@ async function execTransactionWithRetry<T>(
     },
     3
   );
-}
-
-async function execWithRetry<T>(
-  task: () => Promise<T>,
-  shouldRetry: (e: unknown) => boolean,
-  maxTries: number
-): Promise<T> {
-  const span = getActiveSpan();
-  const backoffFactorMs = 100;
-  let latestError = undefined;
-
-  span?.setAttribute("max_tries", maxTries);
-
-  for (let i = 0; i < maxTries; i++) {
-    span?.setAttribute("try_count", i + 1);
-
-    try {
-      const result = await task();
-      span?.setAttribute("retry_succeeded", true);
-      return result;
-    } catch (e) {
-      latestError = e;
-      if (!shouldRetry(e)) {
-        break;
-      }
-    }
-
-    await sleep(backoffFactorMs * (i + 1));
-  }
-
-  span?.setAttribute("retry_succeeded", false);
-  throw latestError;
 }

--- a/apps/passport-server/src/services/telemetryService.ts
+++ b/apps/passport-server/src/services/telemetryService.ts
@@ -66,6 +66,7 @@ export async function writeMarker(
   }
 
   try {
+    // eslint-disable-next-line no-restricted-globals
     await fetch(honeyClient.apiHost + `1/markers/${DATASET_SLUG}`, {
       method: "POST",
       body: JSON.stringify({

--- a/apps/passport-server/src/util/retry.ts
+++ b/apps/passport-server/src/util/retry.ts
@@ -1,4 +1,5 @@
 import { getActiveSpan } from "@opentelemetry/api/build/src/trace/context-utils";
+import { sleep } from "@pcd/util";
 
 export async function execWithRetry<T>(
   task: () => Promise<T>,

--- a/apps/passport-server/src/util/retry.ts
+++ b/apps/passport-server/src/util/retry.ts
@@ -1,0 +1,33 @@
+import { getActiveSpan } from "@opentelemetry/api/build/src/trace/context-utils";
+
+export async function execWithRetry<T>(
+  task: () => Promise<T>,
+  shouldRetry: (e: unknown) => boolean,
+  maxTries: number
+): Promise<T> {
+  const span = getActiveSpan();
+  const backoffFactorMs = 100;
+  let latestError = undefined;
+
+  span?.setAttribute("max_tries", maxTries);
+
+  for (let i = 0; i < maxTries; i++) {
+    span?.setAttribute("try_count", i + 1);
+
+    try {
+      const result = await task();
+      span?.setAttribute("retry_succeeded", true);
+      return result;
+    } catch (e) {
+      latestError = e;
+      if (!shouldRetry(e)) {
+        break;
+      }
+    }
+
+    await sleep(backoffFactorMs * (i + 1));
+  }
+
+  span?.setAttribute("retry_succeeded", false);
+  throw latestError;
+}

--- a/apps/passport-server/test/server.spec.ts
+++ b/apps/passport-server/test/server.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 import { expect } from "chai";
 import "mocha";
 import { startApplication, stopApplication } from "../src/application";


### PR DESCRIPTION
closes https://github.com/proofcarryingdata/zupass/issues/1012

@robknight - i've included a few minor changes to the tripsha sync service
@rrrliu - i've extracted the retry logic into a re-useable function you could use for the telegram retry logic you mentioned earlier today