### PR TITLE
Allow multiple chats per event

### DIFF
--- a/apps/passport-server/migrations/51_multiple_chats_per_event.sql
+++ b/apps/passport-server/migrations/51_multiple_chats_per_event.sql
@@ -1,0 +1,2 @@
+ALTER TABLE telegram_bot_events DROP CONSTRAINT telegram_bot_events_ticket_event_id_key;
+ALTER TABLE telegram_bot_events ADD UNIQUE (telegram_chat_id, ticket_event_id);

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
@@ -70,7 +70,7 @@ export async function fetchEventsWithTelegramChats(
   const result = await sqlQuery(
     client,
     `
-    SELECT
+    SELECT DISTINCT ON (tbe.ticket_event_id)
       tbe.telegram_chat_id AS "telegramChatID",
       dpe.event_name AS "eventName",
       dpe.pretix_events_config_id AS "configEventID",
@@ -78,7 +78,10 @@ export async function fetchEventsWithTelegramChats(
     FROM 
       devconnect_pretix_events_info dpe 
     LEFT JOIN 
-      telegram_bot_events tbe ON dpe.pretix_events_config_id = tbe.ticket_event_id;
+      telegram_bot_events tbe ON dpe.pretix_events_config_id = tbe.ticket_event_id
+    ORDER BY tbe.ticket_event_id, 
+      CASE WHEN tbe.telegram_chat_id = $1 THEN true ELSE false END DESC,
+      tbe.telegram_chat_id;
     `,
     [currentTelegramChatId]
   );

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
@@ -18,7 +18,7 @@ import { sqlQuery } from "../../sqlQuery";
 export async function fetchTelegramEventByEventId(
   client: Pool,
   eventId: string
-): Promise<TelegramEvent> {
+): Promise<TelegramEvent[]> {
   const result = await sqlQuery(
     client,
     `\
@@ -26,6 +26,23 @@ export async function fetchTelegramEventByEventId(
     where ticket_event_id = $1
     `,
     [eventId]
+  );
+
+  return result.rows;
+}
+
+export async function fetchTelegramBotEvent(
+  client: Pool,
+  eventId: string,
+  telegramChatID: string | number
+): Promise<TelegramEvent> {
+  const result = await sqlQuery(
+    client,
+    `\
+    select * from telegram_bot_events
+    where ticket_event_id = $1 and telegram_chat_id = $2
+    `,
+    [eventId, telegramChatID]
   );
 
   return result.rows[0] ?? null;

--- a/apps/passport-server/src/database/queries/telegram/insertTelegramConversation.ts
+++ b/apps/passport-server/src/database/queries/telegram/insertTelegramConversation.ts
@@ -47,8 +47,7 @@ export async function insertTelegramEvent(
     `\
 insert into telegram_bot_events (ticket_event_id, telegram_chat_id)
 values ($1, $2)
-on conflict (ticket_event_id) do update
-set telegram_chat_id = $2;`,
+on conflict (ticket_event_id, telegram_chat_id) do nothing;`,
     [ticketEventId, telegramChatId]
   );
   return result.rowCount;

--- a/apps/passport-server/test/telegram.spec.ts
+++ b/apps/passport-server/test/telegram.spec.ts
@@ -17,8 +17,8 @@ import { deleteTelegramVerification } from "../src/database/queries/telegram/del
 import { fetchTelegramVerificationStatus } from "../src/database/queries/telegram/fetchTelegramConversation";
 import {
   fetchTelegramAnonTopicsByChatId,
+  fetchTelegramBotEvent,
   fetchTelegramChat,
-  fetchTelegramEventByEventId,
   fetchTelegramTopicsByChatId
 } from "../src/database/queries/telegram/fetchTelegramEvent";
 import {
@@ -164,7 +164,11 @@ describe("telegram bot functionality", function () {
   step("should be able to link an event and tg chat", async function () {
     const eventConfigId = testEvents[0].dbEventConfigId;
     await insertTelegramEvent(db, eventConfigId, dummyChatId);
-    const insertedEvent = await fetchTelegramEventByEventId(db, eventConfigId);
+    const insertedEvent = await fetchTelegramBotEvent(
+      db,
+      eventConfigId,
+      dummyChatId
+    );
     expect(insertedEvent?.ticket_event_id).to.eq(eventConfigId);
     // Note: Grammy allows chatIds to be numbers or strings
     expect(insertedEvent?.telegram_chat_id).to.eq(dummyChatId.toString());
@@ -176,9 +180,10 @@ describe("telegram bot functionality", function () {
       const newEventConfigId = testEvents[1].dbEventConfigId;
 
       await insertTelegramEvent(db, newEventConfigId, dummyChatId);
-      const insertedEvent = await fetchTelegramEventByEventId(
+      const insertedEvent = await fetchTelegramBotEvent(
         db,
-        newEventConfigId
+        newEventConfigId,
+        dummyChatId
       );
       expect(insertedEvent?.ticket_event_id).to.eq(newEventConfigId);
       expect(insertedEvent?.telegram_chat_id).to.eq(dummyChatId.toString());
@@ -191,9 +196,10 @@ describe("telegram bot functionality", function () {
       const eventConfigId = testEvents[0].dbEventConfigId;
       await insertTelegramChat(db, dummyChatId_1);
       await insertTelegramEvent(db, eventConfigId, dummyChatId_1);
-      const insertedEvent = await fetchTelegramEventByEventId(
+      const insertedEvent = await fetchTelegramBotEvent(
         db,
-        eventConfigId
+        eventConfigId,
+        dummyChatId_1
       );
       expect(insertedEvent?.ticket_event_id).to.eq(eventConfigId);
       expect(insertedEvent?.telegram_chat_id).to.eq(dummyChatId_1.toString());
@@ -205,18 +211,20 @@ describe("telegram bot functionality", function () {
     async function () {
       const eventConfigId = testEvents[0].dbEventConfigId;
       await insertTelegramEvent(db, eventConfigId, dummyChatId);
-      let insertedEventsByEventId = await fetchTelegramEventByEventId(
+      let insertedEventsByEventId = await fetchTelegramBotEvent(
         db,
-        eventConfigId
+        eventConfigId,
+        dummyChatId
       );
       expect(insertedEventsByEventId?.telegram_chat_id).to.eq(
         dummyChatId.toString()
       );
 
       await insertTelegramEvent(db, eventConfigId, dummyChatId_1);
-      insertedEventsByEventId = await fetchTelegramEventByEventId(
+      insertedEventsByEventId = await fetchTelegramBotEvent(
         db,
-        eventConfigId
+        eventConfigId,
+        dummyChatId_1
       );
       expect(insertedEventsByEventId?.telegram_chat_id).to.eq(
         dummyChatId_1.toString()


### PR DESCRIPTION
Closes #1088

This allows multiple group chats to be linked to the same Pretix event. There is still a requirement that a Zupass team member run the `/manage` command. 