### PR TITLE
Fix styling for redacted text on ZK mode

### DIFF
--- a/apps/passport-client/components/core/RedactedText.tsx
+++ b/apps/passport-client/components/core/RedactedText.tsx
@@ -4,21 +4,27 @@ export const RedactedText = styled.div<{ redacted: boolean }>`
   ${({ redacted }) =>
     redacted
       ? css`
-          background-color: var(--bg-dark-primary);
-          color: var(--bg-dark-primary);
+          color: transparent;
           &:before {
+            border-radius: 4px;
+            background-color: var(--bg-dark-primary);
+            color: var(--bg-dark-primary);
             content: "REDACTED";
             color: white;
             font-weight: bold;
-            left: 25%;
+            min-width: 100%;
+            text-align: center;
             position: absolute;
+            left: 0;
           }
         `
       : css``}
-  border-radius: 4px;
+
   margin-bottom: 4px;
   padding: 2px;
+  width: 300px;
   position: relative;
+  text-align: center;
   transition-property: color, background-color;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   /* Same duration as the toggle slide */


### PR DESCRIPTION
Styling is slightly broken for short email addresses, this fixes it.

Before:

![image](https://github.com/proofcarryingdata/zupass/assets/20022/b755cdbd-053e-4587-a273-c1e6ee936e3c)


After:

![image](https://github.com/proofcarryingdata/zupass/assets/20022/14023a5f-cb15-48bc-a841-2a7589842656)
