### PR TITLE
Add query param for folders

### DIFF
--- a/apps/passport-client/components/screens/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen.tsx
@@ -9,7 +9,7 @@ import React, {
   useLayoutEffect,
   useState
 } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 import { useFolders, usePCDsInFolder, useSelf } from "../../src/appHooks";
 import { useSyncE2EEStorage } from "../../src/useSyncE2EEStorage";
@@ -24,6 +24,8 @@ import { FrogFolder } from "./FrogScreens/FrogFolder";
 
 export const HomeScreen = React.memo(HomeScreenImpl);
 
+const FOLDER_QUERY_PARAM = "folder";
+
 /**
  * Show the user their Zupass, an overview of cards / PCDs.
  */
@@ -32,7 +34,10 @@ export function HomeScreenImpl() {
   const self = useSelf();
   const navigate = useNavigate();
 
-  const [browsingFolder, setBrowsingFolder] = useState("/");
+  const [searchParams, setSeachParams] = useSearchParams();
+  const [browsingFolder, setBrowsingFolder] = useState(
+    decodeURIComponent(searchParams.get(FOLDER_QUERY_PARAM)) || "/"
+  );
   const pcdsInFolder = usePCDsInFolder(browsingFolder);
   const foldersInFolder = useFolders(browsingFolder);
 
@@ -54,9 +59,13 @@ export function HomeScreenImpl() {
     }
   });
 
-  const onFolderClick = useCallback((folder: string) => {
-    setBrowsingFolder(folder);
-  }, []);
+  const onFolderClick = useCallback(
+    (folder: string) => {
+      setBrowsingFolder(folder);
+      setSeachParams({ [FOLDER_QUERY_PARAM]: encodeURIComponent(folder) });
+    },
+    [setSeachParams]
+  );
 
   const isRoot = isRootFolder(browsingFolder);
 

--- a/packages/pcd-collection/src/PCDCollection.ts
+++ b/packages/pcd-collection/src/PCDCollection.ts
@@ -96,6 +96,10 @@ export class PCDCollection {
     return getFoldersInFolder(folderPath, Object.values(this.folders));
   }
 
+  public isValidFolder(folderPath: string): boolean {
+    return Object.values(this.folders).includes(folderPath);
+  }
+
   public setPCDFolder(pcdId: string, folder: string): void {
     if (!this.hasPCDWithId(pcdId)) {
       throw new Error(`can't set folder of pcd ${pcdId} - pcd doesn't exist`);


### PR DESCRIPTION
So the current folder path persists on refresh, and we can just link people to zupass.com/#/?folder=ZuConnect to go straight to ZuConnect ticket.

<img width="586" alt="Screenshot 2023-11-02 at 10 41 37 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/798d95ca-9d0f-4fef-9357-ef3586d43a7c">
