### PR TITLE
Rename Zuconnect folder to ZuConnect

### DIFF
--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -351,16 +351,23 @@ export class IssuanceService {
 
               const pcds = await this.issueZuconnectTicketPCDs(pcd);
 
-              // Clear out the folder
+              // Clear out the old folder
               actions.push({
                 type: PCDActionType.DeleteFolder,
                 folder: "Zuconnect",
                 recursive: false
               } as DeleteFolderAction);
 
+              // Clear out the folder
+              actions.push({
+                type: PCDActionType.DeleteFolder,
+                folder: "ZuConnect",
+                recursive: false
+              } as DeleteFolderAction);
+
               actions.push({
                 type: PCDActionType.ReplaceInFolder,
-                folder: "Zuconnect",
+                folder: "ZuConnect",
                 pcds: await Promise.all(
                   pcds.map((pcd) => EdDSATicketPCDPackage.serialize(pcd))
                 )

--- a/apps/passport-server/test/zuconnect.spec.ts
+++ b/apps/passport-server/test/zuconnect.spec.ts
@@ -333,10 +333,10 @@ describe("zuconnect functionality", function () {
 
     expect(response.success).to.be.true;
 
-    expect(response.value?.actions.length).to.eq(2);
-    const populateAction = response.value?.actions[1] as ReplaceInFolderAction;
+    expect(response.value?.actions.length).to.eq(3);
+    const populateAction = response.value?.actions[2] as ReplaceInFolderAction;
     expect(populateAction.type).to.eq(PCDActionType.ReplaceInFolder);
-    expect(populateAction.folder).to.eq("Zuconnect");
+    expect(populateAction.folder).to.eq("ZuConnect");
     expect(populateAction.pcds[0].type).to.eq(EdDSATicketPCDPackage.name);
 
     ticketPCD = await EdDSATicketPCDPackage.deserialize(
@@ -471,10 +471,10 @@ describe("zuconnect functionality", function () {
 
     expect(response.success).to.be.true;
 
-    expect(response.value?.actions.length).to.eq(2);
-    const populateAction = response.value?.actions[1] as ReplaceInFolderAction;
+    expect(response.value?.actions.length).to.eq(3);
+    const populateAction = response.value?.actions[2] as ReplaceInFolderAction;
     expect(populateAction.type).to.eq(PCDActionType.ReplaceInFolder);
-    expect(populateAction.folder).to.eq("Zuconnect");
+    expect(populateAction.folder).to.eq("ZuConnect");
     expect(populateAction.pcds.length).to.eq(2);
     for (const pcd of populateAction.pcds) {
       expect(

--- a/packages/passport-interface/src/ZupassDefaultSubscriptions.ts
+++ b/packages/passport-interface/src/ZupassDefaultSubscriptions.ts
@@ -100,7 +100,11 @@ export const zupassDefaultSubscriptions: Record<
         type: PCDPermissionType.DeleteFolder
       } as DeleteFolderPermission,
       {
-        folder: "Zuconnect",
+        folder: "ZuConnect",
+        type: PCDPermissionType.DeleteFolder
+      } as DeleteFolderPermission,
+      {
+        folder: "ZuConnect",
         type: PCDPermissionType.ReplaceInFolder
       } as ReplaceInFolderPermission
     ]


### PR DESCRIPTION
We need to retain the permission to delete the old folder, as it's not possible to move the PCDs to a new folder while they're still in the old one.