### PR TITLE
[frogcrypto][2/n] frog basic issuance

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/FrogHomeScreen.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogHomeScreen.tsx
@@ -8,12 +8,11 @@ import {
   useSubscriptions
 } from "../../../src/appHooks";
 import { useSyncE2EEStorage } from "../../../src/useSyncE2EEStorage";
-import { Spacer } from "../../core";
 import { MaybeModal } from "../../modals/Modal";
 import { AppContainer } from "../../shared/AppContainer";
 import { AppHeader } from "../../shared/AppHeader";
+import { PCDCard } from "../../shared/PCDCard";
 import { SyncingPCDs } from "../../shared/SyncingPCDs";
-import { WrappedPCDCard } from "../HomeScreen";
 
 /** A placeholder screen for FrogCrypto.
  *
@@ -76,9 +75,7 @@ export function FrogHomeScreen() {
       <MaybeModal fullScreen />
       <AppContainer bg="gray">
         <Container>
-          <Spacer h={16} />
           <AppHeader />
-          <Spacer h={16} />
 
           <button disabled={!frogSub} onClick={getFrog}>
             Get Frog
@@ -87,15 +84,16 @@ export function FrogHomeScreen() {
           {frogPCDs.length > 0 && (
             <>
               <Separator />
-              {frogPCDs.map((pcd) => (
-                <WrappedPCDCard
-                  key={pcd.id}
-                  pcd={pcd}
-                  mainIdPCD=""
-                  onPcdClick={onPcdClick}
-                  expanded={pcd.id === selectedPCD?.id}
-                />
-              ))}
+              <PCDContainer>
+                {frogPCDs.map((pcd) => (
+                  <PCDCard
+                    key={pcd.id}
+                    pcd={pcd}
+                    onClick={onPcdClick}
+                    expanded={pcd.id === selectedPCD?.id}
+                  />
+                ))}
+              </PCDContainer>
             </>
           )}
         </Container>
@@ -109,4 +107,14 @@ const Container = styled.div`
   width: 100%;
   height: 100%;
   max-width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const PCDContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 `;

--- a/apps/passport-client/components/screens/FrogScreens/FrogHomeScreen.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogHomeScreen.tsx
@@ -1,0 +1,112 @@
+import { Separator } from "@pcd/passport-ui";
+import { useCallback, useMemo, useState } from "react";
+import styled from "styled-components";
+import {
+  useDispatch,
+  useIsSyncSettled,
+  usePCDCollection,
+  useSubscriptions
+} from "../../../src/appHooks";
+import { useSyncE2EEStorage } from "../../../src/useSyncE2EEStorage";
+import { Spacer } from "../../core";
+import { MaybeModal } from "../../modals/Modal";
+import { AppContainer } from "../../shared/AppContainer";
+import { AppHeader } from "../../shared/AppHeader";
+import { SyncingPCDs } from "../../shared/SyncingPCDs";
+import { WrappedPCDCard } from "../HomeScreen";
+
+/** A placeholder screen for FrogCrypto.
+ *
+ * We might want to consider slotting this into the existing HomeScreen to better integrate with PCD explorer.
+ */
+export function FrogHomeScreen() {
+  useSyncE2EEStorage();
+  const dispatch = useDispatch();
+  const syncSettled = useIsSyncSettled();
+  const { value: subs } = useSubscriptions();
+  const frogSub = useMemo(
+    () => subs.getActiveSubscriptions().find((sub) => sub.feed.name === "Bog"),
+    [subs]
+  );
+  const pcds = usePCDCollection();
+  // NB: we cannot use useMemo because pcds are mutate in-place
+  const frogPCDs = pcds.getAllPCDsInFolder("FrogCrypto");
+
+  const getFrog = useCallback(async () => {
+    if (!frogSub) {
+      return;
+    }
+
+    dispatch({
+      type: "sync-subscription",
+      subscriptionId: frogSub.id
+    });
+  }, [dispatch, frogSub]);
+
+  const [selectedPCDID, setSelectedPCDID] = useState("");
+  const selectedPCD = useMemo(() => {
+    // if user just added a PCD, highlight that one
+    if (sessionStorage.newAddedPCDID) {
+      const added = frogPCDs.find(
+        (pcd) => pcd.id === sessionStorage.newAddedPCDID
+      );
+      if (added) {
+        return added;
+      }
+    }
+
+    const selected = frogPCDs.find((pcd) => pcd.id === selectedPCDID);
+    if (selected) {
+      return selected;
+    }
+
+    // default to first PCD if no selected PCD found
+    return frogPCDs[0];
+  }, [frogPCDs, selectedPCDID]);
+  const onPcdClick = useCallback((id: string) => {
+    setSelectedPCDID(id);
+  }, []);
+
+  if (!syncSettled) {
+    return <SyncingPCDs />;
+  }
+
+  return (
+    <>
+      <MaybeModal fullScreen />
+      <AppContainer bg="gray">
+        <Container>
+          <Spacer h={16} />
+          <AppHeader />
+          <Spacer h={16} />
+
+          <button disabled={!frogSub} onClick={getFrog}>
+            Get Frog
+          </button>
+
+          {frogPCDs.length > 0 && (
+            <>
+              <Separator />
+              {frogPCDs.map((pcd) => (
+                <WrappedPCDCard
+                  key={pcd.id}
+                  pcd={pcd}
+                  mainIdPCD=""
+                  onPcdClick={onPcdClick}
+                  expanded={pcd.id === selectedPCD?.id}
+                />
+              ))}
+            </>
+          )}
+        </Container>
+      </AppContainer>
+    </>
+  );
+}
+
+const Container = styled.div`
+  padding: 16px;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+`;

--- a/apps/passport-client/components/screens/FrogScreens/FrogHomeScreen.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogHomeScreen.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import {
   useDispatch,
   useIsSyncSettled,
-  usePCDCollection,
+  usePCDsInFolder,
   useSubscriptions
 } from "../../../src/appHooks";
 import { useSyncE2EEStorage } from "../../../src/useSyncE2EEStorage";
@@ -27,9 +27,7 @@ export function FrogHomeScreen() {
     () => subs.getActiveSubscriptions().find((sub) => sub.feed.name === "Bog"),
     [subs]
   );
-  const pcds = usePCDCollection();
-  // NB: we cannot use useMemo because pcds are mutate in-place
-  const frogPCDs = pcds.getAllPCDsInFolder("FrogCrypto");
+  const frogPCDs = usePCDsInFolder("FrogCrypto");
 
   const getFrog = useCallback(async () => {
     if (!frogSub) {
@@ -72,7 +70,7 @@ export function FrogHomeScreen() {
 
   return (
     <>
-      <MaybeModal fullScreen />
+      <MaybeModal />
       <AppContainer bg="gray">
         <Container>
           <AppHeader />

--- a/apps/passport-client/components/screens/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen.tsx
@@ -286,7 +286,7 @@ const FolderEntryContainer = styled.div`
   }
 `;
 
-const WrappedPCDCard = React.memo(WrappedPCDCardImpl);
+export const WrappedPCDCard = React.memo(WrappedPCDCardImpl);
 
 function WrappedPCDCardImpl({
   pcd,

--- a/apps/passport-client/components/screens/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen.tsx
@@ -286,7 +286,7 @@ const FolderEntryContainer = styled.div`
   }
 `;
 
-export const WrappedPCDCard = React.memo(WrappedPCDCardImpl);
+const WrappedPCDCard = React.memo(WrappedPCDCardImpl);
 
 function WrappedPCDCardImpl({
   pcd,

--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@pcd/eddsa-pcd": "0.3.0",
+    "@pcd/eddsa-frog-pcd": "0.0.1",
     "@pcd/eddsa-ticket-pcd": "0.3.0",
     "@pcd/email-pcd": "0.3.0",
     "@pcd/emitter": "0.2.0",

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -10,6 +10,7 @@ import { AddSubscriptionScreen } from "../components/screens/AddSubscriptionScre
 import { ChangePasswordScreen } from "../components/screens/ChangePasswordScreen";
 import { DevconnectCheckinByIdScreen } from "../components/screens/DevconnectCheckinByIdScreen";
 import { EnterConfirmationCodeScreen } from "../components/screens/EnterConfirmationCodeScreen";
+import { FrogHomeScreen } from "../components/screens/FrogScreens/FrogHomeScreen";
 import { GetWithoutProvingScreen } from "../components/screens/GetWithoutProvingScreen";
 import { HaloScreen } from "../components/screens/HaloScreen/HaloScreen";
 import { HomeScreen } from "../components/screens/HomeScreen";
@@ -194,6 +195,7 @@ function RouterImpl() {
           <Route path="subscriptions" element={<SubscriptionsScreen />} />
           <Route path="add-subscription" element={<AddSubscriptionScreen />} />
           <Route path="telegram" element={<HomeScreen />} />
+          <Route path="frog" element={<FrogHomeScreen />} />
           <Route path="*" element={<MissingScreen />} />
         </Route>
       </Routes>

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -116,6 +116,10 @@ export type Action =
     }
   | {
       type: "prompt-to-agree-privacy-notice";
+    }
+  | {
+      type: "sync-subscription";
+      subscriptionId: string;
     };
 
 export type StateContextState = {
@@ -210,6 +214,8 @@ export async function dispatch(
       return handleAgreedPrivacyNotice(state, update, action.version);
     case "prompt-to-agree-privacy-notice":
       return promptToAgreePrivacyNotice(state, update);
+    case "sync-subscription":
+      return syncSubscription(state, update, action.subscriptionId);
     default:
       // We can ensure that we never get here using the type system
       assertUnreachable(action);
@@ -710,6 +716,39 @@ async function sync(state: AppState, update: ZuUpdate) {
     uploadingUploadId: undefined,
     uploadedUploadId: uploadId
   });
+}
+
+async function syncSubscription(
+  state: AppState,
+  update: ZuUpdate,
+  subscriptionId: string
+) {
+  try {
+    console.log("[SYNC] loading pcds from subscription", subscriptionId);
+    const subscription = state.subscriptions.getSubscription(subscriptionId);
+    const credentialManager = new CredentialManager(
+      state.identity,
+      state.pcds,
+      state.credentialCache
+    );
+    console.log("[SYNC] initalized credentialManager", credentialManager);
+    const actions = await state.subscriptions.pollSingleSubscription(
+      subscription,
+      credentialManager
+    );
+    console.log("[SYNC] fetched actions", actions);
+
+    await applyActions(state.pcds, actions);
+    console.log("[SYNC] applied pcd actions");
+    await savePCDs(state.pcds);
+    console.log("[SYNC] loaded and saved issued pcds");
+
+    update({
+      pcds: state.pcds
+    });
+  } catch (e) {
+    console.log(`[SYNC] failed to load issued PCDs, skipping this step`, e);
+  }
 }
 
 async function resolveSubscriptionError(

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -731,7 +731,6 @@ async function syncSubscription(
       state.pcds,
       state.credentialCache
     );
-    console.log("[SYNC] initalized credentialManager", credentialManager);
     const actions = await state.subscriptions.pollSingleSubscription(
       subscription,
       credentialManager

--- a/apps/passport-client/src/pcdPackages.ts
+++ b/apps/passport-client/src/pcdPackages.ts
@@ -1,3 +1,4 @@
+import { EdDSAFrogPCDPackage } from "@pcd/eddsa-frog-pcd";
 import { EdDSAPCDPackage } from "@pcd/eddsa-pcd";
 import { EdDSATicketPCDPackage } from "@pcd/eddsa-ticket-pcd";
 import { EmailPCDPackage } from "@pcd/email-pcd";
@@ -44,6 +45,10 @@ async function loadPackages(): Promise<PCDPackage[]> {
     makeEncodedVerifyLink
   });
 
+  await EdDSAFrogPCDPackage.init({
+    makeEncodedVerifyLink
+  });
+
   await EdDSATicketPCDPackage.init({
     makeEncodedVerifyLink
   });
@@ -62,6 +67,7 @@ async function loadPackages(): Promise<PCDPackage[]> {
     RSAPCDPackage,
     RSATicketPCDPackage,
     EdDSAPCDPackage,
+    EdDSAFrogPCDPackage,
     EdDSATicketPCDPackage,
     ZKEdDSAEventTicketPCDPackage,
     RSAImagePCDPackage,

--- a/apps/passport-server/package.json
+++ b/apps/passport-server/package.json
@@ -19,6 +19,7 @@
     "@opentelemetry/auto-instrumentations-node": "^0.36.0",
     "@opentelemetry/sdk-node": "^0.34.0",
     "@pcd/eddsa-pcd": "0.3.0",
+    "@pcd/eddsa-frog-pcd": "0.0.1",
     "@pcd/eddsa-ticket-pcd": "0.3.0",
     "@pcd/email-pcd": "0.3.0",
     "@pcd/passport-crypto": "0.8.0",

--- a/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
+++ b/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
@@ -1,6 +1,4 @@
-import { EdDSAPublicKey } from "@pcd/eddsa-pcd";
 import {
-  IssuanceEnabledResponseValue,
   ListFeedsResponseValue,
   PollFeedRequest,
   PollFeedResponseValue
@@ -32,43 +30,6 @@ export function initFrogcryptoRoutes(
       throw new PCDHTTPError(503, "issuance service not instantiated");
     }
   }
-
-  /**
-   * If either of the {@code process.env.SERVER_RSA_PRIVATE_KEY_BASE64} or
-   * {@code process.env.SERVER_EDDSA_PRIVATE_KEY} are not initialized properly,
-   * then this server won't have an {@link IssuanceService}. It'll continue
-   * to work, except users won't get any 'issued' frogs.
-   */
-  app.get("/frogcrypto/issue/enabled", async (req: Request, res: Response) => {
-    const result = issuanceService != null;
-    res.json(result satisfies IssuanceEnabledResponseValue);
-  });
-
-  /**
-   * Gets the RSA public key this server is using for its attestations, so that
-   * 3rd parties can verify whether users have proper attestations.
-   */
-  app.get(
-    "/frogcrypto/issue/rsa-public-key",
-    async (req: Request, res: Response) => {
-      checkIssuanceServiceStarted(issuanceService);
-      const result = issuanceService.getRSAPublicKey();
-      res.send(result satisfies string);
-    }
-  );
-
-  /**
-   * Gets the EdDSA public key this server is using for its attestations, so that
-   * 3rd parties can verify whether users have proper attestations.
-   */
-  app.get(
-    "/frogcrypto/issue/eddsa-public-key",
-    async (req: Request, res: Response) => {
-      checkIssuanceServiceStarted(issuanceService);
-      const result = await issuanceService.getEdDSAPublicKey();
-      res.send(result satisfies EdDSAPublicKey);
-    }
-  );
 
   /**
    * Lets a Zupass client (or even a 3rd-party-developed client get PCDs from a

--- a/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
+++ b/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
@@ -1,0 +1,112 @@
+import { EdDSAPublicKey } from "@pcd/eddsa-pcd";
+import {
+  IssuanceEnabledResponseValue,
+  ListFeedsResponseValue,
+  PollFeedRequest,
+  PollFeedResponseValue
+} from "@pcd/passport-interface";
+import express, { Request, Response } from "express";
+import {
+  FeedProviderName,
+  IssuanceService
+} from "../../services/issuanceService";
+import { ApplicationContext, GlobalServices } from "../../types";
+import { logger } from "../../util/logger";
+import { checkUrlParam } from "../params";
+import { PCDHTTPError } from "../pcdHttpError";
+
+export function initFrogcryptoRoutes(
+  app: express.Application,
+  _context: ApplicationContext,
+  { issuanceService }: GlobalServices
+): void {
+  logger("[INIT] initializing frogcrypto routes");
+
+  /**
+   * Throws if we don't have an instance of {@link issuanceService}.
+   */
+  function checkIssuanceServiceStarted(
+    issuanceService: IssuanceService | null
+  ): asserts issuanceService {
+    if (!issuanceService) {
+      throw new PCDHTTPError(503, "issuance service not instantiated");
+    }
+  }
+
+  /**
+   * If either of the {@code process.env.SERVER_RSA_PRIVATE_KEY_BASE64} or
+   * {@code process.env.SERVER_EDDSA_PRIVATE_KEY} are not initialized properly,
+   * then this server won't have an {@link IssuanceService}. It'll continue
+   * to work, except users won't get any 'issued' frogs.
+   */
+  app.get("/frogcrypto/issue/enabled", async (req: Request, res: Response) => {
+    const result = issuanceService != null;
+    res.json(result satisfies IssuanceEnabledResponseValue);
+  });
+
+  /**
+   * Gets the RSA public key this server is using for its attestations, so that
+   * 3rd parties can verify whether users have proper attestations.
+   */
+  app.get(
+    "/frogcrypto/issue/rsa-public-key",
+    async (req: Request, res: Response) => {
+      checkIssuanceServiceStarted(issuanceService);
+      const result = issuanceService.getRSAPublicKey();
+      res.send(result satisfies string);
+    }
+  );
+
+  /**
+   * Gets the EdDSA public key this server is using for its attestations, so that
+   * 3rd parties can verify whether users have proper attestations.
+   */
+  app.get(
+    "/frogcrypto/issue/eddsa-public-key",
+    async (req: Request, res: Response) => {
+      checkIssuanceServiceStarted(issuanceService);
+      const result = await issuanceService.getEdDSAPublicKey();
+      res.send(result satisfies EdDSAPublicKey);
+    }
+  );
+
+  /**
+   * Lets a Zupass client (or even a 3rd-party-developed client get PCDs from a
+   * particular feed that this server is hosting.
+   */
+  app.get("/frogcrypto/feeds", async (req, res) => {
+    checkIssuanceServiceStarted(issuanceService);
+    const result = await issuanceService.handleListFeedsRequest(
+      req.body as PollFeedRequest,
+      FeedProviderName.FROGCRYPTO
+    );
+    res.json(result satisfies ListFeedsResponseValue);
+  });
+
+  /**
+   * Lets a Zupass client (or even a 3rd-party-developed client get PCDs from a
+   * particular feed that this server is hosting.
+   */
+  app.post("/frogcrypto/feeds", async (req, res) => {
+    checkIssuanceServiceStarted(issuanceService);
+    const result = await issuanceService.handleFeedRequest(
+      req.body as PollFeedRequest,
+      FeedProviderName.FROGCRYPTO
+    );
+    res.json(result satisfies PollFeedResponseValue);
+  });
+
+  app.get("/frogcrypto/feeds/:feedId", async (req: Request, res: Response) => {
+    checkIssuanceServiceStarted(issuanceService);
+    const feedId = checkUrlParam(req, "feedId");
+    if (!issuanceService.hasFeedWithId(feedId, FeedProviderName.FROGCRYPTO)) {
+      throw new PCDHTTPError(404);
+    }
+    res.json(
+      await issuanceService.handleListSingleFeedRequest(
+        { feedId },
+        FeedProviderName.FROGCRYPTO
+      )
+    );
+  });
+}

--- a/apps/passport-server/src/routing/routes/pcdIssuanceRoutes.ts
+++ b/apps/passport-server/src/routing/routes/pcdIssuanceRoutes.ts
@@ -16,7 +16,10 @@ import {
   VerifyTicketResult
 } from "@pcd/passport-interface";
 import express, { Request, Response } from "express";
-import { IssuanceService } from "../../services/issuanceService";
+import {
+  FeedProviderName,
+  IssuanceService
+} from "../../services/issuanceService";
 import { ApplicationContext, GlobalServices } from "../../types";
 import { logger } from "../../util/logger";
 import { checkUrlParam } from "../params";
@@ -79,7 +82,8 @@ export function initPCDIssuanceRoutes(
   app.get("/feeds", async (req: Request, res: Response) => {
     checkIssuanceServiceStarted(issuanceService);
     const result = await issuanceService.handleListFeedsRequest(
-      req.body as ListFeedsRequest
+      req.body as ListFeedsRequest,
+      FeedProviderName.ZUPASS
     );
     res.json(result satisfies ListFeedsResponseValue);
   });
@@ -91,7 +95,8 @@ export function initPCDIssuanceRoutes(
   app.post("/feeds", async (req, res) => {
     checkIssuanceServiceStarted(issuanceService);
     const result = await issuanceService.handleFeedRequest(
-      req.body as PollFeedRequest
+      req.body as PollFeedRequest,
+      FeedProviderName.ZUPASS
     );
     res.json(result satisfies PollFeedResponseValue);
   });
@@ -99,10 +104,15 @@ export function initPCDIssuanceRoutes(
   app.get("/feeds/:feedId", async (req: Request, res: Response) => {
     checkIssuanceServiceStarted(issuanceService);
     const feedId = checkUrlParam(req, "feedId");
-    if (!issuanceService.hasFeedWithId(feedId)) {
+    if (!issuanceService.hasFeedWithId(feedId, FeedProviderName.ZUPASS)) {
       throw new PCDHTTPError(404);
     }
-    res.json(await issuanceService.handleListSingleFeedRequest({ feedId }));
+    res.json(
+      await issuanceService.handleListSingleFeedRequest(
+        { feedId },
+        FeedProviderName.ZUPASS
+      )
+    );
   });
 
   app.post("/issue/check-ticket-by-id", async (req: Request, res: Response) => {

--- a/apps/passport-server/src/routing/server.ts
+++ b/apps/passport-server/src/routing/server.ts
@@ -12,6 +12,7 @@ import { tracingMiddleware } from "./middlewares/tracingMiddleware";
 import { respondWithError } from "./pcdHttpError";
 import { initAccountRoutes } from "./routes/accountRoutes";
 import { initE2EERoutes } from "./routes/e2eeRoutes";
+import { initFrogcryptoRoutes } from "./routes/frogcryptoRoutes";
 import { initHealthcheckRoutes } from "./routes/healthCheckRoutes";
 import { initKudosbotRoutes } from "./routes/kudosbotRoutes";
 import { initLogRoutes } from "./routes/logRoutes";
@@ -119,6 +120,7 @@ function initAllRoutes(
   initPCDIssuanceRoutes(app, context, globalServices);
   initTelegramRoutes(app, context, globalServices);
   initKudosbotRoutes(app, context, globalServices);
+  initFrogcryptoRoutes(app, context, globalServices);
   initLogRoutes(app);
 }
 

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -91,7 +91,7 @@ import { PCDHTTPError } from "../routing/pcdHttpError";
 import { ApplicationContext } from "../types";
 import {
   FROGCRYPTO_FEEDS,
-  FrogCryptoFeedConfig,
+  FrogCryptoFeed,
   FrogCryptoFeedHost,
   createFrogData
 } from "../util/frogcrypto";
@@ -424,24 +424,8 @@ export class IssuanceService {
           }
           return { actions: [] };
         },
-        feed: {
-          ...feed,
-          fetchOnLoad: false,
-          inputPCDType: undefined,
-          partialArgs: undefined,
-          credentialRequest: {
-            signatureType: "sempahore-signature-pcd"
-          },
-          permissions: [
-            {
-              folder: "FrogCrypto",
-              type: PCDPermissionType.AppendToFolder
-            } as AppendToFolderPermission
-          ]
-        }
-      })),
-      `${process.env.PASSPORT_SERVER_URL}/frogcrypto/feeds`,
-      FeedProviderName.FROGCRYPTO
+        feed
+      }))
     );
 
     this.feedHosts = [zupassFeedHost, frogcryptoFeedHost].reduce(
@@ -925,7 +909,7 @@ export class IssuanceService {
 
   private async issueEdDSAFrogPCDs(
     credential: SerializedPCD<SemaphoreSignaturePCD>,
-    feed: FrogCryptoFeedConfig
+    feed: FrogCryptoFeed
   ): Promise<SerializedPCD[]> {
     const serverUrl = process.env.PASSPORT_CLIENT_URL;
 

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -411,7 +411,7 @@ export class IssuanceService {
                   pcds: await this.issueEdDSAFrogPCDs(req.pcd, feed),
                   folder: "FrogCrypto",
                   type: PCDActionType.AppendToFolder
-                } as AppendToFolderAction
+                }
               ]
             };
           } catch (e) {

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -1,3 +1,4 @@
+import { EdDSAFrogPCDPackage } from "@pcd/eddsa-frog-pcd";
 import {
   EdDSAPublicKey,
   getEdDSAPublicKey,
@@ -88,6 +89,12 @@ import {
 import { fetchLoggedInZuzaluUser } from "../database/queries/zuzalu_pretix_tickets/fetchZuzaluUser";
 import { PCDHTTPError } from "../routing/pcdHttpError";
 import { ApplicationContext } from "../types";
+import {
+  FROGCRYPTO_FEEDS,
+  FrogCryptoFeedConfig,
+  FrogCryptoFeedHost,
+  createFrogData
+} from "../util/frogcrypto";
 import { logger } from "../util/logger";
 import { timeBasedId } from "../util/timeBasedId";
 import {
@@ -101,11 +108,16 @@ import { traced } from "./telemetryService";
 
 export const ZUPASS_TICKET_PUBLIC_KEY_NAME = "Zupass";
 
+export enum FeedProviderName {
+  ZUPASS = "Zupass",
+  FROGCRYPTO = "FrogCrypto"
+}
+
 export class IssuanceService {
   private readonly context: ApplicationContext;
   private readonly cacheService: PersistentCacheService;
   private readonly rollbarService: RollbarService | null;
-  private readonly feedHost: FeedHost;
+  private readonly feedHosts: Record<FeedProviderName, FeedHost>;
   private readonly eddsaPrivateKey: string;
   private readonly rsaPrivateKey: NodeRSA;
   private readonly exportedRSAPrivateKey: string;
@@ -129,12 +141,11 @@ export class IssuanceService {
     this.exportedRSAPrivateKey = this.rsaPrivateKey.exportKey("private");
     this.exportedRSAPublicKey = this.rsaPrivateKey.exportKey("public");
     this.eddsaPrivateKey = eddsaPrivateKey;
-    const FEED_PROVIDER_NAME = "Zupass";
     this.verificationPromiseCache = new LRUCache<string, Promise<boolean>>({
       max: 1000
     });
 
-    this.feedHost = new FeedHost(
+    const zupassFeedHost = new FeedHost(
       [
         {
           handleRequest: async (
@@ -383,30 +394,91 @@ export class IssuanceService {
         }
       ],
       `${process.env.PASSPORT_SERVER_URL}/feeds`,
-      FEED_PROVIDER_NAME
+      FeedProviderName.ZUPASS
+    );
+    const frogcryptoFeedHost = new FrogCryptoFeedHost(
+      FROGCRYPTO_FEEDS.map((feed) => ({
+        handleRequest: async (
+          req: PollFeedRequest
+        ): Promise<PollFeedResponseValue> => {
+          try {
+            if (req.pcd === undefined) {
+              throw new Error(`Missing credential`);
+            }
+            await verifyFeedCredential(
+              req.pcd,
+              this.cachedVerifySignaturePCD.bind(this)
+            );
+            return {
+              actions: [
+                {
+                  pcds: await this.issueEdDSAFrogPCDs(req.pcd, feed),
+                  folder: "FrogCrypto",
+                  type: PCDActionType.AppendToFolder
+                } as AppendToFolderAction
+              ]
+            };
+          } catch (e) {
+            logger(`Error encountered while serving feed:`, e);
+            this.rollbarService?.reportError(e);
+          }
+          return { actions: [] };
+        },
+        feed: {
+          ...feed,
+          fetchOnLoad: false,
+          inputPCDType: undefined,
+          partialArgs: undefined,
+          credentialRequest: {
+            signatureType: "sempahore-signature-pcd"
+          },
+          permissions: [
+            {
+              folder: "FrogCrypto",
+              type: PCDPermissionType.AppendToFolder
+            } as AppendToFolderPermission
+          ]
+        }
+      })),
+      `${process.env.PASSPORT_SERVER_URL}/frogcrypto/feeds`,
+      FeedProviderName.FROGCRYPTO
+    );
+
+    this.feedHosts = [zupassFeedHost, frogcryptoFeedHost].reduce(
+      (acc, feedHost) => {
+        acc[feedHost.getProviderName()] = feedHost;
+        return acc;
+      },
+      {} as Record<string, FeedHost>
     );
   }
 
   public async handleListFeedsRequest(
-    request: ListFeedsRequest
+    request: ListFeedsRequest,
+    feedProvider: FeedProviderName
   ): Promise<ListFeedsResponseValue> {
-    return this.feedHost.handleListFeedsRequest(request);
+    return this.feedHosts[feedProvider].handleListFeedsRequest(request);
   }
 
   public async handleListSingleFeedRequest(
-    request: ListSingleFeedRequest
+    request: ListSingleFeedRequest,
+    feedProvider: FeedProviderName
   ): Promise<ListFeedsResponseValue> {
-    return this.feedHost.handleListSingleFeedRequest(request);
+    return this.feedHosts[feedProvider].handleListSingleFeedRequest(request);
   }
 
   public async handleFeedRequest(
-    request: PollFeedRequest
+    request: PollFeedRequest,
+    feedProvider: FeedProviderName
   ): Promise<PollFeedResponseValue> {
-    return this.feedHost.handleFeedRequest(request);
+    return this.feedHosts[feedProvider].handleFeedRequest(request);
   }
 
-  public hasFeedWithId(feedId: string): boolean {
-    return this.feedHost.hasFeedWithId(feedId);
+  public hasFeedWithId(
+    feedId: string,
+    feedProvider: FeedProviderName
+  ): boolean {
+    return this.feedHosts[feedProvider].hasFeedWithId(feedId);
   }
 
   public getRSAPublicKey(): string {
@@ -844,6 +916,42 @@ export class IssuanceService {
         id: {
           argumentType: ArgumentTypeName.String,
           value: id
+        }
+      })
+    );
+
+    return [frogPCD];
+  }
+
+  private async issueEdDSAFrogPCDs(
+    credential: SerializedPCD<SemaphoreSignaturePCD>,
+    feed: FrogCryptoFeedConfig
+  ): Promise<SerializedPCD[]> {
+    const serverUrl = process.env.PASSPORT_CLIENT_URL;
+
+    if (!serverUrl) {
+      logger("[ISSUE] can't issue frogs - unaware of the client location");
+      return [];
+    }
+
+    // TODO: return as user facing error
+    if (!feed.active) {
+      logger("[ISSUE] can't issue frogs - feed is inactive");
+      return [];
+    }
+
+    const frogPCD = await EdDSAFrogPCDPackage.serialize(
+      await EdDSAFrogPCDPackage.prove({
+        privateKey: {
+          argumentType: ArgumentTypeName.String,
+          value: this.exportedRSAPrivateKey
+        },
+        data: {
+          argumentType: ArgumentTypeName.Object,
+          value: await createFrogData(credential, feed)
+        },
+        id: {
+          argumentType: ArgumentTypeName.String
         }
       })
     );

--- a/apps/passport-server/src/services/provingService.ts
+++ b/apps/passport-server/src/services/provingService.ts
@@ -1,3 +1,4 @@
+import { EdDSAFrogPCDPackage } from "@pcd/eddsa-frog-pcd";
 import { EdDSAPCDPackage } from "@pcd/eddsa-pcd";
 import { EdDSATicketPCDPackage } from "@pcd/eddsa-ticket-pcd";
 import {
@@ -198,6 +199,7 @@ export async function startProvingService(
   });
 
   await RSATicketPCDPackage.init?.({ makeEncodedVerifyLink: undefined });
+  await EdDSAFrogPCDPackage.init?.({ makeEncodedVerifyLink: undefined });
   await EdDSATicketPCDPackage.init?.({ makeEncodedVerifyLink: undefined });
 
   await ZKEdDSAEventTicketPCDPackage.init?.({

--- a/apps/passport-server/src/util/frogcrypto.ts
+++ b/apps/passport-server/src/util/frogcrypto.ts
@@ -1,0 +1,173 @@
+import { Biome, IFrogData, Rarity, Temperament } from "@pcd/eddsa-frog-pcd";
+import {
+  Feed,
+  FeedHost,
+  HostedFeed,
+  ListFeedsRequest,
+  ListFeedsResponseValue,
+  PollFeedRequest,
+  PollFeedResponseValue
+} from "@pcd/passport-interface";
+import { PCDPackage, SerializedPCD } from "@pcd/pcd-types";
+import {
+  SemaphoreSignaturePCD,
+  SemaphoreSignaturePCDPackage
+} from "@pcd/semaphore-signature-pcd";
+import _ from "lodash";
+
+export interface FrogCryptoFeedConfig {
+  /**
+   * Unique identifier for this feed. It is important to ensure that the feed cannot be discovered by guessing the ID.
+   */
+  id: string;
+  name: string;
+  description: string;
+  /**
+   * Whether this feed is discoverable in GET /feeds
+   *
+   * A feed can still be queried as GET /feeds/:feedId or polled as POST /feeds even if it is not discoverable
+   * as long as the user knows the feed ID.
+   * @default false
+   */
+  private: boolean;
+  /**
+   * PCD can only be issued from this feed if it is active
+   * @default false
+   *
+   * TODO: There is no way to schedule a feed to become active/inactive yet.
+   * We could add a separate scheduler service that will update the database to set the feed to active/inactive
+   * based on configured schedules.
+   */
+  active: boolean;
+  /**
+   * How long to wait between each PCD issuance in seconds
+   */
+  cooldown: number;
+}
+
+/**
+ * Feed configuration that will eventually be stored in the database
+ * and can be updated by GMs via a TG bot
+ */
+export const FROGCRYPTO_FEEDS: FrogCryptoFeedConfig[] = [
+  {
+    id: "85b139fa-3665-4b96-a7bd-77c6c4ed18cd",
+    name: "Bog",
+    description: "Bog",
+    private: false,
+    active: true,
+    cooldown: 60
+  },
+  {
+    id: "9e827420-79c4-4a84-b8d3-65cecdf495bc",
+    name: "Cog",
+    description: "Cog",
+    private: true,
+    active: true,
+    cooldown: 180
+  },
+  {
+    id: "4fdb8af9-5334-4037-a176-cef05158ef66",
+    name: "Dog",
+    description: "Dog",
+    private: true,
+    active: false,
+    cooldown: 60
+  }
+];
+
+export interface FrogCryptoFeed extends Feed, FrogCryptoFeedConfig {}
+
+export class FrogCryptoFeedHost extends FeedHost<FrogCryptoFeed> {
+  public constructor(
+    feeds: HostedFeed<FrogCryptoFeed>[],
+    providerUrl: string,
+    providerName: string
+  ) {
+    super(feeds, providerUrl, providerName);
+  }
+
+  public handleFeedRequest(
+    request: PollFeedRequest<PCDPackage<any, any, any, any>>
+  ): Promise<PollFeedResponseValue> {
+    const feed = this.hostedFeed.find((f) => f.feed.id === request.feedId);
+    if (!feed) {
+      throw new Error(`couldn't find feed with id ${request.feedId}`);
+    }
+    if (!feed.feed.active) {
+      throw new Error(`feed with id ${request.feedId} is not active`);
+    }
+
+    return feed.handleRequest(request);
+  }
+
+  public async handleListFeedsRequest(
+    _request: ListFeedsRequest
+  ): Promise<ListFeedsResponseValue> {
+    return {
+      providerName: this.providerName,
+      providerUrl: this.providerUrl,
+      feeds: this.hostedFeed.map((f) => f.feed).filter((f) => !f.private)
+    };
+  }
+}
+
+// TODO: This is a temporary hack to get the server to work.
+// We will store this in the database eventually.
+// This hack assumes a single feed
+const LAST_FETCHED_AT = new Map<string, number>();
+
+/**
+ * Returns the number of milliseconds until the next fetch is available.
+ */
+export async function getNextFetchAvailable(
+  id: string,
+  feed: FrogCryptoFeedConfig
+): Promise<number> {
+  const lastFetchedAt = LAST_FETCHED_AT.get(id) ?? 0;
+  const now = Date.now();
+  return Math.max(0, lastFetchedAt + feed.cooldown * 1000 - now);
+}
+
+export async function createFrogData(
+  serializedPCD: SerializedPCD<SemaphoreSignaturePCD>,
+  feed: FrogCryptoFeedConfig
+): Promise<IFrogData> {
+  if (serializedPCD.type !== SemaphoreSignaturePCDPackage.name) {
+    throw new Error("Invalid PCD type");
+  }
+  const pcd = await SemaphoreSignaturePCDPackage.deserialize(serializedPCD.pcd);
+  const id = pcd.claim.identityCommitment;
+
+  const nextFetchAvailable = await getNextFetchAvailable(id, feed);
+  if (nextFetchAvailable > 0) {
+    throw new Error(
+      `Next fetch available in ${nextFetchAvailable} milliseconds`
+    );
+  }
+  LAST_FETCHED_AT.set(id, Date.now());
+
+  // TODO: sample frog from db
+  const frogPaths: string[] = [
+    "images/frogs/frog.jpeg",
+    "images/frogs/frog2.jpeg",
+    "images/frogs/frog3.jpeg",
+    "images/frogs/frog4.jpeg"
+  ];
+
+  return {
+    name: "test name",
+    description: "test description",
+    imageUrl: _.sample(frogPaths) ?? "",
+    frogId: 0,
+    biome: Biome.Unknown,
+    rarity: Rarity.Unknown,
+    temperament: Temperament.UNKNOWN,
+    jump: _.random(0, 10),
+    speed: _.random(0, 10),
+    intelligence: _.random(0, 10),
+    beauty: _.random(0, 10),
+    timestampSigned: Date.now(),
+    ownerSemaphoreId: id
+  };
+}

--- a/apps/passport-server/src/util/frogcrypto.ts
+++ b/apps/passport-server/src/util/frogcrypto.ts
@@ -14,10 +14,7 @@ import {
   PollFeedRequest,
   PollFeedResponseValue
 } from "@pcd/passport-interface";
-import {
-  AppendToFolderPermission,
-  PCDPermissionType
-} from "@pcd/pcd-collection";
+import { PCDPermissionType } from "@pcd/pcd-collection";
 import { PCDPackage, SerializedPCD } from "@pcd/pcd-types";
 import {
   SemaphoreSignaturePCD,
@@ -74,7 +71,7 @@ const commonFeedConfig: Pick<
     {
       folder: "FrogCrypto",
       type: PCDPermissionType.AppendToFolder
-    } as AppendToFolderPermission
+    }
   ]
 };
 

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -1756,7 +1756,7 @@ describe("devconnect functionality", function () {
       MockDate.set(new Date());
       const payload = JSON.stringify(createFeedCredentialPayload());
       const response = await pollFeed(
-        application.expressContext.localEndpoint,
+        `${application.expressContext.localEndpoint}/feeds`,
         identity,
         payload,
         ZupassFeedIds.Devconnect
@@ -1798,13 +1798,13 @@ describe("devconnect functionality", function () {
     MockDate.set(new Date());
     const payload = JSON.stringify(createFeedCredentialPayload());
     const expressResponse1 = await pollFeed(
-      application.expressContext.localEndpoint,
+      `${application.expressContext.localEndpoint}/feeds`,
       identity,
       payload,
       ZupassFeedIds.Devconnect
     );
     const expressResponse2 = await pollFeed(
-      application.expressContext.localEndpoint,
+      `${application.expressContext.localEndpoint}/feeds`,
       identity,
       payload,
       ZupassFeedIds.Devconnect
@@ -1857,7 +1857,7 @@ describe("devconnect functionality", function () {
       MockDate.set(new Date());
       const payload = JSON.stringify(createFeedCredentialPayload());
       const response = await pollFeed(
-        application.expressContext.localEndpoint,
+        `${application.expressContext.localEndpoint}/feeds`,
         identity,
         payload,
         ZupassFeedIds.Devconnect
@@ -1907,7 +1907,7 @@ describe("devconnect functionality", function () {
       MockDate.set(new Date());
       const payload = JSON.stringify(createFeedCredentialPayload());
       const response = await pollFeed(
-        application.expressContext.localEndpoint,
+        `${application.expressContext.localEndpoint}/feeds`,
         identity,
         payload,
         ZupassFeedIds.Devconnect
@@ -1958,7 +1958,7 @@ describe("devconnect functionality", function () {
       MockDate.set(new Date());
       const payload = JSON.stringify(createFeedCredentialPayload());
       const issueResponse = await pollFeed(
-        application.expressContext.localEndpoint,
+        `${application.expressContext.localEndpoint}/feeds`,
         identity,
         payload,
         ZupassFeedIds.Devconnect
@@ -2009,7 +2009,7 @@ describe("devconnect functionality", function () {
     async function () {
       MockDate.set(new Date());
       const expressResponse = await pollFeed(
-        application.expressContext.localEndpoint,
+        `${application.expressContext.localEndpoint}/feeds`,
         identity,
         "asdf",
         ZupassFeedIds.Devconnect
@@ -2031,7 +2031,7 @@ describe("devconnect functionality", function () {
       // Attempt to use credential payload one hour later
       MockDate.set(new Date(2023, 10, 5, 15, 30, 0));
       const expressResponse = await pollFeed(
-        application.expressContext.localEndpoint,
+        `${application.expressContext.localEndpoint}/feeds`,
         identity,
         payload,
         ZupassFeedIds.Devconnect
@@ -2049,7 +2049,7 @@ describe("devconnect functionality", function () {
       MockDate.set(new Date());
       const payload = JSON.stringify(createFeedCredentialPayload());
       const expressResponse = await pollFeed(
-        application.expressContext.localEndpoint,
+        `${application.expressContext.localEndpoint}/feeds`,
         new Identity(),
         payload,
         ZupassFeedIds.Devconnect

--- a/apps/passport-server/test/email-feed.spec.ts
+++ b/apps/passport-server/test/email-feed.spec.ts
@@ -59,7 +59,7 @@ describe("attested email feed functionality", function () {
     async function () {
       const payload = JSON.stringify(createFeedCredentialPayload());
       const pollFeedResult = await pollFeed(
-        application.expressContext.localEndpoint,
+        `${application.expressContext.localEndpoint}/feeds`,
         identity,
         payload,
         ZupassFeedIds.Email

--- a/apps/passport-server/test/frogcrypto.spec.ts
+++ b/apps/passport-server/test/frogcrypto.spec.ts
@@ -1,0 +1,142 @@
+import { expect } from "chai";
+import MockDate from "mockdate";
+import { Pool } from "postgres-pool";
+import { EdDSAFrogPCD, EdDSAFrogPCDPackage } from "@pcd/eddsa-frog-pcd";
+import {
+  createFeedCredentialPayload,
+  pollFeed,
+  PollFeedResult,
+  requestListFeeds
+} from "@pcd/passport-interface";
+import { AppendToFolderAction, PCDActionType } from "@pcd/pcd-collection";
+import { Identity } from "@semaphore-protocol/identity";
+import { stopApplication } from "../src/application";
+import { getDB } from "../src/database/postgresPool";
+import { Zupass } from "../src/types";
+import {
+  FROGCRYPTO_FEEDS,
+  FrogCryptoFeed,
+  FrogCryptoFeedConfig
+} from "../src/util/frogcrypto";
+import { goodResponse } from "./tripsha/mockTripshaAPI";
+import { testLogin } from "./user/testLoginPCDPass";
+import { overrideEnvironment, testingEnv } from "./util/env";
+import { startTestingApp } from "./util/startTestingApplication";
+import "mocha";
+
+describe("frogcrypto functionality", function () {
+  this.timeout(30_000);
+  let db: Pool;
+  let application: Zupass;
+  let identity: Identity;
+  let frogPCD: EdDSAFrogPCD;
+
+  this.beforeAll(async () => {
+    await overrideEnvironment(testingEnv);
+    db = await getDB();
+
+    application = await startTestingApp();
+
+    await EdDSAFrogPCDPackage.init?.({});
+  });
+
+  this.afterAll(async () => {
+    await stopApplication(application);
+    await db.end();
+  });
+
+  it("should be able to log in", async function () {
+    const result = await testLogin(application, goodResponse.tickets[0].email, {
+      expectEmailIncorrect: false,
+      expectUserAlreadyLoggedIn: false,
+      force: false,
+      skipSetupPassword: false
+    });
+
+    if (!result) {
+      throw new Error("failed to log in");
+    }
+
+    expect(result).to.not.be.undefined;
+
+    identity = result.identity;
+  });
+
+  it("should be able to discover only public feeds", async function () {
+    const response = await requestListFeeds(
+      `${application.expressContext.localEndpoint}/frogcrypto/feeds`
+    );
+    expect(response.success).to.be.true;
+    const feeds = response.value?.feeds;
+    expect(feeds).to.not.be.undefined;
+    expect(feeds?.length).to.eq(1);
+    const feed = feeds?.[0] as FrogCryptoFeed;
+    expect(feed?.active).to.be.true;
+    expect(feed?.private).to.be.false;
+  });
+
+  it("should be able to get frog", async () => {
+    const feed = FROGCRYPTO_FEEDS[0];
+    expect(feed.active).to.be.true;
+    expect(feed.private).to.be.false;
+
+    const response = await getFrog(feed);
+    expect(response.success).to.be.true;
+
+    expect(response.value?.actions.length).to.eq(1);
+    const populateAction = response.value?.actions[0] as AppendToFolderAction;
+    expect(populateAction.type).to.eq(PCDActionType.AppendToFolder);
+    expect(populateAction.folder).to.eq("FrogCrypto");
+    expect(populateAction.pcds[0].type).to.eq(EdDSAFrogPCDPackage.name);
+
+    frogPCD = await EdDSAFrogPCDPackage.deserialize(populateAction.pcds[0].pcd);
+    expect(frogPCD.claim.data.ownerSemaphoreId).to.eq(
+      identity.commitment.toString()
+    );
+  });
+
+  it("should be able to get frog even if feed is private", async () => {
+    const feed = FROGCRYPTO_FEEDS[1];
+    expect(feed.active).to.be.true;
+    expect(feed.private).to.be.true;
+
+    const response = await getFrog(feed);
+    expect(response.success).to.be.true;
+
+    expect(response.value?.actions.length).to.eq(1);
+    const populateAction = response.value?.actions[0] as AppendToFolderAction;
+    expect(populateAction.type).to.eq(PCDActionType.AppendToFolder);
+    expect(populateAction.folder).to.eq("FrogCrypto");
+    expect(populateAction.pcds[0].type).to.eq(EdDSAFrogPCDPackage.name);
+
+    frogPCD = await EdDSAFrogPCDPackage.deserialize(populateAction.pcds[0].pcd);
+    expect(frogPCD.claim.data.ownerSemaphoreId).to.eq(
+      identity.commitment.toString()
+    );
+  });
+
+  it("should not be able to get frog if feed is inactive", async () => {
+    const feed = FROGCRYPTO_FEEDS[2];
+    expect(feed.active).to.be.false;
+    expect(feed.private).to.be.true;
+
+    const response = await getFrog(feed);
+    expect(response.success).to.be.false;
+    expect(response.error).to.include("not active");
+  });
+
+  async function getFrog(feed: FrogCryptoFeedConfig): Promise<PollFeedResult> {
+    MockDate.set(new Date());
+    const payload = JSON.stringify(createFeedCredentialPayload());
+    const response = await pollFeed(
+      application.expressContext.localEndpoint,
+      identity,
+      payload,
+      feed.id,
+      `${application.expressContext.localEndpoint}/frogcrypto/feeds`
+    );
+    MockDate.reset();
+
+    return response;
+  }
+});

--- a/apps/passport-server/test/zuconnect.spec.ts
+++ b/apps/passport-server/test/zuconnect.spec.ts
@@ -324,7 +324,7 @@ describe("zuconnect functionality", function () {
     MockDate.set(new Date());
     const payload = JSON.stringify(createFeedCredentialPayload());
     const response = await pollFeed(
-      application.expressContext.localEndpoint,
+      `${application.expressContext.localEndpoint}/feeds`,
       identity,
       payload,
       ZupassFeedIds.Zuconnect_23
@@ -462,7 +462,7 @@ describe("zuconnect functionality", function () {
     MockDate.set(new Date());
     const payload = JSON.stringify(createFeedCredentialPayload());
     const response = await pollFeed(
-      application.expressContext.localEndpoint,
+      `${application.expressContext.localEndpoint}/feeds`,
       userWithTwoTicketsRow.identity,
       payload,
       ZupassFeedIds.Zuconnect_23

--- a/apps/passport-server/test/zuzalu-ticket-feed.spec.ts
+++ b/apps/passport-server/test/zuzalu-ticket-feed.spec.ts
@@ -90,7 +90,7 @@ describe("zuzalu pcdpass functionality", function () {
     async function () {
       const payload = JSON.stringify(createFeedCredentialPayload());
       const response = await pollFeed(
-        application.expressContext.localEndpoint,
+        `${application.expressContext.localEndpoint}/feeds`,
         identity,
         payload,
         ZupassFeedIds.Zuzalu_23

--- a/packages/eddsa-frog-pcd/package.json
+++ b/packages/eddsa-frog-pcd/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@pcd/eddsa-pcd": "0.2.2",
-    "@pcd/passport-ui": "0.7.2",
+    "@pcd/passport-ui": "0.8.0",
     "@pcd/pcd-types": "0.7.2",
     "@pcd/util": "0.1.2",
     "chai": "^4.3.7",

--- a/packages/eddsa-frog-pcd/src/CardBody.tsx
+++ b/packages/eddsa-frog-pcd/src/CardBody.tsx
@@ -35,7 +35,9 @@ export function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
     </Container>
   ) : (
     <Container>
-      <a onClick={() => setShowPCD(true)}>View as proof-carrying data</a>
+      <Button onClick={() => setShowPCD(true)}>
+        View as proof-carrying data
+      </Button>
       <FrogImg src={frogData?.imageUrl} draggable={false} />
       <FrogInfo>
         <FrogAttribute label="JUMP" title="Jump" value={frogData.jump} />
@@ -69,9 +71,9 @@ export function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
           </FrogInfo>
         </>
       )}
-      <a onClick={() => setShowMore(!showMore)}>
+      <Button onClick={() => setShowMore(!showMore)}>
         {showMore ? "Collapse" : "See more"}
-      </a>
+      </Button>
     </Container>
   );
 }
@@ -151,7 +153,9 @@ function CopyFrogPCD({ pcd }: { pcd: EdDSAFrogPCD }) {
     setTimeout(() => setCopied(false), 1000);
   }, [pcd]);
 
-  return <a onClick={onClick}>{copied ? "Copied!" : "Copy frog PCD"}</a>;
+  return (
+    <Button onClick={onClick}>{copied ? "Copied!" : "Copy frog PCD"}</Button>
+  );
 }
 
 const Container = styled.div`
@@ -177,7 +181,7 @@ const FrogImg = styled.img`
 
 const Description = styled.div`
   font-size: 14px;
-  color: rgba(var(--white-rgb), 0.8);
+  color: rgba(var(--black-rgb), 0.8);
 `;
 
 const Attribute = styled.div`
@@ -195,4 +199,10 @@ const AttrTitle = styled.div`
 
 const AttrValue = styled.div`
   font-size: 14px;
+`;
+
+const Button = styled.a`
+  color: var(--accent-darker);
+  cursor: pointer;
+  text-decoration: none;
 `;

--- a/packages/eddsa-frog-pcd/src/CardBody.tsx
+++ b/packages/eddsa-frog-pcd/src/CardBody.tsx
@@ -1,4 +1,5 @@
 import {
+  LinkButton,
   QRDisplayWithRegenerateAndStorage,
   encodeQRPayload
 } from "@pcd/passport-ui";
@@ -35,9 +36,9 @@ export function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
     </Container>
   ) : (
     <Container>
-      <Button onClick={() => setShowPCD(true)}>
+      <LinkButton onClick={() => setShowPCD(true)}>
         View as proof-carrying data
-      </Button>
+      </LinkButton>
       <FrogImg src={frogData?.imageUrl} draggable={false} />
       <FrogInfo>
         <FrogAttribute label="JUMP" title="Jump" value={frogData.jump} />
@@ -71,9 +72,9 @@ export function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
           </FrogInfo>
         </>
       )}
-      <Button onClick={() => setShowMore(!showMore)}>
+      <LinkButton onClick={() => setShowMore(!showMore)}>
         {showMore ? "Collapse" : "See more"}
-      </Button>
+      </LinkButton>
     </Container>
   );
 }
@@ -154,7 +155,9 @@ function CopyFrogPCD({ pcd }: { pcd: EdDSAFrogPCD }) {
   }, [pcd]);
 
   return (
-    <Button onClick={onClick}>{copied ? "Copied!" : "Copy frog PCD"}</Button>
+    <LinkButton onClick={onClick}>
+      {copied ? "Copied!" : "Copy frog PCD"}
+    </LinkButton>
   );
 }
 
@@ -199,10 +202,4 @@ const AttrTitle = styled.div`
 
 const AttrValue = styled.div`
   font-size: 14px;
-`;
-
-const Button = styled.a`
-  color: var(--accent-darker);
-  cursor: pointer;
-  text-decoration: none;
 `;

--- a/packages/passport-interface/src/FeedHost.ts
+++ b/packages/passport-interface/src/FeedHost.ts
@@ -7,18 +7,18 @@ import {
 } from "./RequestTypes";
 import { Feed } from "./SubscriptionManager";
 
-export interface HostedFeed {
-  feed: Feed;
+export interface HostedFeed<IFeed extends Feed = Feed> {
+  feed: IFeed;
   handleRequest(request: PollFeedRequest): Promise<PollFeedResponseValue>;
 }
 
-export class FeedHost {
-  private readonly hostedFeed: HostedFeed[];
-  private readonly providerUrl: string;
-  private readonly providerName: string;
+export class FeedHost<IFeed extends Feed = Feed> {
+  protected readonly hostedFeed: HostedFeed<IFeed>[];
+  protected readonly providerUrl: string;
+  protected readonly providerName: string;
 
   public constructor(
-    feeds: HostedFeed[],
+    feeds: HostedFeed<IFeed>[],
     providerUrl: string,
     providerName: string
   ) {

--- a/packages/passport-interface/src/SubscriptionManager.ts
+++ b/packages/passport-interface/src/SubscriptionManager.ts
@@ -96,8 +96,8 @@ export class FeedSubscriptionManager {
     );
 
     for (const subscription of this.activeSubscriptions) {
-      // nb: undefined fetchOnLoad defaults to true
-      if (subscription.feed.fetchOnLoad === false) {
+      // nb: undefined autoPoll defaults to true
+      if (subscription.feed.autoPoll === false) {
         continue;
       }
       responsePromises.push(
@@ -523,7 +523,7 @@ export interface Feed<T extends PCDPackage = PCDPackage> {
    *
    * @default true
    */
-  fetchOnLoad?: boolean;
+  autoPoll?: boolean;
 }
 
 export interface Subscription {

--- a/packages/passport-interface/src/SubscriptionManager.ts
+++ b/packages/passport-interface/src/SubscriptionManager.ts
@@ -519,7 +519,7 @@ export interface Feed<T extends PCDPackage = PCDPackage> {
   permissions: PCDPermission[];
   credentialRequest: CredentialRequest;
   /**
-   * If false, the feed will not automatic poll for updates.
+   * If false, the feed will not automatically poll for updates.
    *
    * @default true
    */

--- a/packages/passport-interface/src/SubscriptionManager.ts
+++ b/packages/passport-interface/src/SubscriptionManager.ts
@@ -96,6 +96,10 @@ export class FeedSubscriptionManager {
     );
 
     for (const subscription of this.activeSubscriptions) {
+      // nb: undefined fetchOnLoad defaults to true
+      if (subscription.feed.fetchOnLoad === false) {
+        continue;
+      }
       responsePromises.push(
         this.fetchSingleSubscription(subscription, credentialManager)
       );
@@ -514,6 +518,12 @@ export interface Feed<T extends PCDPackage = PCDPackage> {
   partialArgs?: ArgsOf<T>;
   permissions: PCDPermission[];
   credentialRequest: CredentialRequest;
+  /**
+   * If false, the feed will not automatic poll for updates.
+   *
+   * @default true
+   */
+  fetchOnLoad?: boolean;
 }
 
 export interface Subscription {

--- a/packages/passport-interface/src/api/requestPollFeed.ts
+++ b/packages/passport-interface/src/api/requestPollFeed.ts
@@ -26,11 +26,10 @@ export async function requestPollFeed(
 }
 
 export async function pollFeed(
-  zupassServerUrl: string,
+  feedUrl: string,
   identity: Identity,
   signedMessage: string,
-  feedId: string,
-  feedUrl = `${zupassServerUrl}/feeds`
+  feedId: string
 ): Promise<PollFeedResult> {
   return requestPollFeed(feedUrl, {
     feedId,

--- a/packages/passport-interface/src/api/requestPollFeed.ts
+++ b/packages/passport-interface/src/api/requestPollFeed.ts
@@ -29,9 +29,10 @@ export async function pollFeed(
   zupassServerUrl: string,
   identity: Identity,
   signedMessage: string,
-  feedId: string
+  feedId: string,
+  feedUrl = `${zupassServerUrl}/feeds`
 ): Promise<PollFeedResult> {
-  return requestPollFeed(`${zupassServerUrl}/feeds`, {
+  return requestPollFeed(feedUrl, {
     feedId,
     pcd: await SemaphoreSignaturePCDPackage.serialize(
       await SemaphoreSignaturePCDPackage.prove({

--- a/packages/passport-ui/src/Core.tsx
+++ b/packages/passport-ui/src/Core.tsx
@@ -25,3 +25,9 @@ export const Separator = styled.div`
 export const FieldLabel = styled.span`
   font-weight: bold;
 `;
+
+export const LinkButton = styled.a`
+  color: var(--accent-darker);
+  cursor: pointer;
+  text-decoration: none;
+`;


### PR DESCRIPTION
https://github.com/proofcarryingdata/zupass/issues/1057

Implement a new FeedHost to issue FryptoCrypto PCDs

* Extended base Feed type with `fetchOnLoad`. When this is set to false, SubscriptionManager will not automatically poll feed
* Created `FrogCryptoFeedHost extends FeedHost` where some of the logics are overriden 
    * `FrogCryptoFeed extends Feed` with additional config flags such as `private` and `active`. This isolates our FrogCrypto FeedHost specific features
    * `private: true` hides feed from `GET /feeds` and they are not discoverable. We will add separate routes to subscribe these stealth feed
    * `active` makes it possible to pause a feed
* Added `/frogcrypto/feeds[/...]` routes and isolate all changes to existing feeds
* Added FrogHomeScreen with `#/frog` route as a temporary testbed
* Implement a proof of concept cooldown mechanism in memory
    * No explicit error handling yet
    * We need a separate endpoint to ask for next available fetch timestamp

The FrogFeed config and Frog data are hard coded. The fetch cooldown is implemented in-memory and lost upon server restarts. To reduce review burden, we will migrate them to a database based model in subsequent PR.

Tested locally:
* Public feeds can be found and subscribed using feed URL
* Subscribed frog feeds are not automatically polled
* Poll frog and frog shows up
* (fake) cooldown works
* FrogCard renders ok

Added unit tests:
* get frog
* feeds respect private/active
* no test for cooldown to avoid flaky tests

<img width="544" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/697c4420-3b90-4d81-b67a-5232b282143b">
