### PR TITLE
don't report connection terminated errors to rollbar

### DIFF
--- a/apps/passport-server/src/services/rollbarService.ts
+++ b/apps/passport-server/src/services/rollbarService.ts
@@ -42,6 +42,25 @@ export class RollbarService {
       accessToken: rollbarToken,
       captureUncaught: true,
       captureUnhandledRejections: true,
+      // this method allows us to intercept 'items' that are scheduled
+      // to be uploaded to rollbar, and determine if we should ignore them
+      checkIgnore: (isUncaught, args, item): boolean => {
+        const itemAsAny = item as any;
+        const itemErrorMessage =
+          itemAsAny?.body?.trace_chain?.[0]?.exception?.message;
+
+        // for some reason, correctly-caught connection terminated errors
+        // are interpreted as uncaught by rollbar. ignore them to prevent
+        // error spam, so that we can keep tabs on legitimate errors properly.
+        if (
+          typeof itemErrorMessage === "string" &&
+          itemErrorMessage.includes("Connection terminated unexpectedly")
+        ) {
+          return true;
+        } else {
+          return false;
+        }
+      },
       environment: rollbarEnvironmentName,
       payload: {
         custom: { gitCommitHash }


### PR DESCRIPTION
closes https://github.com/proofcarryingdata/zupass/issues/967

#### comment

I know this is not ideal, and we should really get to the bottom of why these errors are being reported when they shouldn't, but I am inclined to just move on. otherwise, rollbar is useless without us doing something about this.