### PR TITLE
better bouncy frog

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -141,11 +141,11 @@ function useParticles(ref: React.RefObject<HTMLDivElement> | null) {
           },
           move: {
             enable: true,
-            speed: { min: 10, max: 20 },
+            speed: { min: 5, max: 20 },
             direction: "top",
-            random: false,
+            random: true,
             straight: false,
-            outMode: "destroy",
+            outMode: "bounce-horizontal",
             gravity: {
               enable: true
             }
@@ -174,11 +174,10 @@ function useParticles(ref: React.RefObject<HTMLDivElement> | null) {
 }
 
 const NewFont = styled.div`
-  font-size: 15px;
-  /* vertical-align: super; */
+  font-size: 14px;
   animation: color-change 1s infinite;
   font-family: monospace;
-  /* align-self: stretch; */
+  margin-left: auto;
 
   @keyframes color-change {
     0% {


### PR DESCRIPTION
https://github.com/proofcarryingdata/zupass/issues/1056

make frogs bounce off the horizontal wall. this makes the mobile experience better

tweak the font a little to make them look better some mobile screen size (iphone SE is a lost cause but other screens at least show on one line)

https://github.com/proofcarryingdata/zupass/assets/4317392/8d30fe91-a3c2-41c7-9829-dceaedcc3f17



