### PR TITLE
fix: do not set expanded privacy background to white

### DIFF
--- a/apps/passport-client/components/shared/PrivacyNotice.tsx
+++ b/apps/passport-client/components/shared/PrivacyNotice.tsx
@@ -307,7 +307,7 @@ const MinimizedNotice = styled.div`
   padding: 16px;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba(70, 140, 128, 0.9); // --bg-lite-primary
   }
 `;
 
@@ -343,7 +343,6 @@ const ExpandedTermsTextContainer = styled.div`
   overflow-y: scroll;
   border-radius: 8px;
   padding: 32px 16px;
-  background: white;
 `;
 const Prose = styled.div`
   p {


### PR DESCRIPTION
Fix #1126 

## Visual Changes

||Before|After|
|---|---|---|
|on hover|![Screenshot from 2023-11-01 10-42-29](https://github.com/proofcarryingdata/zupass/assets/38692952/16ea97aa-67e4-4f84-8d9d-c58b2bd34258)|![Screenshot from 2023-11-01 10-42-14](https://github.com/proofcarryingdata/zupass/assets/38692952/6cd3edc8-56de-4161-bf23-9a869f8e96c5)|
|expanded privacy notice|![Screenshot from 2023-11-01 10-38-49](https://github.com/proofcarryingdata/zupass/assets/38692952/4d4806f7-9c98-4f44-bd52-1494e5241363)|![Screenshot from 2023-11-01 10-38-41](https://github.com/proofcarryingdata/zupass/assets/38692952/2d9dffde-5b93-4761-aabe-757f9c43251f)|

## Test Plan
1. `yarn dev`
2. `open http://localhost:3000`
3. log in with a test user (e.g.`test@example.com`)
4. Hover over privacy notice
5. Expand privacy notice