### PR TITLE
add "Zupass" as sender name in noreply@zupass.org

### DIFF
--- a/apps/passport-server/src/services/emailService.ts
+++ b/apps/passport-server/src/services/emailService.ts
@@ -46,7 +46,7 @@ export class EmailService {
 
       const msg = {
         to: to,
-        from: ZUPASS_SENDER_EMAIL,
+        from: `Zupass <${ZUPASS_SENDER_EMAIL}>`,
         subject: "Welcome to Zupass",
         ...(await this.composeTokenEmail(token))
       };


### PR DESCRIPTION
Before:

<img width="330" alt="Screenshot 2023-10-20 at 10 24 56 AM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/e396f907-226e-4fff-8122-509e564941e3">

Now:

![image](https://github.com/proofcarryingdata/zupass/assets/36896271/0379a6b8-0e26-4dec-99f7-560810ca72de)