### PR TITLE
[frogcrypto] shared verification promise cache

### DIFF
--- a/apps/passport-server/src/routing/routes/pcdIssuanceRoutes.ts
+++ b/apps/passport-server/src/routing/routes/pcdIssuanceRoutes.ts
@@ -18,10 +18,7 @@ import {
   VerifyTicketResult
 } from "@pcd/passport-interface";
 import express, { Request, Response } from "express";
-import {
-  FeedProviderName,
-  IssuanceService
-} from "../../services/issuanceService";
+import { IssuanceService } from "../../services/issuanceService";
 import { ApplicationContext, GlobalServices } from "../../types";
 import { logger } from "../../util/logger";
 import { checkUrlParam } from "../params";
@@ -84,8 +81,7 @@ export function initPCDIssuanceRoutes(
   app.get("/feeds", async (req: Request, res: Response) => {
     checkIssuanceServiceStarted(issuanceService);
     const result = await issuanceService.handleListFeedsRequest(
-      req.body as ListFeedsRequest,
-      FeedProviderName.ZUPASS
+      req.body as ListFeedsRequest
     );
     res.json(result satisfies ListFeedsResponseValue);
   });
@@ -97,8 +93,7 @@ export function initPCDIssuanceRoutes(
   app.post("/feeds", async (req, res) => {
     checkIssuanceServiceStarted(issuanceService);
     const result = await issuanceService.handleFeedRequest(
-      req.body as PollFeedRequest,
-      FeedProviderName.ZUPASS
+      req.body as PollFeedRequest
     );
     res.json(result satisfies PollFeedResponseValue);
   });
@@ -106,15 +101,10 @@ export function initPCDIssuanceRoutes(
   app.get("/feeds/:feedId", async (req: Request, res: Response) => {
     checkIssuanceServiceStarted(issuanceService);
     const feedId = checkUrlParam(req, "feedId");
-    if (!issuanceService.hasFeedWithId(feedId, FeedProviderName.ZUPASS)) {
+    if (!issuanceService.hasFeedWithId(feedId)) {
       throw new PCDHTTPError(404);
     }
-    res.json(
-      await issuanceService.handleListSingleFeedRequest(
-        { feedId },
-        FeedProviderName.ZUPASS
-      )
-    );
+    res.json(await issuanceService.handleListSingleFeedRequest({ feedId }));
   });
 
   app.post("/issue/check-ticket-by-id", async (req: Request, res: Response) => {

--- a/apps/passport-server/src/services.ts
+++ b/apps/passport-server/src/services.ts
@@ -1,4 +1,3 @@
-import { LRUCache } from "lru-cache";
 import { startDevconnectPretixSyncService } from "./services/devconnectPretixSyncService";
 import { startDiscordService } from "./services/discordService";
 import { startE2EEService } from "./services/e2eeService";
@@ -27,10 +26,6 @@ export async function startServices(
 ): Promise<GlobalServices> {
   await startTelemetry(context);
   instrumentPCDs();
-
-  const verificationPromiseCache = new LRUCache<string, Promise<boolean>>({
-    max: 1000
-  });
 
   const multiprocessService = startMultiProcessService();
   const discordService = await startDiscordService();
@@ -71,18 +66,16 @@ export async function startServices(
     context.dbPool,
     rollbarService
   );
-  const frogcryptoService = startFrogcryptoService(
-    context,
-    rollbarService,
-    verificationPromiseCache
-  );
   const issuanceService = await startIssuanceService(
     context,
     persistentCacheService,
     rollbarService,
-    multiprocessService,
-    frogcryptoService,
-    verificationPromiseCache
+    multiprocessService
+  );
+  const frogcryptoService = startFrogcryptoService(
+    context,
+    rollbarService,
+    issuanceService
   );
   const services: GlobalServices = {
     semaphoreService,

--- a/apps/passport-server/src/services/frogcryptoService.ts
+++ b/apps/passport-server/src/services/frogcryptoService.ts
@@ -54,13 +54,12 @@ export class FrogcryptoService {
 
   public constructor(
     context: ApplicationContext,
-    rollbarService: RollbarService | null
+    rollbarService: RollbarService | null,
+    verificationPromiseCache: LRUCache<string, Promise<boolean>>
   ) {
     this.context = context;
     this.rollbarService = rollbarService;
-    this.verificationPromiseCache = new LRUCache<string, Promise<boolean>>({
-      max: 1000
-    });
+    this.verificationPromiseCache = verificationPromiseCache;
     this.adminUsers = this.getAdminUsers();
   }
 
@@ -296,9 +295,14 @@ export class FrogcryptoService {
 
 export function startFrogcryptoService(
   context: ApplicationContext,
-  rollbarService: RollbarService | null
+  rollbarService: RollbarService | null,
+  verificationPromiseCache: LRUCache<string, Promise<boolean>>
 ): FrogcryptoService {
-  const service = new FrogcryptoService(context, rollbarService);
+  const service = new FrogcryptoService(
+    context,
+    rollbarService,
+    verificationPromiseCache
+  );
 
   return service;
 }

--- a/apps/passport-server/src/services/frogcryptoService.ts
+++ b/apps/passport-server/src/services/frogcryptoService.ts
@@ -1,23 +1,27 @@
 import { Biome, IFrogData, Rarity } from "@pcd/eddsa-frog-pcd";
 import {
+  FeedHost,
   FrogCryptoComputedUserState,
   FrogCryptoDeleteFrogsRequest,
   FrogCryptoDeleteFrogsResponseValue,
-  FrogCryptoFrogData,
   FrogCryptoScore,
+  FrogCryptoFolderName,
+  FrogCryptoFrogData,
   FrogCryptoUpdateFrogsRequest,
   FrogCryptoUpdateFrogsResponseValue,
   FrogCryptoUserStateRequest,
   FrogCryptoUserStateResponseValue,
+  ListFeedsRequest,
+  ListFeedsResponseValue,
+  ListSingleFeedRequest,
+  PollFeedRequest,
+  PollFeedResponseValue,
   verifyFeedCredential
 } from "@pcd/passport-interface";
+import { PCDActionType } from "@pcd/pcd-collection";
 import { SerializedPCD } from "@pcd/pcd-types";
-import {
-  SemaphoreSignaturePCD,
-  SemaphoreSignaturePCDPackage
-} from "@pcd/semaphore-signature-pcd";
+import { SemaphoreSignaturePCD } from "@pcd/semaphore-signature-pcd";
 import _ from "lodash";
-import { LRUCache } from "lru-cache";
 import { FrogCryptoUserFeedState } from "../database/models";
 import {
   deleteFrogData,
@@ -39,32 +43,100 @@ import { ApplicationContext } from "../types";
 import {
   FROGCRYPTO_FEEDS,
   FrogCryptoFeed,
+  FrogCryptoFeedHost,
   parseFrogEnum,
   parseFrogTemperament,
   sampleFrogAttribute
 } from "../util/frogcrypto";
 import { logger } from "../util/logger";
+import { IssuanceService } from "./issuanceService";
 import { RollbarService } from "./rollbarService";
 
 export class FrogcryptoService {
   private readonly context: ApplicationContext;
   private readonly rollbarService: RollbarService | null;
-  private readonly verificationPromiseCache: LRUCache<string, Promise<boolean>>;
+  private readonly issuanceService: IssuanceService;
+  private readonly feedHost: FeedHost;
   private readonly adminUsers: string[];
 
   public constructor(
     context: ApplicationContext,
     rollbarService: RollbarService | null,
-    verificationPromiseCache: LRUCache<string, Promise<boolean>>
+    issuanceService: IssuanceService
   ) {
     this.context = context;
     this.rollbarService = rollbarService;
-    this.verificationPromiseCache = verificationPromiseCache;
+    this.issuanceService = issuanceService;
+    this.feedHost = new FrogCryptoFeedHost(
+      FROGCRYPTO_FEEDS.map((feed) => ({
+        handleRequest: async (
+          req: PollFeedRequest
+        ): Promise<PollFeedResponseValue> => {
+          try {
+            if (!feed.active) {
+              throw new PCDHTTPError(403, "Feed is not active");
+            }
+
+            if (req.pcd === undefined) {
+              throw new PCDHTTPError(400, `Missing credential`);
+            }
+            await verifyFeedCredential(
+              req.pcd,
+              this.issuanceService.cachedVerifySignaturePCD
+            );
+
+            return {
+              actions: [
+                {
+                  pcds: await this.issuanceService.issueEdDSAFrogPCDs(
+                    req.pcd,
+                    await this.reserveFrogData(req.pcd, feed)
+                  ),
+                  folder: FrogCryptoFolderName,
+                  type: PCDActionType.AppendToFolder
+                }
+              ]
+            };
+          } catch (e) {
+            if (e instanceof PCDHTTPError) {
+              throw e;
+            }
+
+            logger(`Error encountered while serving feed:`, e);
+            this.rollbarService?.reportError(e);
+          }
+          return { actions: [] };
+        },
+        feed
+      }))
+    );
     this.adminUsers = this.getAdminUsers();
   }
 
   public async getFeeds(): Promise<FrogCryptoFeed[]> {
     return FROGCRYPTO_FEEDS;
+  }
+
+  public async handleListFeedsRequest(
+    request: ListFeedsRequest
+  ): Promise<ListFeedsResponseValue> {
+    return this.feedHost.handleListFeedsRequest(request);
+  }
+
+  public async handleListSingleFeedRequest(
+    request: ListSingleFeedRequest
+  ): Promise<ListFeedsResponseValue> {
+    return this.feedHost.handleListSingleFeedRequest(request);
+  }
+
+  public async handleFeedRequest(
+    request: PollFeedRequest
+  ): Promise<PollFeedResponseValue> {
+    return this.feedHost.handleFeedRequest(request);
+  }
+
+  public hasFeedWithId(feedId: string): boolean {
+    return this.feedHost.hasFeedWithId(feedId);
   }
 
   public async getUserState(
@@ -88,7 +160,7 @@ export class FrogcryptoService {
     };
   }
 
-  public async reserveFrogData(
+  private async reserveFrogData(
     pcd: SerializedPCD<SemaphoreSignaturePCD>,
     feed: FrogCryptoFeed
   ): Promise<IFrogData> {
@@ -228,34 +300,11 @@ export class FrogcryptoService {
     try {
       const { pcd } = await verifyFeedCredential(
         serializedPCD,
-        this.cachedVerifySignaturePCD.bind(this)
+        this.issuanceService.cachedVerifySignaturePCD
       );
       return pcd.claim.identityCommitment;
     } catch (e) {
       throw new PCDHTTPError(400, "invalid PCD");
-    }
-  }
-
-  /**
-   * Returns a promised verification of a PCD, either from the cache or,
-   * if there is no cache entry, from the multiprocess service.
-   */
-  private async cachedVerifySignaturePCD(
-    serializedPCD: SerializedPCD<SemaphoreSignaturePCD>
-  ): Promise<boolean> {
-    const key = JSON.stringify(serializedPCD);
-    const cached = this.verificationPromiseCache.get(key);
-    if (cached) {
-      return cached;
-    } else {
-      const deserialized = await SemaphoreSignaturePCDPackage.deserialize(
-        serializedPCD.pcd
-      );
-      const promise = SemaphoreSignaturePCDPackage.verify(deserialized);
-      this.verificationPromiseCache.set(key, promise);
-      // If the promise rejects, delete it from the cache
-      promise.catch(() => this.verificationPromiseCache.delete(key));
-      return promise;
     }
   }
 
@@ -296,12 +345,17 @@ export class FrogcryptoService {
 export function startFrogcryptoService(
   context: ApplicationContext,
   rollbarService: RollbarService | null,
-  verificationPromiseCache: LRUCache<string, Promise<boolean>>
-): FrogcryptoService {
+  issuanceService: IssuanceService | null
+): FrogcryptoService | null {
+  if (!issuanceService) {
+    logger("[FROGCRYPTO] Issuance service not configured");
+    return null;
+  }
+
   const service = new FrogcryptoService(
     context,
     rollbarService,
-    verificationPromiseCache
+    issuanceService
   );
 
   return service;

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -1,4 +1,4 @@
-import { EdDSAFrogPCDPackage } from "@pcd/eddsa-frog-pcd";
+import { EdDSAFrogPCDPackage, IFrogData } from "@pcd/eddsa-frog-pcd";
 import {
   EdDSAPublicKey,
   getEdDSAPublicKey,
@@ -18,7 +18,6 @@ import {
   CheckTicketInByIdRequest,
   CheckTicketInByIdResult,
   FeedHost,
-  FrogCryptoFolderName,
   GetOfflineTicketsRequest,
   GetOfflineTicketsResponseValue,
   ISSUANCE_STRING,
@@ -93,20 +92,13 @@ import {
 import { fetchLoggedInZuzaluUser } from "../database/queries/zuzalu_pretix_tickets/fetchZuzaluUser";
 import { PCDHTTPError } from "../routing/pcdHttpError";
 import { ApplicationContext } from "../types";
-import {
-  FROGCRYPTO_FEEDS,
-  FrogCryptoFeed,
-  FrogCryptoFeedHost
-} from "../util/frogcrypto";
 import { logger } from "../util/logger";
 import { timeBasedId } from "../util/timeBasedId";
-import { cachedVerifySignaturePCD } from "../util/util";
 import {
   zuconnectProductIdToEventId,
   zuconnectProductIdToName
 } from "../util/zuconnectTicket";
 import { zuzaluRoleToProductId } from "../util/zuzaluUser";
-import { FrogcryptoService } from "./frogcryptoService";
 import { MultiProcessService } from "./multiProcessService";
 import { PersistentCacheService } from "./persistentCacheService";
 import { RollbarService } from "./rollbarService";
@@ -114,46 +106,40 @@ import { traced } from "./telemetryService";
 
 export const ZUPASS_TICKET_PUBLIC_KEY_NAME = "Zupass";
 
-export enum FeedProviderName {
-  ZUPASS = "Zupass",
-  FROGCRYPTO = "FrogCrypto"
-}
-
 export class IssuanceService {
   private readonly context: ApplicationContext;
   private readonly cacheService: PersistentCacheService;
   private readonly rollbarService: RollbarService | null;
-  private readonly feedHosts: Record<FeedProviderName, FeedHost>;
+  private readonly feedHost: FeedHost;
   private readonly eddsaPrivateKey: string;
   private readonly rsaPrivateKey: NodeRSA;
   private readonly exportedRSAPrivateKey: string;
   private readonly exportedRSAPublicKey: string;
   private readonly multiprocessService: MultiProcessService;
-  private readonly frogcryptoService: FrogcryptoService;
   private readonly verificationPromiseCache: LRUCache<string, Promise<boolean>>;
 
   public constructor(
     context: ApplicationContext,
     cacheService: PersistentCacheService,
     multiprocessService: MultiProcessService,
-    frogcryptoService: FrogcryptoService,
     rollbarService: RollbarService | null,
     rsaPrivateKey: NodeRSA,
-    eddsaPrivateKey: string,
-    verificationPromiseCache: LRUCache<string, Promise<boolean>>
+    eddsaPrivateKey: string
   ) {
     this.context = context;
     this.cacheService = cacheService;
     this.multiprocessService = multiprocessService;
-    this.frogcryptoService = frogcryptoService;
     this.rollbarService = rollbarService;
     this.rsaPrivateKey = rsaPrivateKey;
     this.exportedRSAPrivateKey = this.rsaPrivateKey.exportKey("private");
     this.exportedRSAPublicKey = this.rsaPrivateKey.exportKey("public");
     this.eddsaPrivateKey = eddsaPrivateKey;
-    this.verificationPromiseCache = verificationPromiseCache;
+    this.verificationPromiseCache = new LRUCache<string, Promise<boolean>>({
+      max: 1000
+    });
+    this.cachedVerifySignaturePCD = this.cachedVerifySignaturePCD.bind(this);
 
-    const zupassFeedHost = new FeedHost(
+    this.feedHost = new FeedHost(
       [
         {
           handleRequest: async (
@@ -167,7 +153,7 @@ export class IssuanceService {
               }
               const { pcd } = await verifyFeedCredential(
                 req.pcd,
-                cachedVerifySignaturePCD(this.verificationPromiseCache)
+                this.cachedVerifySignaturePCD
               );
               const pcds = await this.issueDevconnectPretixTicketPCDs(pcd);
               const ticketsByEvent = _.groupBy(
@@ -243,7 +229,7 @@ export class IssuanceService {
               }
               await verifyFeedCredential(
                 req.pcd,
-                cachedVerifySignaturePCD(this.verificationPromiseCache)
+                this.cachedVerifySignaturePCD
               );
               return {
                 actions: [
@@ -289,7 +275,7 @@ export class IssuanceService {
               }
               const { pcd } = await verifyFeedCredential(
                 req.pcd,
-                cachedVerifySignaturePCD(this.verificationPromiseCache)
+                this.cachedVerifySignaturePCD
               );
               const pcds = await this.issueEmailPCDs(pcd);
 
@@ -327,7 +313,7 @@ export class IssuanceService {
             try {
               const { pcd } = await verifyFeedCredential(
                 req.pcd,
-                cachedVerifySignaturePCD(this.verificationPromiseCache)
+                this.cachedVerifySignaturePCD
               );
               const pcds = await this.issueZuzaluTicketPCDs(pcd);
 
@@ -365,7 +351,7 @@ export class IssuanceService {
             try {
               const { pcd } = await verifyFeedCredential(
                 req.pcd,
-                cachedVerifySignaturePCD(this.verificationPromiseCache)
+                this.cachedVerifySignaturePCD
               );
 
               const pcds = await this.issueZuconnectTicketPCDs(pcd);
@@ -402,80 +388,30 @@ export class IssuanceService {
         }
       ],
       `${process.env.PASSPORT_SERVER_URL}/feeds`,
-      FeedProviderName.ZUPASS
-    );
-    const frogcryptoFeedHost = new FrogCryptoFeedHost(
-      FROGCRYPTO_FEEDS.map((feed) => ({
-        handleRequest: async (
-          req: PollFeedRequest
-        ): Promise<PollFeedResponseValue> => {
-          try {
-            if (req.pcd === undefined) {
-              throw new PCDHTTPError(400, `Missing credential`);
-            }
-            await verifyFeedCredential(
-              req.pcd,
-              cachedVerifySignaturePCD(this.verificationPromiseCache)
-            );
-
-            return {
-              actions: [
-                {
-                  pcds: await this.issueEdDSAFrogPCDs(req.pcd, feed),
-                  folder: FrogCryptoFolderName,
-                  type: PCDActionType.AppendToFolder
-                }
-              ]
-            };
-          } catch (e) {
-            if (e instanceof PCDHTTPError) {
-              throw e;
-            }
-
-            logger(`Error encountered while serving feed:`, e);
-            this.rollbarService?.reportError(e);
-          }
-          return { actions: [] };
-        },
-        feed
-      }))
-    );
-
-    this.feedHosts = [zupassFeedHost, frogcryptoFeedHost].reduce(
-      (acc, feedHost) => {
-        acc[feedHost.getProviderName()] = feedHost;
-        return acc;
-      },
-      {} as Record<string, FeedHost>
+      "Zupass"
     );
   }
 
   public async handleListFeedsRequest(
-    request: ListFeedsRequest,
-    feedProvider: FeedProviderName
+    request: ListFeedsRequest
   ): Promise<ListFeedsResponseValue> {
-    return this.feedHosts[feedProvider].handleListFeedsRequest(request);
+    return this.feedHost.handleListFeedsRequest(request);
   }
 
   public async handleListSingleFeedRequest(
-    request: ListSingleFeedRequest,
-    feedProvider: FeedProviderName
+    request: ListSingleFeedRequest
   ): Promise<ListFeedsResponseValue> {
-    return this.feedHosts[feedProvider].handleListSingleFeedRequest(request);
+    return this.feedHost.handleListSingleFeedRequest(request);
   }
 
   public async handleFeedRequest(
-    request: PollFeedRequest,
-    feedProvider: FeedProviderName
+    request: PollFeedRequest
   ): Promise<PollFeedResponseValue> {
-    return this.feedHosts[feedProvider].handleFeedRequest(request);
+    return this.feedHost.handleFeedRequest(request);
   }
 
-  public hasFeedWithId(
-    feedId: string,
-    feedProvider: FeedProviderName
-  ): boolean {
-    return this.feedHosts[feedProvider].hasFeedWithId(feedId);
+  public hasFeedWithId(feedId: string): boolean {
+    return this.feedHost.hasFeedWithId(feedId);
   }
 
   public getRSAPublicKey(): string {
@@ -679,6 +615,29 @@ export class IssuanceService {
         error: { name: "ServerError", detailedMessage: getErrorMessage(e) },
         success: false
       };
+    }
+  }
+
+  /**
+   * Returns a promised verification of a PCD, either from the cache or,
+   * if there is no cache entry, from the multiprocess service.
+   */
+  public async cachedVerifySignaturePCD(
+    serializedPCD: SerializedPCD<SemaphoreSignaturePCD>
+  ): Promise<boolean> {
+    const key = JSON.stringify(serializedPCD);
+    const cached = this.verificationPromiseCache.get(key);
+    if (cached) {
+      return cached;
+    } else {
+      const deserialized = await SemaphoreSignaturePCDPackage.deserialize(
+        serializedPCD.pcd
+      );
+      const promise = SemaphoreSignaturePCDPackage.verify(deserialized);
+      this.verificationPromiseCache.set(key, promise);
+      // If the promise rejects, delete it from the cache
+      promise.catch(() => this.verificationPromiseCache.delete(key));
+      return promise;
     }
   }
 
@@ -920,23 +879,13 @@ export class IssuanceService {
     return [frogPCD];
   }
 
-  private async issueEdDSAFrogPCDs(
+  /**
+   * Issue an EdDSAFrogPCD from IFrogData signed with IssuanceService's private key.
+   */
+  public async issueEdDSAFrogPCDs(
     credential: SerializedPCD<SemaphoreSignaturePCD>,
-    feed: FrogCryptoFeed
+    frogData: IFrogData
   ): Promise<SerializedPCD[]> {
-    const serverUrl = process.env.PASSPORT_CLIENT_URL;
-
-    if (!serverUrl) {
-      logger("[ISSUE] can't issue frogs - unaware of the client location");
-      return [];
-    }
-
-    // TODO: return as user facing error
-    if (!feed.active) {
-      logger("[ISSUE] can't issue frogs - feed is inactive");
-      return [];
-    }
-
     const frogPCD = await EdDSAFrogPCDPackage.serialize(
       await EdDSAFrogPCDPackage.prove({
         privateKey: {
@@ -945,7 +894,7 @@ export class IssuanceService {
         },
         data: {
           argumentType: ArgumentTypeName.Object,
-          value: await this.frogcryptoService.reserveFrogData(credential, feed)
+          value: frogData
         },
         id: {
           argumentType: ArgumentTypeName.String
@@ -1413,9 +1362,7 @@ export async function startIssuanceService(
   context: ApplicationContext,
   cacheService: PersistentCacheService,
   rollbarService: RollbarService | null,
-  multiprocessService: MultiProcessService,
-  frogcryptoService: FrogcryptoService,
-  verificationPromiseCache: LRUCache<string, Promise<boolean>>
+  multiprocessService: MultiProcessService
 ): Promise<IssuanceService | null> {
   const zupassRsaKey = loadRSAPrivateKey();
   const zupassEddsaKey = loadEdDSAPrivateKey();
@@ -1434,11 +1381,9 @@ export async function startIssuanceService(
     context,
     cacheService,
     multiprocessService,
-    frogcryptoService,
     rollbarService,
     zupassRsaKey,
-    zupassEddsaKey,
-    verificationPromiseCache
+    zupassEddsaKey
   );
 
   return issuanceService;

--- a/apps/passport-server/src/types.ts
+++ b/apps/passport-server/src/types.ts
@@ -49,7 +49,7 @@ export interface GlobalServices {
   discordService: DiscordService | null;
   telegramService: TelegramService | null;
   kudosbotService: KudosbotService | null;
-  frogcryptoService: FrogcryptoService;
+  frogcryptoService: FrogcryptoService | null;
   persistentCacheService: PersistentCacheService;
   multiprocessService: MultiProcessService;
 }

--- a/apps/passport-server/src/util/frogcrypto.ts
+++ b/apps/passport-server/src/util/frogcrypto.ts
@@ -19,7 +19,6 @@ import { PCDPermissionType } from "@pcd/pcd-collection";
 import { PCDPackage } from "@pcd/pcd-types";
 import _ from "lodash";
 import { PCDHTTPError } from "../routing/pcdHttpError";
-import { FeedProviderName } from "../services/issuanceService";
 
 /**
  * FrogCrypto specific feed configurations
@@ -124,7 +123,7 @@ export class FrogCryptoFeedHost extends FeedHost<FrogCryptoFeed> {
     super(
       feeds,
       `${process.env.PASSPORT_SERVER_URL}/frogcrypto/feeds`,
-      FeedProviderName.FROGCRYPTO
+      "FrogCrypto"
     );
   }
 

--- a/apps/passport-server/src/util/util.ts
+++ b/apps/passport-server/src/util/util.ts
@@ -1,11 +1,5 @@
-import { SerializedPCD } from "@pcd/pcd-types";
-import {
-  SemaphoreSignaturePCD,
-  SemaphoreSignaturePCDPackage
-} from "@pcd/semaphore-signature-pcd";
 import { exec } from "child_process";
 import validator from "email-validator";
-import { LRUCache } from "lru-cache";
 import { promisify } from "util";
 import { logger } from "./logger";
 
@@ -133,32 +127,5 @@ export function compareArrays<T>(
     new: newItems,
     updated: updatedItems,
     removed: removedItems
-  };
-}
-
-/**
- * Returns a promised verification of a PCD, either from the cache or,
- * if there is no cache entry, from the multiprocess service.
- */
-export function cachedVerifySignaturePCD(
-  verificationPromiseCache: LRUCache<string, Promise<boolean>>
-) {
-  return async (
-    serializedPCD: SerializedPCD<SemaphoreSignaturePCD>
-  ): Promise<boolean> => {
-    const key = JSON.stringify(serializedPCD);
-    const cached = verificationPromiseCache.get(key);
-    if (cached) {
-      return cached;
-    } else {
-      const deserialized = await SemaphoreSignaturePCDPackage.deserialize(
-        serializedPCD.pcd
-      );
-      const promise = SemaphoreSignaturePCDPackage.verify(deserialized);
-      verificationPromiseCache.set(key, promise);
-      // If the promise rejects, delete it from the cache
-      promise.catch(() => verificationPromiseCache.delete(key));
-      return promise;
-    }
   };
 }


### PR DESCRIPTION
fixes https://github.com/proofcarryingdata/zupass/issues/1128

A pretty naive refactor to share verification cache between issuanceService and frogcryptoService. 

Alternatives looked at 
1/ put it in PersistentCacheService and rename to CacheServer to support both persistent and in-memory cache. didn't like the end interface toggling between two types of cache
2/ put it in application context, feels it is a little heavy given only used by two services

