### PR TITLE
More stable uploadID to avoid extra uploads.

### DIFF
--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -354,9 +354,10 @@ async function finishAccountCreation(
 
   // Save PCDs to E2EE storage.
   await uploadStorage(user, state.pcds, state.subscriptions);
+  const uploadId = await makeUploadId(state.pcds, state.subscriptions);
 
-  // Close any existing modal, if it exists
-  update({ modal: { modalType: "none" } });
+  // Save what we uploaded, and close any existing modal, if it exists
+  update({ modal: { modalType: "none" }, uploadedUploadId: uploadId });
 
   if (hasPendingRequest()) {
     window.location.hash = "#/login-interstitial";
@@ -712,7 +713,7 @@ async function doSync(
       console.log("[SYNC] initalized credentialManager", credentialManager);
       const actions =
         await state.subscriptions.pollSubscriptions(credentialManager);
-      console.log("[SYNC] fetched actions", actions);
+      console.log(`[SYNC] fetched ${actions.length} actions`);
 
       await applyActions(state.pcds, actions);
       console.log("[SYNC] applied pcd actions");
@@ -792,7 +793,7 @@ async function syncSubscription(
       subscription,
       credentialManager
     );
-    console.log("[SYNC] fetched actions", actions);
+    console.log(`[SYNC] fetched ${actions.length} actions`);
 
     await applyActions(state.pcds, actions);
     console.log("[SYNC] applied pcd actions");

--- a/apps/passport-client/src/useSyncE2EEStorage.tsx
+++ b/apps/passport-client/src/useSyncE2EEStorage.tsx
@@ -13,9 +13,8 @@ import {
   requestUploadEncryptedStorage
 } from "@pcd/passport-interface";
 import { PCDCollection } from "@pcd/pcd-collection";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect } from "react";
 import { appConfig } from "./appConfig";
-import { usePCDCollectionWithHash, useUploadedId } from "./appHooks";
 import { StateContext } from "./dispatch";
 import {
   loadEncryptionKey,
@@ -180,16 +179,4 @@ export function useSyncE2EEStorage() {
   useEffect(() => {
     load();
   }, [load]);
-}
-
-export function useHasUploaded() {
-  const [hasUploaded, setHasUploaded] = useState<boolean | undefined>();
-  const { hash } = usePCDCollectionWithHash();
-  const uploadedId = useUploadedId();
-
-  useEffect(() => {
-    setHasUploaded(hash === uploadedId);
-  }, [hash, uploadedId]);
-
-  return hasUploaded;
 }

--- a/packages/email-pcd/src/EmailPCD.ts
+++ b/packages/email-pcd/src/EmailPCD.ts
@@ -74,7 +74,7 @@ export async function prove(args: EmailPCDArgs): Promise<EmailPCD> {
       argumentType: ArgumentTypeName.String
     },
     id: {
-      value: undefined,
+      value: args.id.value ? args.id.value + "-signature" : undefined,
       argumentType: ArgumentTypeName.String
     }
   });

--- a/packages/email-pcd/test/EmailPCD.spec.ts
+++ b/packages/email-pcd/test/EmailPCD.spec.ts
@@ -7,21 +7,25 @@ describe("EdDSA attested email should work", function () {
   this.timeout(1000 * 30);
 
   let emailPCD: EmailPCD;
+  let stableEmailPCD: EmailPCD;
+
+  // Key borrowed from https://github.com/iden3/circomlibjs/blob/4f094c5be05c1f0210924a3ab204d8fd8da69f49/test/eddsa.js#L103
+  const prvKey =
+    "0001020304050607080900010203040506070809000102030405060708090001";
+  const emailAddress = "user@test.com";
+  const semaphoreId = "12345";
+  const otherEmail = "someuser@example.com";
+  const otherSemaphoreID = "42";
+  const stableId = "attested-email-" + otherEmail;
 
   this.beforeAll(async () => {
-    // Key borrowed from https://github.com/iden3/circomlibjs/blob/4f094c5be05c1f0210924a3ab204d8fd8da69f49/test/eddsa.js#L103
-    const prvKey =
-      "0001020304050607080900010203040506070809000102030405060708090001";
-
-    const emailAddress = "user@test.com";
-
     emailPCD = await EmailPCDPackage.prove({
       emailAddress: {
         value: emailAddress,
         argumentType: ArgumentTypeName.String
       },
       semaphoreId: {
-        value: "12345",
+        value: semaphoreId,
         argumentType: ArgumentTypeName.String
       },
       privateKey: {
@@ -35,6 +39,12 @@ describe("EdDSA attested email should work", function () {
     });
   });
 
+  it("should reflect prove args", async function () {
+    expect(emailPCD.claim.emailAddress).to.eq(emailAddress);
+    expect(emailPCD.claim.semaphoreId).to.eq(semaphoreId);
+    expect(emailPCD.id).to.not.be.empty;
+  });
+
   it("should be able to create and verify a signed email", async function () {
     expect(await EmailPCDPackage.verify(emailPCD)).to.be.true;
   });
@@ -43,5 +53,67 @@ describe("EdDSA attested email should work", function () {
     const serialized = await EmailPCDPackage.serialize(emailPCD);
     const deserialized = await EmailPCDPackage.deserialize(serialized.pcd);
     expect(deserialized).to.deep.eq(emailPCD);
+  });
+
+  it("should accept stable ID", async function () {
+    stableEmailPCD = await EmailPCDPackage.prove({
+      emailAddress: {
+        value: otherEmail,
+        argumentType: ArgumentTypeName.String
+      },
+      semaphoreId: {
+        value: otherSemaphoreID,
+        argumentType: ArgumentTypeName.String
+      },
+      privateKey: {
+        value: prvKey,
+        argumentType: ArgumentTypeName.String
+      },
+      id: {
+        value: stableId,
+        argumentType: ArgumentTypeName.String
+      }
+    });
+
+    expect(stableEmailPCD.id).to.eq(stableId);
+    expect(stableEmailPCD.claim.emailAddress).to.eq(otherEmail);
+    expect(stableEmailPCD.claim.semaphoreId).to.eq(otherSemaphoreID);
+
+    const serialized = await EmailPCDPackage.serialize(stableEmailPCD);
+    const deserialized = await EmailPCDPackage.deserialize(serialized.pcd);
+    expect(deserialized).to.deep.eq(stableEmailPCD);
+  });
+
+  it("should be identical with same stable ID", async function () {
+    const stableEmailPCD2 = await EmailPCDPackage.prove({
+      emailAddress: {
+        value: otherEmail,
+        argumentType: ArgumentTypeName.String
+      },
+      semaphoreId: {
+        value: otherSemaphoreID,
+        argumentType: ArgumentTypeName.String
+      },
+      privateKey: {
+        value: prvKey,
+        argumentType: ArgumentTypeName.String
+      },
+      id: {
+        value: stableId,
+        argumentType: ArgumentTypeName.String
+      }
+    });
+
+    expect(stableEmailPCD2.id).to.eq(stableId);
+    expect(stableEmailPCD2.claim.emailAddress).to.eq(otherEmail);
+    expect(stableEmailPCD2.claim.semaphoreId).to.eq(otherSemaphoreID);
+    expect(stableEmailPCD2).to.deep.eq(stableEmailPCD);
+
+    const serialized1 = await EmailPCDPackage.serialize(stableEmailPCD);
+    const serialized2 = await EmailPCDPackage.serialize(stableEmailPCD2);
+    expect(serialized1).to.deep.eq(serialized2);
+    const deserialized1 = await EmailPCDPackage.deserialize(serialized1.pcd);
+    const deserialized2 = await EmailPCDPackage.deserialize(serialized2.pcd);
+    expect(deserialized2).to.deep.eq(deserialized1);
   });
 });

--- a/packages/pcd-collection/test/PCDFeedActions.spec.ts
+++ b/packages/pcd-collection/test/PCDFeedActions.spec.ts
@@ -1,0 +1,110 @@
+import { ArgumentTypeName, PCDPackage } from "@pcd/pcd-types";
+import { RSAPCDPackage } from "@pcd/rsa-pcd";
+import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
+import { expect } from "chai";
+import "mocha";
+import NodeRSA from "node-rsa";
+import { v4 as uuid } from "uuid";
+import {
+  PCDAction,
+  PCDActionType,
+  PCDCollection,
+  PCDPermission,
+  PCDPermissionType
+} from "../src";
+
+async function newPCD(id?: string) {
+  id = id ?? uuid();
+  const pkey = new NodeRSA({ b: 512 });
+
+  const pcd = await RSAPCDPackage.prove({
+    id: {
+      argumentType: ArgumentTypeName.String,
+      value: id
+    },
+    privateKey: {
+      argumentType: ArgumentTypeName.String,
+      value: pkey.exportKey("private")
+    },
+    signedMessage: {
+      argumentType: ArgumentTypeName.String,
+      value: `signed message ${id}`
+    }
+  });
+
+  return pcd;
+}
+
+describe("PCD Actions which simulate subscription feeds", async function () {
+  const packages: PCDPackage[] = [SemaphoreIdentityPCDPackage, RSAPCDPackage];
+  const allPermissions: PCDPermission[] = [
+    { type: PCDPermissionType.AppendToFolder, folder: "Test Folder 1" },
+    { type: PCDPermissionType.DeleteFolder, folder: "Test Folder 1" },
+    { type: PCDPermissionType.ReplaceInFolder, folder: "Test Folder 1" },
+    { type: PCDPermissionType.AppendToFolder, folder: "Test Folder 2" },
+    { type: PCDPermissionType.DeleteFolder, folder: "Test Folder 2" },
+    { type: PCDPermissionType.ReplaceInFolder, folder: "Test Folder 2" }
+  ];
+
+  const collection = new PCDCollection(packages);
+
+  const pcdList1 = await Promise.all([newPCD(), newPCD(), newPCD()]);
+  const serializedPCDs1 = await Promise.all(
+    pcdList1.map(RSAPCDPackage.serialize)
+  );
+  const pcdList2 = await Promise.all([newPCD(), newPCD(), newPCD()]);
+  const serializedPCDs2 = await Promise.all(
+    pcdList2.map(RSAPCDPackage.serialize)
+  );
+
+  const allPCDs = [...pcdList1, ...pcdList2];
+
+  const actions: PCDAction[] = [
+    {
+      type: PCDActionType.DeleteFolder,
+      folder: "Test Folder 1",
+      recursive: false
+    },
+    {
+      type: PCDActionType.ReplaceInFolder,
+      folder: "Test Folder 1",
+      pcds: serializedPCDs1
+    },
+    {
+      type: PCDActionType.DeleteFolder,
+      folder: "Test Folder 2",
+      recursive: false
+    },
+    {
+      type: PCDActionType.ReplaceInFolder,
+      folder: "Test Folder 2",
+      pcds: serializedPCDs2
+    }
+  ];
+
+  it("should execute properly", async function () {
+    const hash = await collection.getHash();
+
+    for (const action of actions) {
+      expect(await collection.tryExec(action, allPermissions)).to.be.true;
+    }
+
+    expect(collection.getAll()).to.deep.eq(allPCDs);
+
+    const hashAfterActions = await collection.getHash();
+    expect(hashAfterActions).to.not.eq(hash);
+  });
+
+  it("should be idempotent", async function () {
+    const hashAfterActions1 = await collection.getHash();
+
+    for (const action of actions) {
+      expect(await collection.tryExec(action, allPermissions)).to.be.true;
+    }
+
+    expect(collection.getAll()).to.deep.eq(allPCDs);
+
+    const hashAfterActions2 = await collection.getHash();
+    expect(hashAfterActions2).to.eq(hashAfterActions1);
+  });
+});


### PR DESCRIPTION
This fixes some of the causes behind #1073, so we should be able to do fewer unnecessary uploads, meaning fewer opportunities to clobber the user's changes.

The primary fix here is to the Email PCD.  Each time it was re-issued through feeds, it had different contents (specifically the random UUID in the embedded EdDSA signature PCD), thus causing the user's PCDs to be different and need to be uploaded.

There's also a minor fix to save the uploadedID after the initial upload on account creation, which will keep the PCDs from needing to be uploaded twice for that case.  I also deleted an unused bit of state tracking which was relying on the old uploadID format.

The rest of the changes here are enhancements to tests which I wrote during the process of tracking down the cause of the changes.  More test coverage is probably good, so I'm keeping them.