### PR TITLE
robust PCDAction and PCDPermission type

### DIFF
--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -325,7 +325,7 @@ function SinglePermission({ permission }: { permission: PCDPermission }) {
   } else {
     return (
       <PermissionListItem>
-        Unknown permission {permission.type}
+        Unknown permission {permission["type"]}
       </PermissionListItem>
     );
   }

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -42,13 +42,9 @@ import {
   zupassDefaultSubscriptions
 } from "@pcd/passport-interface";
 import {
-  AppendToFolderAction,
-  AppendToFolderPermission,
-  DeleteFolderAction,
   PCDAction,
   PCDActionType,
   PCDPermissionType,
-  ReplaceInFolderAction,
   joinPath
 } from "@pcd/pcd-collection";
 import { ArgumentTypeName, SerializedPCD } from "@pcd/pcd-types";
@@ -140,7 +136,7 @@ export class IssuanceService {
           handleRequest: async (
             req: PollFeedRequest
           ): Promise<PollFeedResponseValue> => {
-            const actions = [];
+            const actions: PCDAction[] = [];
 
             try {
               if (req.pcd === undefined) {
@@ -232,7 +228,7 @@ export class IssuanceService {
                     pcds: await this.issueFrogPCDs(),
                     folder: "Frogs",
                     type: PCDActionType.AppendToFolder
-                  } as AppendToFolderAction
+                  }
                 ]
               };
             } catch (e) {
@@ -254,7 +250,7 @@ export class IssuanceService {
               {
                 folder: "Frogs",
                 type: PCDPermissionType.AppendToFolder
-              } as AppendToFolderPermission
+              }
             ]
           }
         },
@@ -279,7 +275,7 @@ export class IssuanceService {
                 type: PCDActionType.DeleteFolder,
                 folder: "Email",
                 recursive: false
-              } as DeleteFolderAction);
+              });
 
               actions.push({
                 type: PCDActionType.ReplaceInFolder,
@@ -287,7 +283,7 @@ export class IssuanceService {
                 pcds: await Promise.all(
                   pcds.map((pcd) => EmailPCDPackage.serialize(pcd))
                 )
-              } as ReplaceInFolderAction);
+              });
             } catch (e) {
               logger(`Error encountered while serving feed:`, e);
               this.rollbarService?.reportError(e);
@@ -317,7 +313,7 @@ export class IssuanceService {
                 type: PCDActionType.DeleteFolder,
                 folder: "Zuzalu '23",
                 recursive: false
-              } as DeleteFolderAction);
+              });
 
               actions.push({
                 type: PCDActionType.ReplaceInFolder,
@@ -325,7 +321,7 @@ export class IssuanceService {
                 pcds: await Promise.all(
                   pcds.map((pcd) => EdDSATicketPCDPackage.serialize(pcd))
                 )
-              } as ReplaceInFolderAction);
+              });
             } catch (e) {
               logger(`Error encountered while serving feed:`, e);
               this.rollbarService?.reportError(e);
@@ -356,14 +352,14 @@ export class IssuanceService {
                 type: PCDActionType.DeleteFolder,
                 folder: "Zuconnect",
                 recursive: false
-              } as DeleteFolderAction);
+              });
 
               // Clear out the folder
               actions.push({
                 type: PCDActionType.DeleteFolder,
                 folder: "ZuConnect",
                 recursive: false
-              } as DeleteFolderAction);
+              });
 
               actions.push({
                 type: PCDActionType.ReplaceInFolder,
@@ -371,7 +367,7 @@ export class IssuanceService {
                 pcds: await Promise.all(
                   pcds.map((pcd) => EdDSATicketPCDPackage.serialize(pcd))
                 )
-              } as ReplaceInFolderAction);
+              });
             } catch (e) {
               logger(`Error encountered while serving feed:`, e);
               this.rollbarService?.reportError(e);

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -26,11 +26,7 @@ import {
   requestVerifyTicket,
   requestVerifyTicketById
 } from "@pcd/passport-interface";
-import {
-  PCDActionType,
-  ReplaceInFolderAction,
-  isReplaceInFolderAction
-} from "@pcd/pcd-collection";
+import { PCDActionType, isReplaceInFolderAction } from "@pcd/pcd-collection";
 import { ArgumentTypeName, SerializedPCD } from "@pcd/pcd-types";
 import { sleep } from "@pcd/util";
 import { Identity } from "@semaphore-protocol/identity";
@@ -122,6 +118,7 @@ import {
 } from "./user/testUserSync";
 import { overrideEnvironment, testingEnv } from "./util/env";
 import { startTestingApp } from "./util/startTestingApplication";
+import { expectToExist } from "./util/util";
 
 // @todo: merge this with zupass.spec.ts, and delete this file, after completely deprecating pcdpass
 describe("devconnect functionality", function () {
@@ -1770,8 +1767,8 @@ describe("devconnect functionality", function () {
       expect(response.value?.actions?.length).to.eq(3);
 
       // Now we have an action to populate the folder
-      const populateAction = response.value
-        ?.actions?.[2] as ReplaceInFolderAction;
+      const populateAction = response.value?.actions?.[2];
+      expectToExist(populateAction, isReplaceInFolderAction);
 
       expect(populateAction.type).to.eq(PCDActionType.ReplaceInFolder);
       expect(populateAction.folder).to.eq("Devconnect/Event A");
@@ -1812,8 +1809,10 @@ describe("devconnect functionality", function () {
     MockDate.reset();
     const response1 = expressResponse1.value as PollFeedResponseValue;
     const response2 = expressResponse2.value as PollFeedResponseValue;
-    const action1 = response1.actions[2] as ReplaceInFolderAction;
-    const action2 = response2.actions[2] as ReplaceInFolderAction;
+    const action1 = response1.actions[2];
+    expectToExist(action1, isReplaceInFolderAction);
+    const action2 = response2.actions[2];
+    expectToExist(action2, isReplaceInFolderAction);
 
     const pcds1 = await Promise.all(
       action1.pcds.map((pcd) => EdDSATicketPCDPackage.deserialize(pcd.pcd))
@@ -1866,7 +1865,8 @@ describe("devconnect functionality", function () {
       const responseBody = response.value as PollFeedResponseValue;
       expect(responseBody.actions.length).to.eq(3);
 
-      const devconnectAction = responseBody.actions[2] as ReplaceInFolderAction;
+      const devconnectAction = responseBody.actions[2];
+      expectToExist(devconnectAction, isReplaceInFolderAction);
       expect(isReplaceInFolderAction(devconnectAction)).to.be.true;
       expect(devconnectAction.folder).to.eq("Devconnect/New name");
 
@@ -1915,7 +1915,8 @@ describe("devconnect functionality", function () {
       MockDate.reset();
       const responseBody = response.value as PollFeedResponseValue;
       expect(responseBody.actions.length).to.eq(3);
-      const devconnectAction = responseBody.actions[2] as ReplaceInFolderAction;
+      const devconnectAction = responseBody.actions[2];
+      expectToExist(devconnectAction, isReplaceInFolderAction);
       expect(devconnectAction.folder).to.eq("Devconnect/Event A");
 
       expect(Array.isArray(devconnectAction.pcds)).to.eq(true);
@@ -1966,7 +1967,8 @@ describe("devconnect functionality", function () {
       MockDate.reset();
       const issueResponseBody = issueResponse.value as PollFeedResponseValue;
 
-      const action = issueResponseBody.actions[2] as ReplaceInFolderAction;
+      const action = issueResponseBody.actions[2];
+      expectToExist(action, isReplaceInFolderAction);
       const serializedTicket = action.pcds[2] as SerializedPCD<EdDSATicketPCD>;
       ticketPCD = await EdDSATicketPCDPackage.deserialize(serializedTicket.pcd);
 

--- a/apps/passport-server/test/email-feed.spec.ts
+++ b/apps/passport-server/test/email-feed.spec.ts
@@ -4,7 +4,7 @@ import {
   createFeedCredentialPayload,
   pollFeed
 } from "@pcd/passport-interface";
-import { PCDActionType, ReplaceInFolderAction } from "@pcd/pcd-collection";
+import { PCDActionType, isReplaceInFolderAction } from "@pcd/pcd-collection";
 import { Identity } from "@semaphore-protocol/identity";
 import { expect } from "chai";
 import "mocha";
@@ -15,7 +15,7 @@ import { Zupass } from "../src/types";
 import { testLogin } from "./user/testLoginPCDPass";
 import { overrideEnvironment, testingEnv } from "./util/env";
 import { startTestingApp } from "./util/startTestingApplication";
-import { randomEmail } from "./util/util";
+import { expectToExist, randomEmail } from "./util/util";
 
 describe("attested email feed functionality", function () {
   this.timeout(30_000);
@@ -72,8 +72,8 @@ describe("attested email feed functionality", function () {
       expect(pollFeedResult.value?.actions.length).to.eq(2);
 
       // Zeroth action clears the folder, so this one contains the email
-      const action = pollFeedResult?.value
-        ?.actions?.[1] as ReplaceInFolderAction;
+      const action = pollFeedResult?.value?.actions?.[1];
+      expectToExist(action, isReplaceInFolderAction);
       expect(action.type).to.eq(PCDActionType.ReplaceInFolder);
       expect(action.pcds.length).to.eq(1);
       expect(action.pcds[0].type).to.eq(EmailPCDTypeName);

--- a/apps/passport-server/test/util/util.ts
+++ b/apps/passport-server/test/util/util.ts
@@ -1,5 +1,32 @@
+import { expect } from "chai";
 import { v4 as uuid } from "uuid";
 
 export function randomEmail(): string {
   return uuid() + "@test.com";
+}
+
+/**
+ * Use in place of `expect(value).to.exist`
+ *
+ * Work-around for Chai assertions not being recognized by TypeScript's control flow analysis.
+ * @param {any} value
+ */
+export function expectToExist<T, U extends T = T>(
+  value: T | undefined,
+  typeNarrower: (value: T) => value is U
+): asserts value is NonNullable<U>;
+export function expectToExist<T>(
+  value: T | undefined
+): asserts value is NonNullable<T>;
+export function expectToExist<T, U extends T = T>(
+  value: T | undefined,
+  typeNarrower?: (value: T) => value is U
+): asserts value is NonNullable<U> {
+  expect(value).to.exist;
+  if (value === null || value === undefined) {
+    throw new Error("Expected value to exist");
+  }
+  if (typeNarrower && !typeNarrower(value)) {
+    throw new Error("Expected value to be narrowable to U");
+  }
 }

--- a/apps/passport-server/test/zuconnect.spec.ts
+++ b/apps/passport-server/test/zuconnect.spec.ts
@@ -9,7 +9,7 @@ import {
   requestVerifyTicket,
   requestVerifyTicketById
 } from "@pcd/passport-interface";
-import { PCDActionType, ReplaceInFolderAction } from "@pcd/pcd-collection";
+import { PCDActionType, isReplaceInFolderAction } from "@pcd/pcd-collection";
 import { ArgumentTypeName } from "@pcd/pcd-types";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import { ZKEdDSAEventTicketPCDPackage } from "@pcd/zk-eddsa-event-ticket-pcd";
@@ -49,6 +49,7 @@ import {
 import { testLogin } from "./user/testLoginPCDPass";
 import { overrideEnvironment, testingEnv } from "./util/env";
 import { startTestingApp } from "./util/startTestingApplication";
+import { expectToExist } from "./util/util";
 
 describe("zuconnect functionality", function () {
   this.timeout(30_000);
@@ -334,7 +335,8 @@ describe("zuconnect functionality", function () {
     expect(response.success).to.be.true;
 
     expect(response.value?.actions.length).to.eq(3);
-    const populateAction = response.value?.actions[2] as ReplaceInFolderAction;
+    const populateAction = response.value?.actions[2];
+    expectToExist(populateAction, isReplaceInFolderAction);
     expect(populateAction.type).to.eq(PCDActionType.ReplaceInFolder);
     expect(populateAction.folder).to.eq("ZuConnect");
     expect(populateAction.pcds[0].type).to.eq(EdDSATicketPCDPackage.name);
@@ -472,7 +474,8 @@ describe("zuconnect functionality", function () {
     expect(response.success).to.be.true;
 
     expect(response.value?.actions.length).to.eq(3);
-    const populateAction = response.value?.actions[2] as ReplaceInFolderAction;
+    const populateAction = response.value?.actions[2];
+    expectToExist(populateAction, isReplaceInFolderAction);
     expect(populateAction.type).to.eq(PCDActionType.ReplaceInFolder);
     expect(populateAction.folder).to.eq("ZuConnect");
     expect(populateAction.pcds.length).to.eq(2);

--- a/apps/passport-server/test/zuzalu-ticket-feed.spec.ts
+++ b/apps/passport-server/test/zuzalu-ticket-feed.spec.ts
@@ -5,7 +5,7 @@ import {
   ZupassFeedIds,
   ZUZALU_23_EVENT_ID
 } from "@pcd/passport-interface";
-import { PCDActionType, ReplaceInFolderAction } from "@pcd/pcd-collection";
+import { isReplaceInFolderAction, PCDActionType } from "@pcd/pcd-collection";
 import { Identity } from "@semaphore-protocol/identity";
 import { expect } from "chai";
 import "mocha";
@@ -23,6 +23,7 @@ import { ZuzaluPretixDataMocker } from "./pretix/zuzaluPretixDataMocker";
 import { testLogin } from "./user/testLoginPCDPass";
 import { overrideEnvironment, testingEnv } from "./util/env";
 import { startTestingApp } from "./util/startTestingApplication";
+import { expectToExist } from "./util/util";
 
 describe("zuzalu pcdpass functionality", function () {
   this.timeout(30_000);
@@ -101,7 +102,8 @@ describe("zuzalu pcdpass functionality", function () {
       }
 
       expect(response.value.actions.length).to.eq(2);
-      const action = response.value.actions[1] as ReplaceInFolderAction;
+      const action = response.value.actions[1];
+      expectToExist(action, isReplaceInFolderAction);
 
       expect(action.type).to.eq(PCDActionType.ReplaceInFolder);
       expect(action.folder).to.eq("Zuzalu '23");

--- a/packages/passport-interface/src/ZupassDefaultSubscriptions.ts
+++ b/packages/passport-interface/src/ZupassDefaultSubscriptions.ts
@@ -1,9 +1,4 @@
-import {
-  AppendToFolderPermission,
-  DeleteFolderPermission,
-  PCDPermissionType,
-  ReplaceInFolderPermission
-} from "@pcd/pcd-collection";
+import { PCDPermissionType } from "@pcd/pcd-collection";
 import { Feed, ZupassFeedIds } from "./SubscriptionManager";
 
 export const zupassDefaultSubscriptions: Record<
@@ -25,11 +20,11 @@ export const zupassDefaultSubscriptions: Record<
       {
         folder: "Zuzalu '23",
         type: PCDPermissionType.DeleteFolder
-      } as DeleteFolderPermission,
+      },
       {
         folder: "Zuzalu '23",
         type: PCDPermissionType.ReplaceInFolder
-      } as ReplaceInFolderPermission
+      }
     ]
   },
   [ZupassFeedIds.Devconnect]: {
@@ -44,27 +39,27 @@ export const zupassDefaultSubscriptions: Record<
       {
         folder: "Devconnect",
         type: PCDPermissionType.AppendToFolder
-      } as AppendToFolderPermission,
+      },
       {
         folder: "Devconnect",
         type: PCDPermissionType.ReplaceInFolder
-      } as ReplaceInFolderPermission,
+      },
       {
         folder: "Devconnect",
         type: PCDPermissionType.DeleteFolder
-      } as DeleteFolderPermission,
+      },
       {
         folder: "SBC SRW",
         type: PCDPermissionType.AppendToFolder
-      } as AppendToFolderPermission,
+      },
       {
         folder: "SBC SRW",
         type: PCDPermissionType.ReplaceInFolder
-      } as ReplaceInFolderPermission,
+      },
       {
         folder: "SBC SRW",
         type: PCDPermissionType.DeleteFolder
-      } as DeleteFolderPermission
+      }
     ]
   },
   [ZupassFeedIds.Email]: {
@@ -79,11 +74,11 @@ export const zupassDefaultSubscriptions: Record<
       {
         folder: "Email",
         type: PCDPermissionType.DeleteFolder
-      } as DeleteFolderPermission,
+      },
       {
         folder: "Email",
         type: PCDPermissionType.ReplaceInFolder
-      } as ReplaceInFolderPermission
+      }
     ]
   },
   [ZupassFeedIds.Zuconnect_23]: {
@@ -98,15 +93,15 @@ export const zupassDefaultSubscriptions: Record<
       {
         folder: "Zuconnect",
         type: PCDPermissionType.DeleteFolder
-      } as DeleteFolderPermission,
+      },
       {
         folder: "ZuConnect",
         type: PCDPermissionType.DeleteFolder
-      } as DeleteFolderPermission,
+      },
       {
         folder: "ZuConnect",
         type: PCDPermissionType.ReplaceInFolder
-      } as ReplaceInFolderPermission
+      }
     ]
   }
 };

--- a/packages/passport-interface/test/MockFeedApi.ts
+++ b/packages/passport-interface/test/MockFeedApi.ts
@@ -1,8 +1,4 @@
-import {
-  PCDActionType,
-  PCDPermission,
-  PCDPermissionType
-} from "@pcd/pcd-collection";
+import { PCDActionType, PCDPermissionType } from "@pcd/pcd-collection";
 import { SerializedPCD } from "@pcd/pcd-types";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import { getErrorMessage } from "@pcd/util";
@@ -41,7 +37,7 @@ export class MockFeedApi implements IFeedApi {
                   {
                     folder: "TEST",
                     type: PCDPermissionType.ReplaceInFolder
-                  } as PCDPermission
+                  }
                 ],
                 inputPCDType: undefined,
                 partialArgs: undefined,
@@ -85,7 +81,7 @@ export class MockFeedApi implements IFeedApi {
                   {
                     folder: "TEST",
                     type: PCDPermissionType.ReplaceInFolder
-                  } as PCDPermission
+                  }
                 ],
                 inputPCDType: undefined,
                 partialArgs: undefined,

--- a/packages/pcd-collection/src/actions.ts
+++ b/packages/pcd-collection/src/actions.ts
@@ -1,17 +1,18 @@
 import { SerializedPCD } from "@pcd/pcd-types";
 
-export enum PCDActionType {
-  ReplaceInFolder = "ReplaceInFolder_action",
-  AppendToFolder = "AppendToFolder_action",
-  DeleteFolder = "DeleteFolder_action"
-}
+export const PCDActionType = {
+  ReplaceInFolder: "ReplaceInFolder_action",
+  AppendToFolder: "AppendToFolder_action",
+  DeleteFolder: "DeleteFolder_action"
+} as const;
 
-export interface PCDAction {
-  type: PCDActionType;
-}
+export type PCDAction =
+  | AppendToFolderAction
+  | ReplaceInFolderAction
+  | DeleteFolderAction;
 
 export interface ReplaceInFolderAction {
-  type: PCDActionType.ReplaceInFolder;
+  type: typeof PCDActionType.ReplaceInFolder;
   folder: string;
   pcds: SerializedPCD[];
 }
@@ -23,7 +24,7 @@ export function isReplaceInFolderAction(
 }
 
 export interface AppendToFolderAction {
-  type: PCDActionType.AppendToFolder;
+  type: typeof PCDActionType.AppendToFolder;
   folder: string;
   pcds: SerializedPCD[];
 }
@@ -35,7 +36,7 @@ export function isAppendToFolderAction(
 }
 
 export interface DeleteFolderAction {
-  type: PCDActionType.DeleteFolder;
+  type: typeof PCDActionType.DeleteFolder;
   folder: string;
   recursive: boolean;
 }

--- a/packages/pcd-collection/src/permissions.ts
+++ b/packages/pcd-collection/src/permissions.ts
@@ -1,33 +1,31 @@
 // This enum should never overlap with PCDActionType
 // See test "hould not allow action types to be assigned to permission
 // types or vice-versa" in permissions.spec.ts
-export enum PCDPermissionType {
-  ReplaceInFolder = "ReplaceInFolder_permission",
-  AppendToFolder = "AppendToFolder_permission",
-  DeleteFolder = "DeleteFolder_permission"
-}
+export const PCDPermissionType = {
+  ReplaceInFolder: "ReplaceInFolder_permission",
+  AppendToFolder: "AppendToFolder_permission",
+  DeleteFolder: "DeleteFolder_permission"
+} as const;
 
-export interface PCDPermission {
-  type: PCDPermissionType;
-}
+export type PCDPermission = PCDFolderPermission;
 
-export interface PCDFolderPermission extends PCDPermission {
-  type: PCDPermissionType.AppendToFolder | PCDPermissionType.ReplaceInFolder;
+export type PCDFolderPermission =
+  | AppendToFolderPermission
+  | ReplaceInFolderPermission
+  | DeleteFolderPermission;
+
+export interface AppendToFolderPermission {
+  type: typeof PCDPermissionType.AppendToFolder;
   folder: string;
 }
 
-export interface AppendToFolderPermission extends PCDPermission {
-  type: PCDPermissionType.AppendToFolder;
+export interface ReplaceInFolderPermission {
+  type: typeof PCDPermissionType.ReplaceInFolder;
   folder: string;
 }
 
-export interface ReplaceInFolderPermission extends PCDPermission {
-  type: PCDPermissionType.ReplaceInFolder;
-  folder: string;
-}
-
-export interface DeleteFolderPermission extends PCDPermission {
-  type: PCDPermissionType.DeleteFolder;
+export interface DeleteFolderPermission {
+  type: typeof PCDPermissionType.DeleteFolder;
   folder: string;
 }
 


### PR DESCRIPTION
fixes https://github.com/proofcarryingdata/zupass/issues/1113

* Use [Discriminated Union](https://basarat.gitbook.io/typescript/type-system/discriminated-unions) to better type PCDAction and PCDPermission. This allows TS to better infer and more robustly typecheck these types.
* Refactored enum to const string because TS sometimes infer enum value to the parent enum type and is not specific enough to discriminate among the sub-types.
* Added `expectToExist` helper that allows us assert and typecheck in tests.