### PR TITLE
Ensure skip password modal is not closeable with the "X"

### DIFF
--- a/apps/passport-client/components/modals/Modal.tsx
+++ b/apps/passport-client/components/modals/Modal.tsx
@@ -64,7 +64,8 @@ function isModalDismissable(modal: AppState["modal"]) {
     "changed-password",
     "another-device-changed-password",
     "upgrade-account-modal",
-    "require-add-password"
+    "require-add-password",
+    "confirm-setup-later"
   ].includes(modal.modalType);
 }
 


### PR DESCRIPTION
Still closeable via the "cancel" button.

Before:
<img width="504" alt="Screenshot 2023-10-19 at 3 26 06 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/7f5a5ad6-5d55-4f8e-91e2-18dcb4e67a0b">

After:
<img width="477" alt="Screenshot 2023-10-19 at 3 25 37 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/179cfa91-4112-41d6-8ecf-484c4ea18d0d">
