### PR TITLE
Remove hard-coded QR code width

### DIFF
--- a/packages/passport-ui/src/QR.tsx
+++ b/packages/passport-ui/src/QR.tsx
@@ -1,7 +1,7 @@
 import { gzip, ungzip } from "pako";
 import qr from "qr-image";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 export function encodeQRPayload(unencoded: string): string {
   console.log(`encoding payload with length ${unencoded.length}`);
@@ -109,6 +109,7 @@ export function QRDisplayWithRegenerateAndStorage({
       value={savedState?.payload}
       fgColor={fgColor}
       bgColor={bgColor}
+      saved={!!savedState}
     />
   );
 }
@@ -117,15 +118,17 @@ export function QRDisplay({
   value,
   logoOverlay,
   fgColor,
-  bgColor
+  bgColor,
+  saved
 }: {
   value?: string;
   logoOverlay?: React.ReactNode;
   fgColor?: string;
   bgColor?: string;
+  saved: boolean;
 }) {
   return (
-    <QRWrap>
+    <QRWrap saved={saved}>
       {value !== undefined && (
         <QR
           value={value}
@@ -139,9 +142,13 @@ export function QRDisplay({
 }
 
 // Style constants
-const QRWrap = styled.div`
+const QRWrap = styled.div<{ saved: boolean }>`
+  ${({ saved }) => (saved ? css`` : css``)}
+  height: 0;
+  padding-bottom: 100%;
   position: relative;
   margin: 0 auto;
+  width: 100%;
 `;
 
 export function QR({
@@ -184,6 +191,7 @@ const Container = styled.div`
   height: 100% !important;
 
   svg {
+    position: absolute;
     width: 100%;
     height: 100%;
   }

--- a/packages/passport-ui/src/QR.tsx
+++ b/packages/passport-ui/src/QR.tsx
@@ -33,7 +33,7 @@ export function QRDisplayWithRegenerateAndStorage({
   loadingLogo,
   loadedLogo,
   fgColor,
-  bgColor,
+  bgColor
 }: {
   generateQRPayload: () => Promise<string>;
   maxAgeMs: number;
@@ -117,7 +117,7 @@ export function QRDisplay({
   value,
   logoOverlay,
   fgColor,
-  bgColor,
+  bgColor
 }: {
   value?: string;
   logoOverlay?: React.ReactNode;
@@ -139,18 +139,15 @@ export function QRDisplay({
 }
 
 // Style constants
-const qrSize = "300px";
 const QRWrap = styled.div`
   position: relative;
-  width: ${qrSize};
-  height: ${qrSize};
   margin: 0 auto;
 `;
 
 export function QR({
   value,
   fgColor,
-  bgColor,
+  bgColor
 }: {
   value: string;
   fgColor: string;


### PR DESCRIPTION
In in-person testing, I've seen a case of someone whose phone resolution is low enough that they can't display a 300px-wide QR code.

The 300px width being hard-coded seems to be unnecessary, and removing it doesn't cause a problem on other browsers, but does allow it to be scaled down on screens with fewer than 300px available.