### PR TITLE
Defer initialization of default subscriptions

### DIFF
--- a/apps/passport-client/src/defaultSubscriptions.ts
+++ b/apps/passport-client/src/defaultSubscriptions.ts
@@ -2,7 +2,7 @@ import {
   FeedSubscriptionManager,
   Subscription,
   ZupassFeedIds,
-  zupassDefaultSubscriptions
+  getZupassDefaultSubscriptions
 } from "@pcd/passport-interface";
 import { appConfig } from "../src/appConfig";
 
@@ -28,7 +28,7 @@ export async function addDefaultSubscriptions(
   if (!subscriptions.hasProvider(DEFAULT_FEED_URL)) {
     subscriptions.addProvider(DEFAULT_FEED_URL, DEFAULT_FEED_PROVIDER_NAME);
   }
-
+  const zupassDefaultSubscriptions = getZupassDefaultSubscriptions();
   for (const id in zupassDefaultSubscriptions) {
     subscriptions.subscribe(
       DEFAULT_FEED_URL,

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -40,8 +40,8 @@ import {
   ZUZALU_23_VISITOR_PRODUCT_ID,
   ZupassFeedIds,
   ZuzaluUserRole,
-  verifyFeedCredential,
-  zupassDefaultSubscriptions
+  getZupassDefaultSubscriptions,
+  verifyFeedCredential
 } from "@pcd/passport-interface";
 import {
   PCDAction,
@@ -144,6 +144,8 @@ export class IssuanceService {
     this.verificationPromiseCache = new LRUCache<string, Promise<boolean>>({
       max: 1000
     });
+
+    const zupassDefaultSubscriptions = getZupassDefaultSubscriptions();
 
     const zupassFeedHost = new FeedHost(
       [

--- a/packages/passport-interface/src/ZupassDefaultSubscriptions.ts
+++ b/packages/passport-interface/src/ZupassDefaultSubscriptions.ts
@@ -1,107 +1,111 @@
 import { PCDPermissionType } from "@pcd/pcd-collection";
 import { Feed, ZupassFeedIds } from "./SubscriptionManager";
 
-export const zupassDefaultSubscriptions: Record<
-  | ZupassFeedIds.Devconnect
-  | ZupassFeedIds.Email
-  | ZupassFeedIds.Zuzalu_23
-  | ZupassFeedIds.Zuconnect_23,
-  Feed
-> = {
-  [ZupassFeedIds.Zuzalu_23]: {
-    id: ZupassFeedIds.Zuzalu_23,
-    name: "Zuzalu tickets",
-    description: "Your Zuzalu Tickets",
-    partialArgs: undefined,
-    credentialRequest: {
-      signatureType: "sempahore-signature-pcd"
+export function getZupassDefaultSubscriptions() {
+  const zupassDefaultSubscriptions: Record<
+    | ZupassFeedIds.Devconnect
+    | ZupassFeedIds.Email
+    | ZupassFeedIds.Zuzalu_23
+    | ZupassFeedIds.Zuconnect_23,
+    Feed
+  > = {
+    [ZupassFeedIds.Zuzalu_23]: {
+      id: ZupassFeedIds.Zuzalu_23,
+      name: "Zuzalu tickets",
+      description: "Your Zuzalu Tickets",
+      partialArgs: undefined,
+      credentialRequest: {
+        signatureType: "sempahore-signature-pcd"
+      },
+      permissions: [
+        {
+          folder: "Zuzalu '23",
+          type: PCDPermissionType.DeleteFolder
+        },
+        {
+          folder: "Zuzalu '23",
+          type: PCDPermissionType.ReplaceInFolder
+        }
+      ]
     },
-    permissions: [
-      {
-        folder: "Zuzalu '23",
-        type: PCDPermissionType.DeleteFolder
+    [ZupassFeedIds.Devconnect]: {
+      id: ZupassFeedIds.Devconnect,
+      name: "Devconnect Tickets",
+      description: "Get your Devconnect tickets here!",
+      partialArgs: undefined,
+      credentialRequest: {
+        signatureType: "sempahore-signature-pcd"
       },
-      {
-        folder: "Zuzalu '23",
-        type: PCDPermissionType.ReplaceInFolder
-      }
-    ]
-  },
-  [ZupassFeedIds.Devconnect]: {
-    id: ZupassFeedIds.Devconnect,
-    name: "Devconnect Tickets",
-    description: "Get your Devconnect tickets here!",
-    partialArgs: undefined,
-    credentialRequest: {
-      signatureType: "sempahore-signature-pcd"
+      permissions: [
+        {
+          folder: "Devconnect",
+          type: PCDPermissionType.AppendToFolder
+        },
+        {
+          folder: "Devconnect",
+          type: PCDPermissionType.ReplaceInFolder
+        },
+        {
+          folder: "Devconnect",
+          type: PCDPermissionType.DeleteFolder
+        },
+        {
+          folder: "SBC SRW",
+          type: PCDPermissionType.AppendToFolder
+        },
+        {
+          folder: "SBC SRW",
+          type: PCDPermissionType.ReplaceInFolder
+        },
+        {
+          folder: "SBC SRW",
+          type: PCDPermissionType.DeleteFolder
+        }
+      ]
     },
-    permissions: [
-      {
-        folder: "Devconnect",
-        type: PCDPermissionType.AppendToFolder
+    [ZupassFeedIds.Email]: {
+      id: ZupassFeedIds.Email,
+      name: "Zupass Verified Emails",
+      description: "Emails verified by Zupass",
+      partialArgs: undefined,
+      credentialRequest: {
+        signatureType: "sempahore-signature-pcd"
       },
-      {
-        folder: "Devconnect",
-        type: PCDPermissionType.ReplaceInFolder
-      },
-      {
-        folder: "Devconnect",
-        type: PCDPermissionType.DeleteFolder
-      },
-      {
-        folder: "SBC SRW",
-        type: PCDPermissionType.AppendToFolder
-      },
-      {
-        folder: "SBC SRW",
-        type: PCDPermissionType.ReplaceInFolder
-      },
-      {
-        folder: "SBC SRW",
-        type: PCDPermissionType.DeleteFolder
-      }
-    ]
-  },
-  [ZupassFeedIds.Email]: {
-    id: ZupassFeedIds.Email,
-    name: "Zupass Verified Emails",
-    description: "Emails verified by Zupass",
-    partialArgs: undefined,
-    credentialRequest: {
-      signatureType: "sempahore-signature-pcd"
+      permissions: [
+        {
+          folder: "Email",
+          type: PCDPermissionType.DeleteFolder
+        },
+        {
+          folder: "Email",
+          type: PCDPermissionType.ReplaceInFolder
+        }
+      ]
     },
-    permissions: [
-      {
-        folder: "Email",
-        type: PCDPermissionType.DeleteFolder
+    [ZupassFeedIds.Zuconnect_23]: {
+      id: ZupassFeedIds.Zuconnect_23,
+      name: "Zuconnect tickets",
+      description: "Your Zuconnect Tickets",
+      partialArgs: undefined,
+      credentialRequest: {
+        signatureType: "sempahore-signature-pcd"
       },
-      {
-        folder: "Email",
-        type: PCDPermissionType.ReplaceInFolder
-      }
-    ]
-  },
-  [ZupassFeedIds.Zuconnect_23]: {
-    id: ZupassFeedIds.Zuconnect_23,
-    name: "Zuconnect tickets",
-    description: "Your Zuconnect Tickets",
-    partialArgs: undefined,
-    credentialRequest: {
-      signatureType: "sempahore-signature-pcd"
-    },
-    permissions: [
-      {
-        folder: "Zuconnect",
-        type: PCDPermissionType.DeleteFolder
-      },
-      {
-        folder: "ZuConnect",
-        type: PCDPermissionType.DeleteFolder
-      },
-      {
-        folder: "ZuConnect",
-        type: PCDPermissionType.ReplaceInFolder
-      }
-    ]
-  }
-};
+      permissions: [
+        {
+          folder: "Zuconnect",
+          type: PCDPermissionType.DeleteFolder
+        },
+        {
+          folder: "ZuConnect",
+          type: PCDPermissionType.DeleteFolder
+        },
+        {
+          folder: "ZuConnect",
+          type: PCDPermissionType.ReplaceInFolder
+        }
+      ]
+    }
+  };
+
+  return zupassDefaultSubscriptions;
+}


### PR DESCRIPTION
This _might_ be part of the problem that comes up when importing `passport-interface` - something to do with the enums from `pcd-collection` not being set up at the point where they're being used in `passport-interface`.