### PR TITLE
[frogcrypto][8/n] exclude objects from frogedex

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/DexTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/DexTab.tsx
@@ -2,15 +2,16 @@ import { EdDSAFrogPCD } from "@pcd/eddsa-frog-pcd";
 import _ from "lodash";
 import { useMemo } from "react";
 import styled from "styled-components";
+import { RippleLoader } from "../../core/RippleLoader";
 
 /**
  * The FrogeDex tab allows users to view their progress towards collecting all frogs.
  */
 export function DexTab({
-  possibleFrogCount,
+  possibleFrogIds,
   pcds
 }: {
-  possibleFrogCount?: number;
+  possibleFrogIds?: [number, number][];
   pcds: EdDSAFrogPCD[];
 }) {
   const names = useMemo(() => {
@@ -23,23 +24,27 @@ export function DexTab({
     return names;
   }, [pcds]);
 
-  if (!possibleFrogCount) {
-    return <div>loading...</div>;
+  if (!possibleFrogIds) {
+    return <RippleLoader />;
   }
 
   return (
     <table>
       <tbody>
-        {_.range(1, possibleFrogCount + 1).map((i) => (
-          <tr key={i}>
-            <Cell>{i}</Cell>
-            {names[i] ? (
-              <Cell>{names[i]}</Cell>
-            ) : (
-              <UnknownCell>???</UnknownCell>
-            )}
-          </tr>
-        ))}
+        {_.chain(possibleFrogIds)
+          .map(([min, max]) => _.range(min, max + 1))
+          .flatten()
+          .value()
+          .map((i) => (
+            <tr key={i}>
+              <Cell>{i}</Cell>
+              {names[i] ? (
+                <Cell>{names[i]}</Cell>
+              ) : (
+                <UnknownCell>???</UnknownCell>
+              )}
+            </tr>
+          ))}
       </tbody>
     </table>
   );

--- a/apps/passport-client/components/screens/FrogScreens/DexTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/DexTab.tsx
@@ -11,7 +11,7 @@ export function DexTab({
   possibleFrogIds,
   pcds
 }: {
-  possibleFrogIds?: [number, number][];
+  possibleFrogIds?: number[];
   pcds: EdDSAFrogPCD[];
 }) {
   const names = useMemo(() => {
@@ -31,20 +31,16 @@ export function DexTab({
   return (
     <table>
       <tbody>
-        {_.chain(possibleFrogIds)
-          .map(([min, max]) => _.range(min, max + 1))
-          .flatten()
-          .value()
-          .map((i) => (
-            <tr key={i}>
-              <Cell>{i}</Cell>
-              {names[i] ? (
-                <Cell>{names[i]}</Cell>
-              ) : (
-                <UnknownCell>???</UnknownCell>
-              )}
-            </tr>
-          ))}
+        {possibleFrogIds.map((i) => (
+          <tr key={i}>
+            <Cell>{i}</Cell>
+            {names[i] ? (
+              <Cell>{names[i]}</Cell>
+            ) : (
+              <UnknownCell>???</UnknownCell>
+            )}
+          </tr>
+        ))}
       </tbody>
     </table>
   );

--- a/apps/passport-client/components/screens/FrogScreens/FrogHomeScreen.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogHomeScreen.tsx
@@ -120,7 +120,7 @@ export function FrogHomeScreen() {
                 {tab === "score" && <ScoreTab score={userState?.myScore} />}
                 {tab === "dex" && (
                   <DexTab
-                    possibleFrogCount={userState.possibleFrogCount}
+                    possibleFrogIds={userState.possibleFrogIds}
                     pcds={frogPCDs}
                   />
                 )}

--- a/apps/passport-server/src/database/queries/frogcrypto.ts
+++ b/apps/passport-server/src/database/queries/frogcrypto.ts
@@ -152,40 +152,21 @@ export async function deleteFrogData(
 }
 
 /**
- * Returns a list of possible frog ids as a pair list of [min, max] consecutive
- * ids.
- *
- * FrogCrypto entities are identified by a unique consecutive integer ids.
- * However, some FrogCrypto entities are not "frogs" but are instead "objects"
- * such as "stick" or "rock". These objects are not included in the list of
- * possible frogs and create holes in the list of ids shown on Frogedex. This
- * function returns a list of pairs of consecutive ids that are possible frogs.
- * For example: [[1, 10], [12, 15]] means that frog ids 1-10 and 12-15 are all
- * possible frogs.
- *
- * How does the query work: Every group of consecutive ids shares the same
- * distance from the id to its relative rank in the universe. In the above
- * example, the distance is 0 and 1 respectively. Effectively, the distance is
- * the cumulative number of skipped ids.
+ * Returns a list of possible frog ids
  */
-export async function getPossibleFrogIds(
-  pool: Pool
-): Promise<[number, number][]> {
+export async function getPossibleFrogIds(pool: Pool): Promise<number[]> {
   const result = await sqlQuery(
     pool,
     `
-select min(id) as min, max(id) as max
-from (
-  select *, row_number() over (order by id) as rank from frogcrypto_frogs
+  select id
+  from frogcrypto_frogs
   where frog->>'rarity' <> 'object'
-) frogs
-group by (id - rank)
-order by min(id)
+  order by id
     `,
     []
   );
 
-  return result.rows.map((row) => [row.min, row.max]);
+  return result.rows.map((row) => row.id);
 }
 
 /**

--- a/apps/passport-server/src/database/queries/frogcrypto.ts
+++ b/apps/passport-server/src/database/queries/frogcrypto.ts
@@ -151,16 +151,41 @@ export async function deleteFrogData(
   );
 }
 
-export async function getPossibleFrogCount(pool: Pool): Promise<number> {
+/**
+ * Returns a list of possible frog ids as a pair list of [min, max] consecutive
+ * ids.
+ *
+ * FrogCrypto entities are identified by a unique consecutive integer ids.
+ * However, some FrogCrypto entities are not "frogs" but are instead "objects"
+ * such as "stick" or "rock". These objects are not included in the list of
+ * possible frogs and create holes in the list of ids shown on Frogedex. This
+ * function returns a list of pairs of consecutive ids that are possible frogs.
+ * For example: [[1, 10], [12, 15]] means that frog ids 1-10 and 12-15 are all
+ * possible frogs.
+ *
+ * How does the query work: Every group of consecutive ids shares the same
+ * distance from the id to its relative rank in the universe. In the above
+ * example, the distance is 0 and 1 respectively. Effectively, the distance is
+ * the cumulative number of skipped ids.
+ */
+export async function getPossibleFrogIds(
+  pool: Pool
+): Promise<[number, number][]> {
   const result = await sqlQuery(
     pool,
-    `select
-    cast(count(*) as int) as count
-    from frogcrypto_frogs`,
+    `
+select min(id) as min, max(id) as max
+from (
+  select *, row_number() over (order by id) as rank from frogcrypto_frogs
+  where frog->>'rarity' <> 'object'
+) frogs
+group by (id - rank)
+order by min(id)
+    `,
     []
   );
 
-  return result.rows[0].count;
+  return result.rows.map((row) => [row.min, row.max]);
 }
 
 /**

--- a/apps/passport-server/src/services/frogcryptoService.ts
+++ b/apps/passport-server/src/services/frogcryptoService.ts
@@ -23,10 +23,10 @@ import {
   deleteFrogData,
   fetchUserFeedsState,
   getFrogData,
-  getPossibleFrogCount,
   getScoreboard,
   getUserScore,
   incrementScore,
+  getPossibleFrogIds,
   initializeUserFeedState,
   sampleFrogData,
   updateUserFeedState,
@@ -84,7 +84,7 @@ export class FrogcryptoService {
       feeds: userFeeds.map((userFeed) =>
         this.computeUserFeedState(userFeed, allFeeds[userFeed.feed_id])
       ),
-      possibleFrogCount: await getPossibleFrogCount(this.context.dbPool),
+      possibleFrogIds: await getPossibleFrogIds(this.context.dbPool),
       myScore: await getUserScore(this.context.dbPool, semaphoreId)
     };
   }

--- a/apps/passport-server/test/frogcrypto.spec.ts
+++ b/apps/passport-server/test/frogcrypto.spec.ts
@@ -12,6 +12,7 @@ import {
 import { AppendToFolderAction, PCDActionType } from "@pcd/pcd-collection";
 import { Identity } from "@semaphore-protocol/identity";
 import { expect } from "chai";
+import _ from "lodash";
 import "mocha";
 import MockDate from "mockdate";
 import { Pool } from "postgres-pool";
@@ -132,9 +133,9 @@ describe("frogcrypto functionality", function () {
 
     let userState = await getUserState();
     expect(userState.success).to.be.true;
-    expect(userState.value?.possibleFrogIds).to.deep.equal([
-      [1, testFrogs.length]
-    ]);
+    expect(userState.value?.possibleFrogIds).to.deep.equal(
+      _.range(1, testFrogs.length + 1)
+    );
     expect(userState.value?.feeds).to.be.empty;
     expect(userState.value?.myScore).to.be.undefined;
 
@@ -143,13 +144,12 @@ describe("frogcrypto functionality", function () {
 
     userState = await getUserState();
     expect(userState.success).to.be.true;
-    expect(userState.value?.possibleFrogIds).to.deep.equal([
-      [1, testFrogs.length]
-    ]);
+    expect(userState.value?.possibleFrogIds).to.deep.equal(
+      _.range(1, testFrogs.length + 1)
+    );
     expect(userState.value?.myScore?.score).to.eq(1);
     expect(userState.value?.myScore?.semaphore_id).to.be.eq(
-      identity.getCommitment().toString()
-    );
+      identity.getCommitment().toString());
     expect(userState.value?.feeds).to.be.not.empty;
     const feedState = userState.value?.feeds?.[0];
     expect(feedState?.feedId).to.eq(feed.id);

--- a/apps/passport-server/test/frogcrypto.spec.ts
+++ b/apps/passport-server/test/frogcrypto.spec.ts
@@ -132,7 +132,9 @@ describe("frogcrypto functionality", function () {
 
     let userState = await getUserState();
     expect(userState.success).to.be.true;
-    expect(userState.value?.possibleFrogCount).to.be.eq(testFrogs.length);
+    expect(userState.value?.possibleFrogIds).to.deep.equal([
+      [1, testFrogs.length]
+    ]);
     expect(userState.value?.feeds).to.be.empty;
     expect(userState.value?.myScore).to.be.undefined;
 
@@ -141,7 +143,9 @@ describe("frogcrypto functionality", function () {
 
     userState = await getUserState();
     expect(userState.success).to.be.true;
-    expect(userState.value?.possibleFrogCount).to.be.eq(testFrogs.length);
+    expect(userState.value?.possibleFrogIds).to.deep.equal([
+      [1, testFrogs.length]
+    ]);
     expect(userState.value?.myScore?.score).to.eq(1);
     expect(userState.value?.myScore?.semaphore_id).to.be.eq(
       identity.getCommitment().toString()

--- a/apps/passport-server/test/frogcryptodb.spec.ts
+++ b/apps/passport-server/test/frogcryptodb.spec.ts
@@ -9,13 +9,14 @@ import {
   deleteFrogData,
   fetchUserFeedsState,
   getFrogData,
+  getPossibleFrogIds,
   initializeUserFeedState,
   sampleFrogData,
   updateUserFeedState,
   upsertFrogData
 } from "../src/database/queries/frogcrypto";
 import { overrideEnvironment, testingEnv } from "./util/env";
-import { testFrogs } from "./util/frogcrypto";
+import { testFrogs, testFrogsAndObjects } from "./util/frogcrypto";
 
 describe("database reads and writes for frogcrypto features", function () {
   this.timeout(15_000);
@@ -117,5 +118,15 @@ describe("database reads and writes for frogcrypto features", function () {
 
     const userFeedState = await fetchUserFeedsState(db, "test");
     expect(userFeedState[0].last_fetched_at.getTime()).to.be.greaterThan(0);
+  });
+
+  step("returns possible frog ids excluding objects", async function () {
+    await upsertFrogData(db, testFrogsAndObjects);
+
+    const possibleFrogIds = await getPossibleFrogIds(db);
+    expect(possibleFrogIds).to.deep.eq([
+      [1, 3],
+      [7, 8]
+    ]);
   });
 });

--- a/apps/passport-server/test/frogcryptodb.spec.ts
+++ b/apps/passport-server/test/frogcryptodb.spec.ts
@@ -124,9 +124,6 @@ describe("database reads and writes for frogcrypto features", function () {
     await upsertFrogData(db, testFrogsAndObjects);
 
     const possibleFrogIds = await getPossibleFrogIds(db);
-    expect(possibleFrogIds).to.deep.eq([
-      [1, 3],
-      [7, 8]
-    ]);
+    expect(possibleFrogIds).to.deep.eq([1, 2, 3, 7, 8]);
   });
 });

--- a/apps/passport-server/test/util/frogcrypto.ts
+++ b/apps/passport-server/test/util/frogcrypto.ts
@@ -75,3 +75,78 @@ export const testFrogs: FrogCryptoFrogData[] = [
     beauty_max: 1
   }
 ];
+
+export const testFrogsAndObjects: FrogCryptoFrogData[] = [
+  {
+    id: 5,
+    uuid: uuid(),
+    name: "Object 1",
+    description: "A object",
+    biome: "N/A",
+    rarity: "object",
+    temperament: undefined,
+    drop_weight: 1,
+    jump_min: 1,
+    jump_max: 1,
+    speed_min: 1,
+    speed_max: 1,
+    intelligence_min: 1,
+    intelligence_max: 1,
+    beauty_min: 1,
+    beauty_max: 1
+  },
+  {
+    id: 6,
+    uuid: uuid(),
+    name: "Object 2",
+    description: "A object",
+    biome: "N/A",
+    rarity: "object",
+    temperament: undefined,
+    drop_weight: 1,
+    jump_min: 1,
+    jump_max: 1,
+    speed_min: 1,
+    speed_max: 1,
+    intelligence_min: 1,
+    intelligence_max: 1,
+    beauty_min: 1,
+    beauty_max: 1
+  },
+  {
+    id: 7,
+    uuid: uuid(),
+    name: "Frog 7",
+    description: "A frog",
+    biome: "Jungle",
+    rarity: "common",
+    temperament: undefined,
+    drop_weight: 1,
+    jump_min: 1,
+    jump_max: 1,
+    speed_min: 1,
+    speed_max: 1,
+    intelligence_min: 1,
+    intelligence_max: 1,
+    beauty_min: 1,
+    beauty_max: 1
+  },
+  {
+    id: 8,
+    uuid: uuid(),
+    name: "Frog 8",
+    description: "A frog",
+    biome: "Desert",
+    rarity: "rare",
+    temperament: "MEOW",
+    drop_weight: 1,
+    jump_min: 1,
+    jump_max: 1,
+    speed_min: 1,
+    speed_max: 1,
+    intelligence_min: 1,
+    intelligence_max: 1,
+    beauty_min: 1,
+    beauty_max: 1
+  }
+];

--- a/packages/passport-interface/src/RequestTypes.ts
+++ b/packages/passport-interface/src/RequestTypes.ts
@@ -641,13 +641,9 @@ export interface FrogCryptoComputedUserState {
 export interface FrogCryptoUserStateResponseValue {
   feeds: FrogCryptoComputedUserState[];
   /**
-   * A pair list of [min, max] over consecutive integer sequences that represent
-   * the possible frog ids. For example, [[1, 5], [7, 10]] means there are frogs
-   * with ids [1, 2, 3, 4, 5, 7, 8, 9, 10].
-   *
-   * See {@link getPossibleFrogIds}
+   * A list of possible frog ids
    */
-  possibleFrogIds: [number, number][];
+  possibleFrogIds: number[];
   myScore?: FrogCryptoScore;
 }
 

--- a/packages/passport-interface/src/RequestTypes.ts
+++ b/packages/passport-interface/src/RequestTypes.ts
@@ -640,7 +640,14 @@ export interface FrogCryptoComputedUserState {
  */
 export interface FrogCryptoUserStateResponseValue {
   feeds: FrogCryptoComputedUserState[];
-  possibleFrogCount: number;
+  /**
+   * A pair list of [min, max] over consecutive integer sequences that represent
+   * the possible frog ids. For example, [[1, 5], [7, 10]] means there are frogs
+   * with ids [1, 2, 3, 4, 5, 7, 8, 9, 10].
+   *
+   * See {@link getPossibleFrogIds}
+   */
+  possibleFrogIds: [number, number][];
   myScore?: FrogCryptoScore;
 }
 


### PR DESCRIPTION
https://github.com/proofcarryingdata/zupass/issues/1057

Exclude objects from Frogedex by returning groups of consecutive frog ids with min and max of each group.

Added unit test and tested locally

<img width="590" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/67967a9a-8690-4c2e-8957-ccb3c3549ce4">
