### PR TITLE
Fix flash

### DIFF
--- a/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
@@ -41,6 +41,7 @@ export function AlreadyRegisteredScreen() {
   const identityCommitment = query?.get("identityCommitment");
   const [error, setError] = useState<string | undefined>();
   const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const [isLoadingUser, setIsLoadingUser] = useState(false);
   const [sendingConfirmationEmail, setSendingConfirmationEmail] =
     useState(false);
   const [password, setPassword] = useState("");
@@ -141,12 +142,12 @@ export function AlreadyRegisteredScreen() {
         );
       }
 
+      setIsLoadingUser(true);
       dispatch({
         type: "load-from-sync",
         storage: storageResult.value,
         encryptionKey: encryptionKey
       });
-      window.location.hash = "#/login-interstitial";
     },
     [dispatch, password, salt]
   );
@@ -157,6 +158,7 @@ export function AlreadyRegisteredScreen() {
 
   useEffect(() => {
     if (self || !email) {
+      setIsLoadingUser(false);
       if (hasPendingRequest()) {
         window.location.hash = "#/login-interstitial";
       } else {
@@ -179,7 +181,7 @@ export function AlreadyRegisteredScreen() {
     content = (
       <ScreenLoader text="Sending you an email with a reset token..." />
     );
-  } else if (isLoggingIn) {
+  } else if (isLoggingIn || isLoadingUser) {
     content = <ScreenLoader text="Logging you in..." />;
   } else {
     content = (

--- a/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
@@ -146,6 +146,7 @@ export function AlreadyRegisteredScreen() {
         storage: storageResult.value,
         encryptionKey: encryptionKey
       });
+      window.location.hash = "#/login-interstitial";
     },
     [dispatch, password, salt]
   );

--- a/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
@@ -141,11 +141,16 @@ export function AlreadyRegisteredScreen() {
         );
       }
 
-      dispatch({
-        type: "load-from-sync",
-        storage: storageResult.value,
-        encryptionKey: encryptionKey
-      });
+      try {
+        await dispatch({
+          type: "load-from-sync",
+          storage: storageResult.value,
+          encryptionKey: encryptionKey
+        });
+      } catch (e) {
+        setIsLoggingIn(false);
+        return setError(e.message);
+      }
     },
     [dispatch, password, salt]
   );

--- a/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
@@ -41,7 +41,6 @@ export function AlreadyRegisteredScreen() {
   const identityCommitment = query?.get("identityCommitment");
   const [error, setError] = useState<string | undefined>();
   const [isLoggingIn, setIsLoggingIn] = useState(false);
-  const [isLoadingUser, setIsLoadingUser] = useState(false);
   const [sendingConfirmationEmail, setSendingConfirmationEmail] =
     useState(false);
   const [password, setPassword] = useState("");
@@ -133,16 +132,15 @@ export function AlreadyRegisteredScreen() {
         appConfig.zupassServer,
         encryptionKey
       );
-      setIsLoggingIn(false);
 
       if (!storageResult.success) {
+        setIsLoggingIn(false);
         return setError(
           "Password incorrect. Double-check your password. " +
             "If you've lost access, you can reset your account below."
         );
       }
 
-      setIsLoadingUser(true);
       dispatch({
         type: "load-from-sync",
         storage: storageResult.value,
@@ -158,7 +156,6 @@ export function AlreadyRegisteredScreen() {
 
   useEffect(() => {
     if (self || !email) {
-      setIsLoadingUser(false);
       if (hasPendingRequest()) {
         window.location.hash = "#/login-interstitial";
       } else {
@@ -181,7 +178,7 @@ export function AlreadyRegisteredScreen() {
     content = (
       <ScreenLoader text="Sending you an email with a reset token..." />
     );
-  } else if (isLoggingIn || isLoadingUser) {
+  } else if (isLoggingIn) {
     content = <ScreenLoader text="Logging you in..." />;
   } else {
     content = (


### PR DESCRIPTION
Closes #833 

The update to `self` is asynchronous, so there might be a small delay before the redirection to the home screen takes place, especially if you're on a slow network. To provide feedback to the user, we need to keep displaying a loader instead of clearing it early.

### How to test:

In your dev tools (on any branch that's not this one), throttle your network to something slow (e.g. Slow 3G) and then log in. You should see a brief "flash" of the login screen after entering your password and clicking the login button.

Try again but on this branch. There should be no flash.