### PR TITLE
Ignore admission and personalization check if item is an add-on

### DIFF
--- a/apps/passport-server/src/services/devconnect/organizerSync.ts
+++ b/apps/passport-server/src/services/devconnect/organizerSync.ts
@@ -3,6 +3,7 @@ import { UNREDACT_TICKETS_TERMS_VERSION } from "@pcd/passport-interface";
 import _ from "lodash";
 import { Pool } from "postgres-pool";
 import {
+  DevconnectPretixCategory,
   DevconnectPretixCheckinList,
   DevconnectPretixEvent,
   DevconnectPretixEventSettings,
@@ -63,6 +64,7 @@ export const PRETIX_CHECKER = "Pretix";
 interface EventData {
   settings: DevconnectPretixEventSettings;
   eventInfo: DevconnectPretixEvent;
+  categories: DevconnectPretixCategory[];
   items: DevconnectPretixItem[];
   tickets: DevconnectPretixOrder[];
   checkinLists: DevconnectPretixCheckinList[];
@@ -242,19 +244,26 @@ export class OrganizerSync {
 
   /**
    * Validate that an item/products settings match our expectations.
-   * These settings correspond to the product being of type "Admission",
-   * "Personalization" being set to "Personalized ticket", and
-   * "Generate tickets" in the "Tickets & Badges" section being set to
+   * These settings correspond to the product either being an add-on OR of
+   * type "Admission", "Personalization" being set to "Personalized ticket",
+   * and "Generate tickets" in the "Tickets & Badges" section being set to
    * "Choose automatically depending on event settings" in the Pretix UI.
    */
-  private validateEventItem(item: DevconnectPretixItem): string[] {
+  private validateEventItem(
+    item: DevconnectPretixItem,
+    addonCategoryIdSet: Set<number>
+  ): string[] {
     const errors = [];
-    if (item.admission !== true) {
-      errors.push(`Product type is not "Admission"`);
-    }
 
-    if (item.personalized !== true) {
-      errors.push(`"Personalization" is not set to "Personalized ticket"`);
+    // If item is not an add-on, check that it is an Admission product and
+    if (!addonCategoryIdSet.has(item.category)) {
+      if (item.admission !== true) {
+        errors.push(`Product type is not "Admission"`);
+      }
+
+      if (item.personalized !== true) {
+        errors.push(`"Personalization" is not set to "Personalized ticket"`);
+      }
     }
 
     if (
@@ -279,9 +288,12 @@ export class OrganizerSync {
     eventData: EventData,
     eventConfig: DevconnectPretixEventConfig
   ): string[] {
-    const { settings, items } = eventData;
+    const { settings, items, categories } = eventData;
     const activeItemIdSet = new Set(eventConfig.activeItemIDs);
     const superuserItemIdSet = new Set(eventConfig.superuserItemIds);
+    const addonCategoryIdSet = new Set(
+      categories.filter((a) => a.is_addon).map((a) => a.id)
+    );
 
     // We want to make sure that we log all errors, so we collect everything
     // and only throw an exception once we have found all of them.
@@ -301,7 +313,7 @@ export class OrganizerSync {
       // Ignore items which are not in the event's "activeItemIDs" set
       if (activeItemIdSet.has(item.id.toString())) {
         fetchedItemsIdSet.add(item.id.toString());
-        const itemErrors = this.validateEventItem(item);
+        const itemErrors = this.validateEventItem(item, addonCategoryIdSet);
         if (itemErrors.length > 0) {
           errors.push(
             `Product "${item.name.en}" (${item.id}) in event "${eventData.eventInfo.name.en}" is invalid:\n` +
@@ -403,6 +415,12 @@ export class OrganizerSync {
         eventID
       );
 
+      const categories = await this.pretixAPI.fetchCategories(
+        orgURL,
+        token,
+        eventID
+      );
+
       const items = await this.pretixAPI.fetchItems(orgURL, token, eventID);
 
       const eventInfo = await this.pretixAPI.fetchEvent(orgURL, token, eventID);
@@ -417,6 +435,7 @@ export class OrganizerSync {
 
       return {
         settings,
+        categories,
         items,
         eventInfo,
         tickets,
@@ -1023,7 +1042,7 @@ export class OrganizerSync {
 
           tickets.push({
             email,
-            full_name: attendee_name,
+            full_name: attendee_name || order.name || "", // Fallback since we have a not-null constraint
             devconnect_pretix_items_info_id: existingItem.id,
             pretix_events_config_id: eventConfigID,
             is_deleted: false,

--- a/apps/passport-server/src/services/devconnect/organizerSync.ts
+++ b/apps/passport-server/src/services/devconnect/organizerSync.ts
@@ -243,10 +243,10 @@ export class OrganizerSync {
   }
 
   /**
-   * Validate that an item/products settings match our expectations.
-   * These settings correspond to the product either being an add-on OR of
-   * type "Admission", "Personalization" being set to "Personalized ticket",
-   * and "Generate tickets" in the "Tickets & Badges" section being set to
+   * Validate that an item / product's settings match our expectations.
+   * These settings correspond to the product (1) either being an add-on item OR of
+   * type "Admission" with "Personalization" being set to "Personalized ticket"
+   * and (2) "Generate tickets" in the "Tickets & Badges" section being set to
    * "Choose automatically depending on event settings" in the Pretix UI.
    */
   private validateEventItem(
@@ -256,6 +256,7 @@ export class OrganizerSync {
     const errors = [];
 
     // If item is not an add-on, check that it is an Admission product and
+    // that "Personalization" is set to "Personalized Ticket"
     if (!addonCategoryIdSet.has(item.category)) {
       if (item.admission !== true) {
         errors.push(`Product type is not "Admission"`);

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -245,14 +245,14 @@ describe("devconnect functionality", function () {
             {
               id: eventAConfigId,
               eventID: "event-a",
-              superuserItemIds: ["10002"],
-              activeItemIDs: ["10001", "10002"]
+              superuserItemIds: ["10003"],
+              activeItemIDs: ["10001", "10003"]
             },
             {
               id: eventBConfigId,
               eventID: "event-b",
-              activeItemIDs: ["10003"],
-              superuserItemIds: ["10003"]
+              activeItemIDs: ["10005"],
+              superuserItemIds: ["10005"]
             },
             {
               id: eventCConfigId,

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -185,7 +185,10 @@ describe("devconnect functionality", function () {
     eventBConfigId = await insertPretixEventConfig(
       db,
       organizerConfigId,
-      [mocker.get().organizer1.eventBItem3.id + ""],
+      [
+        mocker.get().organizer1.eventBItem3.id + "",
+        mocker.get().organizer1.eventBItem4.id + ""
+      ],
       [mocker.get().organizer1.eventBItem3.id + ""],
       mocker.get().organizer1.eventB.slug
     );
@@ -245,14 +248,14 @@ describe("devconnect functionality", function () {
             {
               id: eventAConfigId,
               eventID: "event-a",
-              superuserItemIds: ["10003"],
-              activeItemIDs: ["10001", "10003"]
+              superuserItemIds: ["10002"],
+              activeItemIDs: ["10001", "10002"]
             },
             {
               id: eventBConfigId,
               eventID: "event-b",
-              activeItemIDs: ["10005"],
-              superuserItemIds: ["10005"]
+              activeItemIDs: ["10003", "10004"],
+              superuserItemIds: ["10003"]
             },
             {
               id: eventCConfigId,
@@ -1419,14 +1422,19 @@ describe("devconnect functionality", function () {
         throw new Error(`Could not fetch event info for ${eventBConfigId}`);
       }
 
+      const originalItemId = mocker.get().organizer1.eventBItem3.id;
       const originalItem = (
         await fetchPretixItemsInfoByEvent(db, eventInfo.id)
-      )[0];
+      ).find((i) => i.item_id === originalItemId.toString());
+
+      if (!originalItem) {
+        throw new Error(`Could not fetch item info for ${originalItemId}`);
+      }
 
       mocker.updateItem(
         mocker.get().organizer1.orgUrl,
         mocker.get().organizer1.eventB.slug,
-        mocker.get().organizer1.eventBItem3.id,
+        originalItemId,
         (item) => {
           // This is valid
           //item.generate_tickets = null;
@@ -1435,7 +1443,13 @@ describe("devconnect functionality", function () {
       );
 
       await devconnectPretixSyncService.trySync();
-      const item = (await fetchPretixItemsInfoByEvent(db, eventInfo.id))[0];
+      const item = (await fetchPretixItemsInfoByEvent(db, eventInfo.id)).find(
+        (i) => i.item_id === originalItemId.toString()
+      );
+
+      if (!item) {
+        throw new Error(`Could not fetch item info for ${originalItemId}`);
+      }
 
       // The event name matches the one fetched during sync
       expect(item.item_name).to.eq(updatedNameInNewSync);
@@ -2355,7 +2369,7 @@ describe("devconnect functionality", function () {
         (tt) => tt.ticketGroup === KnownTicketGroup.Devconnect23
       );
 
-      expect(devconnectTicketTypes?.length).to.eq(3);
+      expect(devconnectTicketTypes?.length).to.eq(4);
     }
   );
 

--- a/apps/passport-server/test/pretix/devconnectPretixDataMocker.ts
+++ b/apps/passport-server/test/pretix/devconnectPretixDataMocker.ts
@@ -35,6 +35,7 @@ export interface IOrganizer {
   eventAItem1: DevconnectPretixItem;
   eventAItem2: DevconnectPretixItem;
   eventBItem3: DevconnectPretixItem;
+  eventBItem4: DevconnectPretixItem;
 
   eventA: DevconnectPretixEvent;
   eventB: DevconnectPretixEvent;
@@ -197,13 +198,20 @@ export class DevconnectPretixDataMocker {
     const eventBSettings = this.newEventSettings();
     const eventCSettings = this.newEventSettings();
 
-    const eventACategories = this.newEventCategories();
-    const eventBCategories = this.newEventCategories();
-    const eventCCategories = this.newEventCategories();
+    const eventACategories = [1, 2, 3].map((n) =>
+      this.newEventCategory(n, false)
+    );
+    const eventBCategories = [
+      this.newEventCategory(1, false),
+      this.newEventCategory(2, true)
+    ];
+    const eventCCategories = [1, 2].map((n) => this.newEventCategory(n, false));
 
-    const eventAItem1 = this.newItem("item-1");
-    const eventAItem2 = this.newItem("item-2");
-    const eventBItem3 = this.newItem("item-3");
+    const eventAItem1 = this.newItem("item-1", 1);
+    const eventAItem2 = this.newItem("item-2", 1);
+    const eventBItem3 = this.newItem("item-3", 1);
+    // Add-on item
+    const eventBItem4 = this.newItem("item-4", 2, true);
 
     const eventAOrders: DevconnectPretixOrder[] = [
       this.newPretixOrder(EMAIL_4, [[eventAItem1.id, EMAIL_4]]),
@@ -242,7 +250,7 @@ export class DevconnectPretixDataMocker {
 
     const itemsByEventID: Map<string, DevconnectPretixItem[]> = new Map();
     itemsByEventID.set(eventA.slug, [eventAItem1, eventAItem2]);
-    itemsByEventID.set(eventB.slug, [eventBItem3]);
+    itemsByEventID.set(eventB.slug, [eventBItem3, eventBItem4]);
 
     const settingsByEventID: Map<string, DevconnectPretixEventSettings> =
       new Map();
@@ -266,6 +274,7 @@ export class DevconnectPretixDataMocker {
       eventAItem1,
       eventAItem2,
       eventBItem3,
+      eventBItem4,
       eventA,
       eventB,
       eventC,
@@ -287,13 +296,17 @@ export class DevconnectPretixDataMocker {
     };
   }
 
-  private newItem(name: string): DevconnectPretixItem {
+  private newItem(
+    name: string,
+    category: number,
+    addon = false
+  ): DevconnectPretixItem {
     return {
       id: this.nextId(),
       name: { en: name },
-      category: this.nextId(),
-      admission: true,
-      personalized: true
+      category,
+      admission: !addon,
+      personalized: !addon
     };
   }
 
@@ -343,8 +356,14 @@ export class DevconnectPretixDataMocker {
     };
   }
 
-  private newEventCategories(): DevconnectPretixCategory[] {
-    return [];
+  private newEventCategory(
+    id: number,
+    isAddon: boolean
+  ): DevconnectPretixCategory {
+    return {
+      id,
+      is_addon: isAddon
+    };
   }
 
   private nextId(): number {

--- a/apps/passport-server/test/pretix/devconnectPretixDataMocker.ts
+++ b/apps/passport-server/test/pretix/devconnectPretixDataMocker.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { v4 as uuid } from "uuid";
 import {
+  DevconnectPretixCategory,
   DevconnectPretixEvent,
   DevconnectPretixEventSettings,
   DevconnectPretixItem,
@@ -28,6 +29,7 @@ export interface IOrganizer {
   eventByEventID: Map<string, DevconnectPretixEvent>;
   itemsByEventID: Map<string, DevconnectPretixItem[]>;
   settingsByEventID: Map<string, DevconnectPretixEventSettings>;
+  categoriesByEventId: Map<string, DevconnectPretixCategory[]>;
 
   // specific data for easier testing
   eventAItem1: DevconnectPretixItem;
@@ -195,6 +197,10 @@ export class DevconnectPretixDataMocker {
     const eventBSettings = this.newEventSettings();
     const eventCSettings = this.newEventSettings();
 
+    const eventACategories = this.newEventCategories();
+    const eventBCategories = this.newEventCategories();
+    const eventCCategories = this.newEventCategories();
+
     const eventAItem1 = this.newItem("item-1");
     const eventAItem2 = this.newItem("item-2");
     const eventBItem3 = this.newItem("item-3");
@@ -244,6 +250,12 @@ export class DevconnectPretixDataMocker {
     settingsByEventID.set(eventB.slug, eventBSettings);
     settingsByEventID.set(eventC.slug, eventCSettings);
 
+    const categoriesByEventId: Map<string, DevconnectPretixCategory[]> =
+      new Map();
+    categoriesByEventId.set(eventA.slug, eventACategories);
+    categoriesByEventId.set(eventB.slug, eventBCategories);
+    categoriesByEventId.set(eventC.slug, eventCCategories);
+
     return {
       orgUrl,
       token,
@@ -260,6 +272,7 @@ export class DevconnectPretixDataMocker {
       eventASettings,
       eventBSettings,
       eventCSettings,
+      categoriesByEventId,
       EMAIL_1,
       EMAIL_2,
       EMAIL_3,
@@ -278,6 +291,7 @@ export class DevconnectPretixDataMocker {
     return {
       id: this.nextId(),
       name: { en: name },
+      category: this.nextId(),
       admission: true,
       personalized: true
     };
@@ -291,6 +305,7 @@ export class DevconnectPretixDataMocker {
 
     return {
       code: orderId,
+      name: "name",
       status: "p",
       testmode: false,
       secret: this.randomSecret(),
@@ -326,6 +341,10 @@ export class DevconnectPretixDataMocker {
       attendee_emails_asked: true,
       attendee_emails_required: true
     };
+  }
+
+  private newEventCategories(): DevconnectPretixCategory[] {
+    return [];
   }
 
   private nextId(): number {

--- a/apps/passport-server/test/pretix/devconnectPretixDataMocker.ts
+++ b/apps/passport-server/test/pretix/devconnectPretixDataMocker.ts
@@ -305,7 +305,7 @@ export class DevconnectPretixDataMocker {
 
     return {
       code: orderId,
-      name: "name",
+      name: this.randomName(),
       status: "p",
       testmode: false,
       secret: this.randomSecret(),

--- a/apps/passport-server/test/pretix/mockDevconnectPretixApi.ts
+++ b/apps/passport-server/test/pretix/mockDevconnectPretixApi.ts
@@ -47,6 +47,15 @@ export function getDevconnectMockPretixAPIServer(
     );
 
     handlers.push(
+      rest.get(orgUrl + "/events/:event/categories", (req, res, ctx) => {
+        const org = mocker.getOrgByUrl(orgUrl);
+        const categories =
+          org.categoriesByEventId.get(req.params.event as string) ?? [];
+        return res(ctx.json({ results: categories, next: null }));
+      })
+    );
+
+    handlers.push(
       rest.get(orgUrl + "/events/:event/settings", (req, res, ctx) => {
         const org = mocker.getOrgByUrl(orgUrl);
         const settings = org.settingsByEventID.get(req.params.event as string);


### PR DESCRIPTION
To do this, we fetch the event's add-on categories, and check if the item's category matches one of those IDs.

This allows the "towel" product in cowork space to show up, for example.