### PR TITLE
Fix accidental detection of differences between Zuconnect tickets

### DIFF
--- a/apps/passport-server/src/apis/zuconnect/zuconnectTripshaAPI.ts
+++ b/apps/passport-server/src/apis/zuconnect/zuconnectTripshaAPI.ts
@@ -31,7 +31,10 @@ const ZuconnectTripshaSchema = z.object({
     .nullable()
     .optional()
     .transform((last) => last ?? ""),
-  options: z.array(z.object({ id: z.string(), name: z.string() })).optional()
+  options: z
+    .array(z.object({ id: z.string(), name: z.string() }))
+    .optional()
+    .default([])
 });
 
 const ZuconnectTripshaNormalizedSchema = ZuconnectTripshaSchema


### PR DESCRIPTION
When saving a Zuconnect ticket to the DB, we give it a default `extra_info` value of an empty array. However, the corresponding API ticket has value of `undefined`, and the comparison function did not account for this. Now we assign an empty array to this value during parsing, and make the comparison function do a deep equality check.