### PR TITLE
Add section on going to Zupass help desk to wasm screen if during devconnect

### DIFF
--- a/apps/passport-client/components/screens/NoWASMScreen.tsx
+++ b/apps/passport-client/components/screens/NoWASMScreen.tsx
@@ -1,19 +1,35 @@
+import {
+  DEVCONNECT_2023_END,
+  DEVCONNECT_2023_START
+} from "../../src/sharedConstants";
 import { H2, Spacer, TextCenter } from "../core";
 import { AppContainer } from "../shared/AppContainer";
 
 export function NoWASMScreen() {
+  const currentTimeMs = new Date().getTime();
+  const isDuringDevconnect =
+    currentTimeMs >= DEVCONNECT_2023_START &&
+    currentTimeMs < DEVCONNECT_2023_END;
   return (
     <>
       <AppContainer bg="primary">
         <Spacer h={64} />
         <TextCenter>
           <H2>Browser not supported</H2>
+          {isDuringDevconnect && (
+            <>
+              <Spacer h={24} />
+              If you are currently at Devconnect, please visit the Zupass Help
+              Desk at the entrance of the Istanbul Congress Center (ICC) for
+              support.
+            </>
+          )}
           <Spacer h={24} />
-         Your browser does not currently support WebAssembly, which is
-         required for Zupass to generate zero-knowledge proofs. Try using
-         Zupass on a different browser, and check that WebAssembly
-         is not disabled. You can view a list of supported browsers
-         <a href="https://webassembly.org/roadmap/">here</a>.
+          Your browser does not currently support WebAssembly, which is required
+          for Zupass to generate zero-knowledge proofs. Try using Zupass on a
+          different browser, and check that WebAssembly is not disabled. You can
+          view a list of supported browsers{" "}
+          <a href="https://webassembly.org/roadmap/">here</a>.
         </TextCenter>
         <Spacer h={64} />
       </AppContainer>

--- a/apps/passport-client/src/sharedConstants.ts
+++ b/apps/passport-client/src/sharedConstants.ts
@@ -3,3 +3,13 @@
  * registers it.
  */
 export const SERVICE_WORKER_ENABLED = process.env.NODE_ENV !== "development";
+
+/** Start time of Devconnect 2023, from https://devconnect.org/schedule */
+export const DEVCONNECT_2023_START = Date.parse(
+  "November 13, 2023, 00:00:00 UTC+3"
+);
+
+/** End time of Devconnect 2023, from https://devconnect.org/schedule */
+export const DEVCONNECT_2023_END = Date.parse(
+  "November 20, 2023, 00:00:00 UTC+3"
+);


### PR DESCRIPTION
Closes #1049 

Plus add a space that was missing

Before:

<img width="401" alt="Screenshot 2023-10-26 at 2 08 38 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/f3a22f06-b563-49eb-9a8b-6a6567acd584">


After:

(during Devconnect)

<img width="407" alt="Screenshot 2023-10-26 at 2 02 43 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/4ee14a25-cfb3-4335-9235-48193c923275">

(not during Devconnect)

<img width="404" alt="Screenshot 2023-10-26 at 2 08 06 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/9dbfb8df-386e-4f17-ab3f-4eea84d27552">
