### PR TITLE
Background Poll and Sync

### DIFF
--- a/apps/passport-client/src/state.ts
+++ b/apps/passport-client/src/state.ts
@@ -50,12 +50,15 @@ export interface AppState {
   anotherDeviceChangedPassword?: boolean;
 
   // Dynamic (in-memory-only) state-machine for sync of E2EE encrypted data.
+  // TODO(artwyman): The parts of this not needed by the rest of the app
+  // might be better stored elsewhere, to avoid issues with reentrancy
+  // and stale snapshots delivered via dispatch().
   uploadedUploadId?: string;
-  uploadingUploadId?: string;
   downloadedPCDs?: boolean;
-  downloadingPCDs?: boolean;
   loadedIssuedPCDs?: boolean;
-  loadingIssuedPCDs?: boolean;
+  loadingIssuedPCDs?: boolean; // Used only to update UI
+  completedFirstSync?: boolean;
+  extraDownloadRequested?: boolean;
 
   // Persistent sync state-machine fields, saved in local storage as a
   // PersistentSyncStatus object.  This is structured to allow for more

--- a/apps/passport-client/src/user.ts
+++ b/apps/passport-client/src/user.ts
@@ -5,8 +5,8 @@ import { Dispatcher } from "./dispatch";
 // Starts polling the user from the server, in the background.
 export async function pollUser(self: User, dispatch: Dispatcher) {
   try {
+    console.log("[USER_POLL] polling user");
     const response = await requestUser(appConfig.zupassServer, self.uuid);
-
     if (response.error?.userMissing) {
       // this user was previously a valid user, but now the
       // app isn't able to find them, so we should log the


### PR DESCRIPTION
Note this PR builds on top of #1077 which will merge first.  I may or may not know how to update this PR to merge into main when that time comes.  Meanwhile this PR is in draft state with some TODOs indicating open questions I'd like input on.

Two user-visible features here:
- Background polling is now disabled and re-enabled when browser tab becomes visible/invisible.
- In addition to the user, polling will now trigger a download from E2EE storage, if there are change.

Between those two features and prior work in #1077, updates made across multiple browsers/tabs update pretty quickly (within 60s) and automatically, which reduces the risk of unnecessary conflicts.  Downloads and uploads now both have a mechanism to avoid clobbering when there are no changes.  Each new change can still clobber others as it propagates to server and down to other clients, but the periodic polls make it less likely a user will make changes without having already incorporated all prior changes.  Note that multiple tabs in the same browser will get each other's updates via the server, not via local storage, so this scheme only works smoothly online.

A hidden feature is refactoring sync() to add reentrancy protection.  I thought I could manage to enable those two features without significant refactoring, but I ran into reentrancy problems leading to duplicate downloads.  I believe the delayed nature of AppState updates was to blame: listeners run with a snapshot of the state from when they were scheduled, even if it's changed further since then.  It's possible that the sync state-machine's primary tracking doesn't belong in AppState at all.

The split of the doSync() function is the simplest form of refactoring for general reentrancy protection I could come up with, using a single global boolean.  I removed the unnecessary tracking ("downloading" and "uploading") which were only used for that purpose.  I kept the "loadingIssuedPCDs" variable for the purpose of updating the UI.  We could think about more general sync status UI later, but I didn't want to add speculative features there.