### PR TITLE
Update Sync Existing copy

### DIFF
--- a/apps/passport-client/components/screens/LoginScreens/SyncExistingScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/SyncExistingScreen.tsx
@@ -76,9 +76,12 @@ export function SyncExistingScreen() {
         <H2>LOGIN WITH SYNC KEY</H2>
         <Spacer h={32} />
         <TextCenter>
-          If you've already registered, you can sync with your other device here
-          using your Sync Key. You can find your Sync Key on your existing
-          device by clicking on the settings icon.
+          If you've already registered and you've saved your Sync Key, you can
+          sync with your other device here using your Sync Key. If you haven't
+          saved your Sync Key, you may add a password by clicking on the
+          settings icon on another logged-in device, and then refresh to log in
+          with your password. If you've lost access to your account, you can
+          reset your account from the homepage of this website.
         </TextCenter>
         <Spacer h={32} />
         <CenterColumn>

--- a/apps/passport-client/components/screens/LoginScreens/SyncExistingScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/SyncExistingScreen.tsx
@@ -79,9 +79,9 @@ export function SyncExistingScreen() {
           If you've already registered and you've saved your Sync Key, you can
           sync with your other device here using your Sync Key. If you haven't
           saved your Sync Key, you may add a password by clicking on the
-          settings icon on another logged-in device, and then refresh to log in
-          with your password. If you've lost access to your account, you can
-          reset your account from the homepage of this website.
+          settings icon on another logged-in device, and then refreshing here to
+          log in with your password. If you've lost access to your account, you
+          can reset your account from the homepage of this website.
         </TextCenter>
         <Spacer h={32} />
         <CenterColumn>


### PR DESCRIPTION
Now we no longer allow Zupasses created during Zuzalu to copy their Sync Key, so we should prompt users to add a password if they don't have their Sync Key saved.