### PR TITLE
turn off generic semaphore group

### DIFF
--- a/apps/passport-server/src/services/semaphoreService.ts
+++ b/apps/passport-server/src/services/semaphoreService.ts
@@ -89,7 +89,8 @@ export class SemaphoreService {
       logger(`[SEMA] Reloading semaphore service...`);
 
       await this.reloadZuzaluGroups();
-      await this.reloadGenericGroup();
+      // turned off for devconnect - lots of users = slow global group.
+      // await this.reloadGenericGroup();
       await this.saveHistoricSemaphoreGroups();
 
       logger(`[SEMA] Semaphore service reloaded.`);

--- a/apps/passport-server/test/semaphore/checkSemaphore.ts
+++ b/apps/passport-server/test/semaphore/checkSemaphore.ts
@@ -19,7 +19,8 @@ export function expectGroupsEqual(
   expect(new Set(...lhs.r)).to.deep.eq(new Set(...rhs.r));
   expect(new Set(...lhs.v)).to.deep.eq(new Set(...rhs.v));
   expect(new Set(...lhs.o)).to.deep.eq(new Set(...rhs.o));
-  expect(new Set(...lhs.g)).to.deep.eq(new Set(...rhs.g));
+  // turned off for devconnect - lots of users = slow global group.
+  // expect(new Set(...lhs.g)).to.deep.eq(new Set(...rhs.g));
 }
 
 export function expectCurrentSemaphoreToBe(


### PR DESCRIPTION
if we expect to have thousands of ppl sign up, recalculating the group on every sign up + forgotten password will get expensive. nothing in prod relies on there being a globally-accessible 'all zupass users' group. 3rd parties only depend on one of the first four groups, which are zuzalu-specific and have few members. I could have also made this calculation run in a background process, but I think i'm just not going to do that because i don't care about this feature.

closes https://github.com/proofcarryingdata/zupass/issues/1064