### PR TITLE
[frogcrypto][3/n] add PCDCardList component

### DIFF
--- a/apps/passport-client/components/screens/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen.tsx
@@ -3,13 +3,10 @@ import {
   getParentFolder,
   isRootFolder
 } from "@pcd/pcd-collection";
-import { PCD } from "@pcd/pcd-types";
-import { SemaphoreIdentityPCDTypeName } from "@pcd/semaphore-identity-pcd";
 import React, {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useState
 } from "react";
 import { useNavigate } from "react-router-dom";
@@ -22,7 +19,7 @@ import { MaybeModal } from "../modals/Modal";
 import { AppContainer } from "../shared/AppContainer";
 import { AppHeader } from "../shared/AppHeader";
 import { LoadingIssuedPCDs } from "../shared/LoadingIssuedPCDs";
-import { PCDCard } from "../shared/PCDCard";
+import { PCDCardList } from "../shared/PCDCardList";
 import { FrogFolder } from "./FrogScreens/FrogFolder";
 
 export const HomeScreen = React.memo(HomeScreenImpl);
@@ -56,36 +53,6 @@ export function HomeScreenImpl() {
       delete sessionStorage.newAddedPCDID;
     }
   });
-
-  const mainPCDId = useMemo(() => {
-    if (pcdsInFolder[0]?.type === SemaphoreIdentityPCDTypeName) {
-      return pcdsInFolder[0]?.id;
-    }
-  }, [pcdsInFolder]);
-  const [selectedPCDID, setSelectedPCDID] = useState("");
-  const selectedPCD = useMemo(() => {
-    let selected;
-
-    // if user just added a PCD, highlight that one
-    if (sessionStorage.newAddedPCDID != null) {
-      selected = pcdsInFolder.find(
-        (pcd) => pcd.id === sessionStorage.newAddedPCDID
-      );
-    } else {
-      selected = pcdsInFolder.find((pcd) => pcd.id === selectedPCDID);
-    }
-
-    // default to first PCD if no selected PCD found
-    if (selected === undefined) {
-      selected = pcdsInFolder[0];
-    }
-
-    return selected;
-  }, [pcdsInFolder, selectedPCDID]);
-
-  const onPcdClick = useCallback((id: string) => {
-    setSelectedPCDID(id);
-  }, []);
 
   const onFolderClick = useCallback((folder: string) => {
     setBrowsingFolder(folder);
@@ -136,15 +103,7 @@ export function HomeScreenImpl() {
           )}
           {!(foldersInFolder.length === 0 && isRoot) && <Separator />}
           {pcdsInFolder.length > 0 ? (
-            pcdsInFolder.map((pcd) => (
-              <WrappedPCDCard
-                key={pcd.id}
-                pcd={pcd}
-                mainIdPCD={mainPCDId}
-                onPcdClick={onPcdClick}
-                expanded={pcd.id === selectedPCD?.id}
-              />
-            ))
+            <PCDCardList pcds={pcdsInFolder} />
           ) : (
             <NoPcdsContainer>This folder has no PCDs</NoPcdsContainer>
           )}
@@ -284,34 +243,4 @@ const FolderEntryContainer = styled.div`
   &:hover {
     background: var(--primary-lite);
   }
-`;
-
-const WrappedPCDCard = React.memo(WrappedPCDCardImpl);
-
-function WrappedPCDCardImpl({
-  pcd,
-  expanded,
-  mainIdPCD,
-  onPcdClick
-}: {
-  pcd: PCD;
-  expanded: boolean;
-  mainIdPCD: string;
-  onPcdClick?: (id: string) => void;
-}) {
-  return (
-    <PCDContainer key={"container-" + pcd.id}>
-      <PCDCard
-        key={"card-" + pcd.id}
-        pcd={pcd}
-        expanded={expanded}
-        isMainIdentity={pcd.id === mainIdPCD}
-        onClick={onPcdClick}
-      />
-    </PCDContainer>
-  );
-}
-
-const PCDContainer = styled.div`
-  margin-top: 8px;
 `;

--- a/apps/passport-client/components/shared/PCDCard.tsx
+++ b/apps/passport-client/components/shared/PCDCard.tsx
@@ -186,7 +186,7 @@ function CardBody({
 
 export const CardContainerExpanded = styled.div`
   width: 100%;
-  padding: 0 8px;
+  padding: 8px;
 `;
 
 const CardContainerCollapsed = styled(CardContainerExpanded)`

--- a/apps/passport-client/components/shared/PCDCardList.tsx
+++ b/apps/passport-client/components/shared/PCDCardList.tsx
@@ -1,0 +1,279 @@
+import { PCD } from "@pcd/pcd-types";
+import { SemaphoreIdentityPCDTypeName } from "@pcd/semaphore-identity-pcd";
+import _ from "lodash";
+import { useCallback, useMemo, useState } from "react";
+import styled from "styled-components";
+import { usePCDCollection } from "../../src/appHooks";
+import { PCDCard } from "./PCDCard";
+
+type Sortable = {
+  name: string;
+  order: number;
+};
+type SortKey = keyof Sortable;
+type SortOption = {
+  render: () => JSX.Element;
+  key: SortKey;
+};
+const SORT_OPTIONS: SortOption[] = [
+  { render: () => <NameIcon />, key: "name" },
+  /**
+   * PCDs are naturally sorted by order of when it is added to the collection.
+   * The order of its sequence proximates the time it was added.
+   */
+  { render: () => <ClockIcon />, key: "order" }
+];
+type SortState = {
+  sortBy?: SortKey;
+  sortOrder?: "asc" | "desc";
+};
+
+export function PCDCardList({ pcds }: { pcds: PCD[] }) {
+  const mainPCDId = useMemo(() => {
+    if (pcds[0]?.type === SemaphoreIdentityPCDTypeName) {
+      return pcds[0]?.id;
+    }
+  }, [pcds]);
+
+  const pcdCollection = usePCDCollection();
+  const sortablePCDs = useMemo(
+    () =>
+      pcds.map((pcd, i) => ({
+        pcd,
+        name: pcdCollection.getPackage(pcd.type).getDisplayOptions?.(pcd)
+          ?.displayName,
+        order: i
+      })),
+    [pcdCollection, pcds]
+  );
+  // only show sort options that are valid for all PCDs
+  const sortOptions = useMemo(
+    () =>
+      SORT_OPTIONS.filter(
+        (option) =>
+          !sortablePCDs.some((pcd) => typeof pcd[option.key] === "undefined")
+      ),
+    [sortablePCDs]
+  );
+  const [sortState, setSortState] = useState<SortState>({
+    sortBy: "order",
+    sortOrder: "asc"
+  });
+  const sortedPCDs = useMemo(
+    () =>
+      (sortState.sortBy && sortState.sortOrder
+        ? _.orderBy(sortablePCDs, [sortState.sortBy], [sortState.sortOrder])
+        : sortablePCDs
+      ).map((o) => o.pcd),
+    [sortState, sortablePCDs]
+  );
+
+  const [selectedPCDID, setSelectedPCDID] = useState("");
+  const selectedPCD = useMemo(() => {
+    // if user just added a PCD, highlight that one
+    if (sessionStorage.newAddedPCDID != null) {
+      const added = pcds.find((pcd) => pcd.id === sessionStorage.newAddedPCDID);
+      if (added) {
+        return added;
+      }
+    }
+
+    const selected = pcds.find((pcd) => pcd.id === selectedPCDID);
+    if (selected) {
+      return selected;
+    }
+
+    // default to first PCD if no selected PCD found
+    return pcds[0];
+  }, [pcds, selectedPCDID]);
+
+  const onClick = useCallback((id: string) => {
+    setSelectedPCDID(id);
+  }, []);
+
+  return (
+    <Container>
+      {sortablePCDs.length > 1 && (
+        <ToolBar
+          sortOptions={sortOptions}
+          sortState={sortState}
+          onSortStateChange={setSortState}
+        />
+      )}
+      {sortedPCDs.map((pcd) => (
+        <PCDCard
+          key={pcd.id}
+          pcd={pcd}
+          isMainIdentity={pcd.id === mainPCDId}
+          onClick={onClick}
+          expanded={pcd.id === selectedPCD?.id}
+        />
+      ))}
+    </Container>
+  );
+}
+
+function ToolBar({
+  sortOptions,
+  sortState,
+  onSortStateChange
+}: {
+  sortOptions: SortOption[];
+  sortState: SortState;
+  onSortStateChange: (sortState: SortState) => void;
+}) {
+  if (sortOptions.length === 0) return null;
+
+  return (
+    <ToolBarContainer>
+      {sortOptions.map((o) => {
+        const active = sortState.sortBy === o.key;
+        const onClick = () => {
+          if (active) {
+            onSortStateChange({
+              sortBy: o.key,
+              sortOrder: sortState.sortOrder === "asc" ? "desc" : "asc"
+            });
+          } else {
+            onSortStateChange({
+              sortBy: o.key,
+              sortOrder: "asc"
+            });
+          }
+        };
+
+        return (
+          <ToolBarItem key={o.key} onClick={onClick}>
+            {o.render()}
+            <SortIcon sortOrder={active ? sortState.sortOrder : undefined} />
+          </ToolBarItem>
+        );
+      })}
+    </ToolBarContainer>
+  );
+}
+
+function SortIcon({ sortOrder }: { sortOrder?: "asc" | "desc" }) {
+  return (
+    <SortIconContainer>
+      <SortIconUp active={sortOrder === "asc"} />
+      <SortIconDown active={sortOrder === "desc"} />
+    </SortIconContainer>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const ToolBarContainer = styled.div`
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 8px;
+  align-items: center;
+`;
+
+const ToolBarItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+`;
+
+const SortIconContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const SortIconUp = styled.div<{ active: boolean }>`
+  left: 3px;
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border: solid 5px transparent;
+  background: transparent;
+  border-bottom: solid 7px
+    ${(p) =>
+      p.active ? "var(--accent-darker)" : "rgba(var(--white-rgb), 0.6)"};
+  border-top-width: 0;
+`;
+
+const SortIconDown = styled.div<{ active: boolean }>`
+  left: 3px;
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border: solid 5px transparent;
+  background: transparent;
+  border-top: solid 7px
+    ${(p) =>
+      p.active ? "var(--accent-darker)" : "rgba(var(--white-rgb), 0.6)"};
+  border-bottom-width: 0;
+`;
+
+const ClockIcon = styled.div`
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: rgba(var(--white-rgb), 0.6);
+  position: relative;
+  display: block;
+
+  &::before {
+    content: "";
+    height: 9px;
+    width: 1px;
+    background-color: var(--black);
+    display: block;
+    position: absolute;
+    left: 9px;
+    top: 3px;
+    opacity: 0.6;
+  }
+  &::after {
+    content: "";
+    height: 6px;
+    width: 1px;
+    background-color: var(--black);
+    display: block;
+    position: absolute;
+    top: 7px;
+    left: 11px;
+    transform: rotate(45deg);
+    opacity: 0.6;
+  }
+`;
+
+const NameIcon = styled.div`
+  width: 18px;
+  height: 18px;
+  position: relative;
+  display: block;
+
+  &::before {
+    content: "A";
+    font-size: 12px;
+    line-height: 12px;
+    font-weight: 600;
+    color: var(--white);
+    display: block;
+    position: absolute;
+    top: 0px;
+    opacity: 0.6;
+  }
+  &::after {
+    content: "Z";
+    font-size: 12px;
+    line-height: 12px;
+    font-weight: 600;
+    color: var(--white);
+    display: block;
+    position: absolute;
+    right: 0px;
+    bottom: 0px;
+    opacity: 0.6;
+  }
+`;

--- a/apps/passport-client/components/shared/PCDCardList.tsx
+++ b/apps/passport-client/components/shared/PCDCardList.tsx
@@ -236,15 +236,16 @@ const ClockIcon = styled.div`
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background-color: rgba(var(--white-rgb), 0.8);
+  background-color: #fff;
   position: relative;
   display: block;
+  opacity: 0.8;
 
   &::before {
     content: "";
     height: 10px;
     width: 1px;
-    background-color: var(--black);
+    background-color: #000;
     display: block;
     position: absolute;
     left: 10px;
@@ -255,7 +256,7 @@ const ClockIcon = styled.div`
     content: "";
     height: 6px;
     width: 1px;
-    background-color: var(--black);
+    background-color: #000;
     display: block;
     position: absolute;
     top: 8px;
@@ -276,7 +277,7 @@ const NameIcon = styled.div`
     font-size: 14px;
     line-height: 14px;
     font-weight: 600;
-    color: var(--white);
+    color: #fff;
     display: block;
     position: absolute;
     top: 0px;
@@ -287,7 +288,7 @@ const NameIcon = styled.div`
     font-size: 14px;
     line-height: 14px;
     font-weight: 600;
-    color: var(--white);
+    color: #fff;
     display: block;
     position: absolute;
     right: 0px;


### PR DESCRIPTION
https://github.com/proofcarryingdata/zupass/issues/1057

Refactor PCDCard list into its own component. This can be used for FrogCrypto special screen. Added ability to order PCDs by time issued (proximated by its order in the PCDCollection) and name of PCD when available. The sort functionality is especially useful for frogcrypto.


<img width="606" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/a8ad3769-fa8b-4c75-84e6-c36d51c019da">

Tested locally the ordering toolbar only shows up when there are multiple PCDs

<img width="521" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/5b05b81c-348e-42d8-82b0-e79b7fb0f051">
