### PR TITLE
Tidy up some package imports

### DIFF
--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -9,13 +9,13 @@ import {
   isSyncedEncryptedStorageV3,
   KnownTicketTypesAndKeys,
   LATEST_PRIVACY_NOTICE,
+  NetworkFeedApi,
   requestCreateNewUser,
   requestLogToServer,
   requestUser,
   SyncedEncryptedStorage,
   User
 } from "@pcd/passport-interface";
-import { NetworkFeedApi } from "@pcd/passport-interface/src/FeedAPI";
 import { PCDCollection, PCDPermission } from "@pcd/pcd-collection";
 import { SerializedPCD } from "@pcd/pcd-types";
 import {

--- a/apps/passport-client/src/localstorage.ts
+++ b/apps/passport-client/src/localstorage.ts
@@ -1,5 +1,8 @@
-import { FeedSubscriptionManager, User } from "@pcd/passport-interface";
-import { NetworkFeedApi } from "@pcd/passport-interface/src/FeedAPI";
+import {
+  FeedSubscriptionManager,
+  NetworkFeedApi,
+  User
+} from "@pcd/passport-interface";
 import { PCDCollection } from "@pcd/pcd-collection";
 import { Identity } from "@semaphore-protocol/identity";
 import { getPackages } from "./pcdPackages";

--- a/apps/passport-client/src/useSyncE2EEStorage.tsx
+++ b/apps/passport-client/src/useSyncE2EEStorage.tsx
@@ -2,15 +2,15 @@ import { getHash, passportEncrypt } from "@pcd/passport-crypto";
 import {
   ChangeBlobKeyResult,
   FeedSubscriptionManager,
+  NetworkFeedApi,
+  SyncedEncryptedStorageV2,
+  SyncedEncryptedStorageV3,
   isSyncedEncryptedStorageV2,
   isSyncedEncryptedStorageV3,
   requestChangeBlobKey,
   requestDownloadAndDecryptStorage,
-  requestUploadEncryptedStorage,
-  SyncedEncryptedStorageV2,
-  SyncedEncryptedStorageV3
+  requestUploadEncryptedStorage
 } from "@pcd/passport-interface";
-import { NetworkFeedApi } from "@pcd/passport-interface/src/FeedAPI";
 import { PCDCollection } from "@pcd/pcd-collection";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { appConfig } from "./appConfig";

--- a/packages/passport-interface/src/index.ts
+++ b/packages/passport-interface/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./CredentialManager";
 export * from "./EncryptedStorage";
+export * from "./FeedAPI";
 export * from "./FeedCredential";
 export * from "./FeedHost";
 export * from "./PassportInterface";


### PR DESCRIPTION
`passport-interface` wasn't exporting `FeedAPI`, and `passport-client` was importing it anyway. This PR cleans that up.

`anon-message-client` still imports from `passport-interface` in a non-standard way, but changing it breaks the build.