### PR TITLE
Include signed name and email in EdDSATicketPCD

### DIFF
--- a/apps/consumer-client/src/pages/examples/zk-eddsa-event-ticket-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/zk-eddsa-event-ticket-proof.tsx
@@ -35,6 +35,8 @@ export default function Page() {
     useState(false);
   const [revealIsConsumed, setRevealIsConsumed] = useState(false);
   const [revealIsRevoked, setRevealIsRevoked] = useState(false);
+  const [revealAttendeeEmail, setRevealAttendeeEmail] = useState(false);
+  const [revealAttendeeName, setRevealAttendeeName] = useState(false);
   const [revealFieldsUserProvided, setRevealFieldsUserProvided] =
     useState(false);
   const [validEventIdsInput, setValidEventIdsInput] = useState("");
@@ -65,7 +67,9 @@ export default function Page() {
       revealTimestampSigned,
       revealAttendeeSemaphoreId,
       revealIsConsumed,
-      revealIsRevoked
+      revealIsRevoked,
+      revealAttendeeEmail,
+      revealAttendeeName
     }),
     [
       revealTicketId,
@@ -75,7 +79,9 @@ export default function Page() {
       revealTimestampSigned,
       revealAttendeeSemaphoreId,
       revealIsConsumed,
-      revealIsRevoked
+      revealIsRevoked,
+      revealAttendeeEmail,
+      revealAttendeeName
     ]
   );
 
@@ -234,6 +240,28 @@ export default function Page() {
         <label>
           <input
             type="checkbox"
+            checked={revealAttendeeEmail}
+            onChange={() => {
+              setRevealAttendeeEmail((checked) => !checked);
+            }}
+          />
+          request attendeeEmail?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealAttendeeName}
+            onChange={() => {
+              setRevealAttendeeName((checked) => !checked);
+            }}
+          />
+          request attendeeName?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
             checked={revealFieldsUserProvided}
             onChange={() => {
               setRevealFieldsUserProvided((checked) => !checked);
@@ -322,6 +350,20 @@ export default function Page() {
                   // undefined means it is not revealed in this PCD
                   pcd.claim.partialTicket.isRevoked !== undefined
                     ? pcd.claim.partialTicket.isRevoked
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Attendee Email: ${
+                  // attendeeEmail can be true, false, or undefined
+                  // undefined means it is not revealed in this PCD
+                  pcd.claim.partialTicket.attendeeEmail !== undefined
+                    ? pcd.claim.partialTicket.attendeeEmail
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Attendee Name: ${
+                  // attendeeName can be true, false, or undefined
+                  // undefined means it is not revealed in this PCD
+                  pcd.claim.partialTicket.attendeeName !== undefined
+                    ? pcd.claim.partialTicket.attendeeName
                     : "HIDDEN"
                 }`}</p>
                 <p>{`Signer: ${pcd.claim.signer}`}</p>

--- a/apps/passport-server/migrations/46_clear_cache.sql
+++ b/apps/passport-server/migrations/46_clear_cache.sql
@@ -1,0 +1,1 @@
+DELETE FROM cache;

--- a/packages/eddsa-ticket-pcd/src/EdDSATicketPCD.ts
+++ b/packages/eddsa-ticket-pcd/src/EdDSATicketPCD.ts
@@ -213,7 +213,7 @@ export async function verify(pcd: EdDSATicketPCD): Promise<boolean> {
   const messageDerivedFromClaim = ticketDataToBigInts(pcd.claim.ticket);
 
   if (!_.isEqual(messageDerivedFromClaim, pcd.proof.eddsaPCD.claim.message)) {
-    throw new Error(`ticket data does not match proof`);
+    return false;
   }
 
   return EdDSAPCDPackage.verify(pcd.proof.eddsaPCD);

--- a/packages/eddsa-ticket-pcd/src/EdDSATicketPCD.ts
+++ b/packages/eddsa-ticket-pcd/src/EdDSATicketPCD.ts
@@ -53,8 +53,6 @@ export enum TicketCategory {
  */
 export interface ITicketData {
   // The fields below are not signed and are used for display purposes.
-  attendeeName: string;
-  attendeeEmail: string;
   eventName: string;
   ticketName: string;
   checkerEmail: string | undefined;
@@ -69,6 +67,8 @@ export interface ITicketData {
   isConsumed: boolean;
   isRevoked: boolean;
   ticketCategory: TicketCategory;
+  attendeeName: string;
+  attendeeEmail: string;
 }
 
 /**

--- a/packages/eddsa-ticket-pcd/src/utils.ts
+++ b/packages/eddsa-ticket-pcd/src/utils.ts
@@ -1,5 +1,10 @@
 import { EdDSAPublicKey } from "@pcd/eddsa-pcd";
-import { booleanToBigInt, numberToBigInt, uuidToBigInt } from "@pcd/util";
+import {
+  booleanToBigInt,
+  generateSnarkMessageHash,
+  numberToBigInt,
+  uuidToBigInt
+} from "@pcd/util";
 import { EdDSATicketPCD, ITicketData } from "./EdDSATicketPCD";
 
 /**
@@ -42,8 +47,8 @@ export function ticketDataToBigInts(data: ITicketData): SerializedTicket {
     booleanToBigInt(data.isConsumed),
     booleanToBigInt(data.isRevoked),
     numberToBigInt(data.ticketCategory),
-    numberToBigInt(0),
-    numberToBigInt(0),
+    generateSnarkMessageHash(data.attendeeEmail),
+    generateSnarkMessageHash(data.attendeeName),
     numberToBigInt(0)
   ];
 }

--- a/packages/zk-eddsa-event-ticket-pcd/src/CardBody.tsx
+++ b/packages/zk-eddsa-event-ticket-pcd/src/CardBody.tsx
@@ -70,6 +70,18 @@ export function ZKEdDSAEventTicketCardBody({
       </TextContainer>
       <Spacer h={8} />
 
+      <FieldLabel>Attendee Email</FieldLabel>
+      <TextContainer>
+        {pcd.claim.partialTicket.attendeeEmail || "HIDDEN"}
+      </TextContainer>
+      <Spacer h={8} />
+
+      <FieldLabel>Attendee Name</FieldLabel>
+      <TextContainer>
+        {pcd.claim.partialTicket.attendeeName || "HIDDEN"}
+      </TextContainer>
+      <Spacer h={8} />
+
       <FieldLabel>Watermark</FieldLabel>
       <TextContainer>{pcd.claim.watermark}</TextContainer>
       <Spacer h={8} />

--- a/packages/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCD.ts
+++ b/packages/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCD.ts
@@ -314,10 +314,11 @@ function snarkInputForProof(
     revealTicketIsRevoked: fieldsToReveal.revealIsRevoked ? "1" : "0",
     ticketCategory: ticketAsBigIntArray[8].toString(),
     revealTicketCategory: fieldsToReveal.revealTicketCategory ? "1" : "0",
-    // Now used for attendee email:
+    // This field was previously reserved, but is now used for attendee email.
+    // See later comment to explain the concept of reserved fields.
     reservedSignedField1: ticketAsBigIntArray[9].toString(),
     revealReservedSignedField1: fieldsToReveal.revealAttendeeEmail ? "1" : "0",
-    // Now used for attendee name:
+    // This field was previously reserved, but is now used for attendee name:
     reservedSignedField2: ticketAsBigIntArray[10].toString(),
     revealReservedSignedField2: fieldsToReveal.revealAttendeeName ? "1" : "0",
 

--- a/packages/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCD.ts
+++ b/packages/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCD.ts
@@ -314,12 +314,15 @@ function snarkInputForProof(
     revealTicketIsRevoked: fieldsToReveal.revealIsRevoked ? "1" : "0",
     ticketCategory: ticketAsBigIntArray[8].toString(),
     revealTicketCategory: fieldsToReveal.revealTicketCategory ? "1" : "0",
+    // Now used for attendee email:
     reservedSignedField1: ticketAsBigIntArray[9].toString(),
     revealReservedSignedField1: fieldsToReveal.revealAttendeeEmail ? "1" : "0",
+    // Now used for attendee name:
     reservedSignedField2: ticketAsBigIntArray[10].toString(),
     revealReservedSignedField2: fieldsToReveal.revealAttendeeName ? "1" : "0",
-    // These fields currently do not have any preset semantic meaning, although the intention
-    // is for them to convert into meaningful fields in the future. We are reserving them now
+
+    // This field currently does not have any preset semantic meaning, although the intention
+    // is for it to convert into a meaningful field in the future. We are reserving it now
     // so that we can keep the Circom configuration (.zkey and .wasm) as we add new fields,
     // and we would only need to change the TypeScript. For now, we will treat the inputs as
     // 0 in terms of signatures.
@@ -394,20 +397,11 @@ function claimFromProofResult(
   if (!babyJubIsNegativeOne(publicSignals[10])) {
     partialTicket.attendeeName = ticketPCD.claim.ticket.attendeeName;
   }
-  // These three fields are currently not typed or being used, but are kept
-  // as reserved fields that are hardcoded to zero and included in the preimage
-  // of the hashed signature. As such, the flags for revealing these reserved
-  // signed fields should always be -1 until they are being typed and used.
-  /*  if (!babyJubIsNegativeOne(publicSignals[9])) {
-    throw new Error(
-      "ZkEdDSAEventTicketPCD: reservedSignedField1 is not in use"
-    );
-  }
-  if (!babyJubIsNegativeOne(publicSignals[10])) {
-    throw new Error(
-      "ZkEdDSAEventTicketPCD: reservedSignedField2 is not in use"
-    );
-  }*/
+
+  // This field is currently not typed or being used, but is being kept as
+  // a reserved field that is hardcoded to zero and included in the preimage
+  // of the hashed signature. As such, the flags for revealing this reserved
+  // signed field should always be -1 until it is being typed and used.
   if (!babyJubIsNegativeOne(publicSignals[11])) {
     throw new Error(
       "ZkEdDSAEventTicketPCD: reservedSignedField3 is not in use"
@@ -587,9 +581,10 @@ function publicSignalsFromClaim(claim: ZKEdDSAEventTicketPCDClaim): string[] {
       ? negOne
       : generateSnarkMessageHash(t.attendeeName).toString()
   );
-  // Placeholder for reserved fields
 
+  // Placeholder for reserved field
   ret.push(negOne);
+
   ret.push(claim.nullifierHash || negOne);
 
   // Public inputs appear in public signals in declaration order

--- a/packages/zk-eddsa-event-ticket-pcd/test/ZKEdDSAEventTicketPCD.spec.ts
+++ b/packages/zk-eddsa-event-ticket-pcd/test/ZKEdDSAEventTicketPCD.spec.ts
@@ -451,6 +451,12 @@ describe("ZKEdDSAEventTicketPCD should work", function () {
     await testProveBadTicketArgs(validArgs, async (ticket: ITicketData) => {
       ticket.isRevoked = !ticket.isRevoked;
     });
+    await testProveBadTicketArgs(validArgs, async (ticket: ITicketData) => {
+      ticket.attendeeEmail = "invalid@example.com";
+    });
+    await testProveBadTicketArgs(validArgs, async (ticket: ITicketData) => {
+      ticket.attendeeName = "Invalid Name";
+    });
 
     // Non-ticket arguments set to incorrect values.
     await testProveBadArgs(
@@ -537,7 +543,7 @@ describe("ZKEdDSAEventTicketPCD should work", function () {
       claim.partialTicket.attendeeEmail = "wrongemail@example.com";
     });
     await testVerifyBadClaim(validPCD, (claim: ZKEdDSAEventTicketPCDClaim) => {
-      claim.partialTicket.attendeeName = "Some guy who doesn't exist";
+      claim.partialTicket.attendeeName = "Some person who doesn't exist";
     });
   });
 
@@ -576,6 +582,12 @@ describe("ZKEdDSAEventTicketPCD should work", function () {
     });
     await testVerifyBadClaim(validPCD, (claim: ZKEdDSAEventTicketPCDClaim) => {
       claim.partialTicket.ticketCategory = TicketCategory.PcdWorkingGroup;
+    });
+    await testVerifyBadClaim(validPCD, (claim: ZKEdDSAEventTicketPCDClaim) => {
+      claim.partialTicket.attendeeEmail = "incorrect@example.com";
+    });
+    await testVerifyBadClaim(validPCD, (claim: ZKEdDSAEventTicketPCDClaim) => {
+      claim.partialTicket.attendeeName = "Incorrect name";
     });
   });
 


### PR DESCRIPTION
Closes #1051.

~Does not add support for revealing these fields as part of the `ZKEdDSAEventTicketPCD` - this can be added separately as necessary.~ It turned out to be necessary to add support for this to the `ZKEdDSAEventTicketPCD`, so now it's also possible to disclose your name and email address as part of the ZK proof.