### PR TITLE
Kudosbot improvements

### DIFF
--- a/apps/passport-server/src/routing/params.ts
+++ b/apps/passport-server/src/routing/params.ts
@@ -61,6 +61,31 @@ export function checkUrlParam(req: Request, paramName: string): string {
 }
 
 /**
+ * Extracts an optional string value from the url params of an Express
+ * {@link Request}.  If the value is missing, return undefined.  If the value is
+ * not a string, throws a {@link PCDHTTPError}.
+ */
+export function checkOptionalUrlParam(
+  req: Request,
+  paramName: string
+): string | undefined {
+  const value = req.params[paramName];
+
+  if (typeof value === "undefined") {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw new PCDHTTPError(
+      400,
+      `missing required url path parameter '${paramName}' - was ${value}`
+    );
+  }
+
+  return decodeURIComponent(value);
+}
+
+/**
  * Extracts a javascript value from the request body of a {@link Request}.
  * If the value is `null` or `undefined`, throws an error.
  *

--- a/apps/passport-server/src/routing/routes/telegramRoutes.ts
+++ b/apps/passport-server/src/routing/routes/telegramRoutes.ts
@@ -31,12 +31,9 @@ export function initTelegramRoutes(
     "/telegram/verify/:id/:username?",
     async (req: Request, res: Response) => {
       try {
-        const { proof } = req.query;
+        const proof = checkQueryParam(req, "proof");
         const telegram_user_id = checkUrlParam(req, "id");
         let telegram_username = checkOptionalUrlParam(req, "username");
-        if (!proof || typeof proof !== "string") {
-          throw new Error("proof field needs to be a string and be non-empty");
-        }
 
         if (!telegram_user_id || !/^-?\d+$/.test(telegram_user_id)) {
           throw new Error(

--- a/apps/passport-server/src/services/kudosbotService.ts
+++ b/apps/passport-server/src/services/kudosbotService.ts
@@ -74,14 +74,14 @@ export class KudosbotService {
     const kudosbotMenu = new Menu<BotContext>("kudos");
     kudosbotMenu.dynamic((ctx, menu) => {
       if (ctx.session.kudosData) {
-        const kudosGiver = ctx.session.kudosData?.giver;
-        const kudosReceiver = ctx.session.kudosData?.receiver;
+        const { senderSemaphoreId, recipientSemaphoreId, recipientUsername } =
+          ctx.session.kudosData;
         const proofUrl = getProofUrl(
           PASSPORT_CLIENT_URL,
           KUDOSBOT_UPLOAD_URL,
-          `KUDOS:${kudosGiver}:${kudosReceiver}`
+          `KUDOS:${senderSemaphoreId}:${recipientSemaphoreId}`
         );
-        menu.webApp("Send kudos", proofUrl);
+        menu.webApp(`Send kudos to @${recipientUsername}`, proofUrl);
       } else {
         ctx.reply("Kudosbot encountered an error.");
       }
@@ -134,8 +134,9 @@ export class KudosbotService {
             );
           }
           ctx.session.kudosData = {
-            giver: kudosGiverSemaphoreId,
-            receiver: kudosReceiverSemaphoreId
+            senderSemaphoreId: kudosGiverSemaphoreId,
+            recipientSemaphoreId: kudosReceiverSemaphoreId,
+            recipientUsername: kudosReceiver
           };
           await ctx.reply("Send a kudos by pressing on the button.", {
             reply_markup: kudosbotMenu

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -931,7 +931,8 @@ export class TelegramService {
    */
   public async handleVerification(
     serializedZKEdDSATicket: string,
-    telegramUserId: number
+    telegramUserId: number,
+    telegramUsername?: string
   ): Promise<void> {
     return traced("telegram", "handleVerification", async (span) => {
       span?.setAttribute("userId", telegramUserId.toString());
@@ -989,7 +990,10 @@ export class TelegramService {
 
       span?.setAttribute("chatTitle", chat.title);
 
-      logger(`[TELEGRAM] Verified PCD for ${telegramUserId}, chat ${chat}`);
+      logger(
+        `[TELEGRAM] Verified PCD for ${telegramUserId}, chat ${chat}` +
+          (telegramUsername && `, username ${telegramUsername}`)
+      );
 
       // We've verified that the chat exists, now add the user to our list.
       // This will be important later when the user requests to join.
@@ -997,7 +1001,8 @@ export class TelegramService {
         this.context.dbPool,
         telegramUserId,
         parseInt(telegramChatId),
-        attendeeSemaphoreId
+        attendeeSemaphoreId,
+        telegramUsername
       );
 
       // Send invite link

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -63,7 +63,11 @@ export interface SessionData {
   anonBotURL: string;
   lastMessageId?: number;
   selectedChat?: TopicChat;
-  kudosData?: { giver: string; receiver: string };
+  kudosData?: {
+    senderSemaphoreId: string;
+    recipientSemaphoreId: string;
+    recipientUsername: string;
+  };
   topicToForwardTo?: ChatIDWithChat<TelegramTopicWithFwdInfo>;
 }
 

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -352,7 +352,8 @@ const editOrSendMessage = async (
 
 const generateTicketProofUrl = async (
   telegramUserId: string,
-  validEventIds: string[]
+  validEventIds: string[],
+  telegramUsername?: string
 ): Promise<string> => {
   return traced("telegram", "generateTicketProofUrl", async (span) => {
     span?.setAttribute("userId", telegramUserId);
@@ -420,7 +421,12 @@ const generateTicketProofUrl = async (
       // TG bot doesn't like localhost URLs
       passportOrigin = "http://127.0.0.1:3000/";
     }
-    const returnUrl = `${process.env.PASSPORT_SERVER_URL}/telegram/verify/${telegramUserId}`;
+
+    // pass telegram username as path param if nonempty
+    const returnUrl =
+      telegramUsername && telegramUsername.length > 0
+        ? `${process.env.PASSPORT_SERVER_URL}/telegram/verify/${telegramUserId}/${telegramUsername}`
+        : `${process.env.PASSPORT_SERVER_URL}/telegram/verify/${telegramUserId}`;
     span?.setAttribute("returnUrl", returnUrl);
 
     const proofUrl = constructZupassPcdGetRequestUrl<
@@ -566,6 +572,8 @@ export const chatsToJoin = async (
       return;
     }
 
+    const telegramUsername = ctx.from?.username;
+
     for (const chat of chatsWithMembership) {
       if (chat.isChatMember) {
         const invite = await ctx.api.createChatInviteLink(chat.telegramChatID, {
@@ -576,7 +584,8 @@ export const chatsToJoin = async (
       } else {
         const proofUrl = await generateTicketProofUrl(
           userId.toString(),
-          chat.ticketEventIds
+          chat.ticketEventIds,
+          telegramUsername
         );
         range.webApp(`${chat.chat?.title}`, proofUrl).row();
       }


### PR DESCRIPTION
completes most of https://github.com/proofcarryingdata/zupass/issues/1115:
- Add telegram username on join (if the telegram account has a username, otherwise null)
- Changed kudosbot menu button to "Send kudos to @username"

tested the verify flow using both a telegram account with a username and a telegram account without a username