### PR TITLE
Improve display of Zuconnect verify screen

### DIFF
--- a/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
+++ b/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
@@ -30,6 +30,7 @@ type VerifyResult =
       productId: string;
       group: KnownTicketGroup;
       publicKeyName: string;
+      ticketName?: string;
     }
   | {
       outcome: VerifyOutcome.NotVerified;
@@ -110,6 +111,7 @@ export function SecondPartyTicketVerifyScreen() {
               productId={verifyResult.productId}
               category={verifyResult.group}
               publicKeyName={verifyResult.publicKeyName}
+              ticketName={verifyResult.ticketName}
             />
           )}
       </Placeholder>
@@ -133,11 +135,13 @@ export function SecondPartyTicketVerifyScreen() {
 function VerifiedAndKnownTicket({
   productId,
   publicKeyName,
-  category
+  category,
+  ticketName
 }: {
   productId: string;
   publicKeyName: string;
   category: KnownTicketGroup;
+  ticketName: string | undefined;
 }) {
   // Devconnect tickets with the "simple" QR code have a separate "check-in"
   // flow and never come here.
@@ -148,6 +152,7 @@ function VerifiedAndKnownTicket({
       <ZuconnectKnownTicketDetails
         productId={productId}
         publicKeyName={publicKeyName}
+        ticketName={ticketName}
       />
     );
   }
@@ -215,7 +220,8 @@ async function verifyById(
       outcome: VerifyOutcome.KnownTicketType,
       productId: result.value.productId,
       publicKeyName: result.value.publicKeyName,
-      group: result.value.group
+      group: result.value.group,
+      ticketName: result.value.ticketName
     };
   }
 

--- a/apps/passport-client/components/shared/cards/ZuconnectTicket.tsx
+++ b/apps/passport-client/components/shared/cards/ZuconnectTicket.tsx
@@ -8,10 +8,12 @@ import {
 
 export function ZuconnectKnownTicketDetails({
   productId,
-  publicKeyName
+  publicKeyName,
+  ticketName
 }: {
   productId: string;
   publicKeyName: string;
+  ticketName: string | undefined;
 }) {
   const type = Object.entries(ZUCONNECT_PRODUCT_ID_MAPPINGS).find(
     ([_name, product]) => product.id === productId
@@ -20,15 +22,26 @@ export function ZuconnectKnownTicketDetails({
     <CardContainerExpanded>
       <CardOutlineExpanded>
         <CardHeader col="var(--accent-lite)">
-          <div>VERIFIED ZUCONNECT '23 TICKET</div>
-          <div>SIGNED BY: {publicKeyName}</div>
-          <ZuzaluRole>TYPE: {type}</ZuzaluRole>
+          <VerifyLine>
+            VERIFIED <strong>ZUCONNECT '23</strong> TICKET
+          </VerifyLine>
+          <VerifyLine>
+            {(ticketName ?? type).split("\n").map((line) => {
+              return <NameLine>{line}</NameLine>;
+            })}
+          </VerifyLine>
+          <VerifyLine>SIGNED BY: {publicKeyName}</VerifyLine>
         </CardHeader>
       </CardOutlineExpanded>
     </CardContainerExpanded>
   );
 }
 
-const ZuzaluRole = styled.div`
-  text-transform: uppercase;
+const VerifyLine = styled.div`
+  text-transform: capitalize;
+  margin: 12px 0px;
+`;
+
+const NameLine = styled.p`
+  margin: 2px 0px;
 `;

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -1182,7 +1182,11 @@ export class IssuanceService {
           verified: true,
           group: KnownTicketGroup.Zuconnect23,
           publicKeyName: ZUPASS_TICKET_PUBLIC_KEY_NAME,
-          productId: zuconnectTicket.product_id
+          productId: zuconnectTicket.product_id,
+          ticketName:
+            zuconnectTicket.product_id === ZUCONNECT_23_DAY_PASS_PRODUCT_ID
+              ? zuconnectTicket.extra_info.join("\n")
+              : zuconnectProductIdToName(zuconnectTicket.product_id)
         }
       };
     } else {
@@ -1202,7 +1206,8 @@ export class IssuanceService {
                 ? ZUZALU_23_VISITOR_PRODUCT_ID
                 : zuzaluTicket.role === ZuzaluUserRole.Organizer
                 ? ZUZALU_23_ORGANIZER_PRODUCT_ID
-                : ZUZALU_23_RESIDENT_PRODUCT_ID
+                : ZUZALU_23_RESIDENT_PRODUCT_ID,
+            ticketName: undefined
           }
         };
       }

--- a/packages/passport-interface/src/RequestTypes.ts
+++ b/packages/passport-interface/src/RequestTypes.ts
@@ -354,6 +354,7 @@ export type VerifyTicketByIdResponseValue =
       publicKeyName: string;
       group: KnownTicketGroup;
       productId: string;
+      ticketName?: string;
     }
   | {
       verified: false;


### PR DESCRIPTION
Closes #1020 

Per request from Zuconnect organizers, this makes the "verify" screen easier to read and highlights relevant information about the dates a day pass is active.

Before:

<img width="457" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/d08f1c3d-e64f-455d-982a-ddb09755ea1f">

After:

<img width="466" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/6af2d87e-1683-40d9-875d-9ebf0740d028">
