### PR TITLE
[frogcrypto] wire frog folders

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
@@ -229,7 +229,7 @@ function feedParser(data: string): FrogCryptoDbFeedData[] {
         name: rawFeed.name,
         description: rawFeed.description,
         private: Boolean(rawFeed.private),
-        activeUntil: new Date(rawFeed.activeUntil).getTime(),
+        activeUntil: Math.round(new Date(rawFeed.activeUntil).getTime() / 1000),
         cooldown: Number.parseInt(rawFeed.cooldown),
         biomes: parseBiomes(rawFeed)
       }
@@ -256,7 +256,7 @@ function feedUnparser(feeds: FrogCryptoDbFeedData[]): string {
       name: feed.feed.name,
       description: feed.feed.description,
       private: feed.feed.private,
-      activeUntil: feed.feed.activeUntil,
+      activeUntil: new Date(feed.feed.activeUntil * 1000).toISOString(),
       cooldown: feed.feed.cooldown,
       ...Object.keys(Biome).reduce(
         (acc, biome) => {
@@ -321,7 +321,7 @@ export function DataTable({
           if (!activeUntil) {
             return "<undefined>";
           }
-          const duration = activeUntil - Date.now();
+          const duration = activeUntil * 1000 - Date.now();
 
           return (
             <div>
@@ -331,7 +331,7 @@ export function DataTable({
               </p>
               <p>
                 <b>Date: </b>
-                {new Date(activeUntil).toISOString()}
+                {new Date(activeUntil * 1000).toISOString()}
               </p>
               {duration > 0 ? (
                 <p>

--- a/apps/passport-client/components/screens/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen.tsx
@@ -1,3 +1,4 @@
+import { FrogCryptoFolderName } from "@pcd/passport-interface";
 import {
   getNameFromPath,
   getParentFolder,
@@ -19,6 +20,7 @@ import {
   useSelf
 } from "../../src/appHooks";
 import { useSyncE2EEStorage } from "../../src/useSyncE2EEStorage";
+import { isFrogCryptoFolder } from "../../src/util";
 import { Placeholder, Spacer } from "../core";
 import { icons } from "../icons";
 import { MaybeModal } from "../modals/Modal";
@@ -27,6 +29,7 @@ import { AppHeader } from "../shared/AppHeader";
 import { LoadingIssuedPCDs } from "../shared/LoadingIssuedPCDs";
 import { PCDCardList } from "../shared/PCDCardList";
 import { FrogFolder } from "./FrogScreens/FrogFolder";
+import { FrogHomeSection } from "./FrogScreens/FrogHomeSection";
 
 export const HomeScreen = React.memo(HomeScreenImpl);
 
@@ -92,6 +95,7 @@ export function HomeScreenImpl() {
   }, []);
 
   const isRoot = isRootFolder(browsingFolder);
+  const isFrogCrypto = isFrogCryptoFolder(browsingFolder);
 
   // scroll to top when we navigate to this page
   useLayoutEffect(() => {
@@ -118,6 +122,10 @@ export function HomeScreenImpl() {
                 />
               )}
               {foldersInFolder
+                .filter(
+                  // /FrogCrypto is a special and rendered by <FrogFolder />
+                  (folder) => folder !== FrogCryptoFolderName
+                )
                 .sort((a, b) => a.localeCompare(b))
                 .map((folder) => {
                   return (
@@ -128,17 +136,26 @@ export function HomeScreenImpl() {
                     />
                   );
                 })}
-              <FrogFolder
-                folder={browsingFolder}
-                Container={FolderEntryContainer}
-              />
+              {isRoot && (
+                <FrogFolder
+                  Container={FolderEntryContainer}
+                  onFolderClick={onFolderClick}
+                />
+              )}
             </FolderExplorerContainer>
           )}
-          {!(foldersInFolder.length === 0 && isRoot) && <Separator />}
-          {pcdsInFolder.length > 0 ? (
-            <PCDCardList pcds={pcdsInFolder} />
+
+          {isFrogCrypto ? (
+            <FrogHomeSection />
           ) : (
-            <NoPcdsContainer>This folder has no PCDs</NoPcdsContainer>
+            <>
+              {!(foldersInFolder.length === 0 && isRoot) && <Separator />}
+              {pcdsInFolder.length > 0 ? (
+                <PCDCardList pcds={pcdsInFolder} />
+              ) : (
+                <NoPcdsContainer>This folder has no PCDs</NoPcdsContainer>
+              )}
+            </>
           )}
           <LoadingIssuedPCDs />
         </Placeholder>

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -15,7 +15,6 @@ import { AddSubscriptionScreen } from "../components/screens/AddSubscriptionScre
 import { ChangePasswordScreen } from "../components/screens/ChangePasswordScreen";
 import { DevconnectCheckinByIdScreen } from "../components/screens/DevconnectCheckinByIdScreen";
 import { EnterConfirmationCodeScreen } from "../components/screens/EnterConfirmationCodeScreen";
-import { FrogHomeScreen } from "../components/screens/FrogScreens/FrogHomeScreen";
 import { FrogManagerScreen } from "../components/screens/FrogScreens/FrogManagerScreen";
 import { GetWithoutProvingScreen } from "../components/screens/GetWithoutProvingScreen";
 import { HaloScreen } from "../components/screens/HaloScreen/HaloScreen";
@@ -346,7 +345,6 @@ function RouterImpl() {
           <Route path="subscriptions" element={<SubscriptionsScreen />} />
           <Route path="add-subscription" element={<AddSubscriptionScreen />} />
           <Route path="telegram" element={<HomeScreen />} />
-          <Route path="frog" element={<FrogHomeScreen />} />
           <Route path="frog-admin" element={<FrogManagerScreen />} />
           <Route path="*" element={<MissingScreen />} />
         </Route>

--- a/apps/passport-client/src/util.ts
+++ b/apps/passport-client/src/util.ts
@@ -1,3 +1,5 @@
+import { FrogCryptoFolderName } from "@pcd/passport-interface";
+import { splitPath } from "@pcd/pcd-collection";
 import { sleep } from "@pcd/util";
 import validator from "email-validator";
 import { v4 as uuid } from "uuid";
@@ -82,4 +84,12 @@ export function maybeRedirect(text: string): string | null {
     return hash;
   }
   return null;
+}
+
+/**
+ * Check if a folder path is a FrogCrypto (sub)folder.
+ */
+export function isFrogCryptoFolder(folderPath: string): boolean {
+  const parts = splitPath(folderPath);
+  return parts[0] === FrogCryptoFolderName;
 }

--- a/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
+++ b/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
@@ -94,7 +94,12 @@ export function initFrogcryptoRoutes(
 
     req
       .pipe(
-        request(urljoin(process.env.FROGCRYPTO_ASSETS_URL, `${imageId}.png`))
+        request(
+          urljoin(process.env.FROGCRYPTO_ASSETS_URL, `${imageId}.png`)
+        ).on("error", (err) => {
+          logger(`[FrogCrypto] Error fetching FrogCrypto Assets: ${err}`);
+          throw new PCDHTTPError(503, "FrogCrypto Assets Unavailable");
+        })
       )
       .pipe(res);
   });

--- a/packages/passport-interface/src/FrogCrypto.ts
+++ b/packages/passport-interface/src/FrogCrypto.ts
@@ -36,11 +36,9 @@ export type FrogCryptoFeedBiomeConfigs = z.infer<
 >;
 
 /**
- * FrogCrypto specific feed configurations
- *
- * Note: It is important to ensure that the feed cannot be discovered by guessing the {@link Feed#id}
+ * Schema for FrogCrypto specific feed interface
  */
-export interface FrogCryptoFeed extends Feed<typeof EdDSAFrogPCDPackage> {
+export const IFrogCryptoFeedSchema = z.object({
   /**
    * Whether this feed is discoverable in GET /feeds
    *
@@ -48,23 +46,31 @@ export interface FrogCryptoFeed extends Feed<typeof EdDSAFrogPCDPackage> {
    * as long as the user knows the feed ID.
    * @default false
    */
-  private: boolean;
+  private: z.boolean(),
   /**
    * Unix timestamp in seconds of when this feed will become inactive
    *
    * PCD can only be issued from this feed if it is active
    * @default 0 means the feed is inactive
    */
-  activeUntil: number;
+  activeUntil: z.number().nonnegative().int(),
   /**
    * How long to wait between each PCD issuance in seconds
    */
-  cooldown: number;
+  cooldown: z.number().nonnegative().int(),
   /**
    * Map of configs for Biome(s) where PCDs can be issued from this feed
    */
-  biomes: FrogCryptoFeedBiomeConfigs;
-}
+  biomes: FrogCryptoFeedBiomeConfigsSchema
+});
+
+/**
+ * FrogCrypto specific feed configuration
+ *
+ * Note: It is important to ensure that the feed cannot be discovered by guessing the {@link Feed#id}
+ */
+export type FrogCryptoFeed = Feed<typeof EdDSAFrogPCDPackage> &
+  z.infer<typeof IFrogCryptoFeedSchema>;
 
 /**
  * DB schema for feed data


### PR DESCRIPTION
https://github.com/proofcarryingdata/zupass/issues/1057

Wire FrogCrypto Folder to home screen
* Set up a temporary poll in FrogCryptoFolder to check if the game is on
* If the game is on, click on Frog folder navigates
* Otherwise, render the hard coded countdown (we will update countdown when we finalize our launch plan)
* Replace in-line toast with toast box
* Fix a bug where feed admin page didn't convert activeUntil to second even though it is seconds everywhere else


Testing procedure

Unsubscribe from all Frogs subscription, Turn all feeds to private (or delete all feeds in db)

<img width="533" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/9b90d004-42f7-4eaf-8368-e8ef94130ddc">

Set feeds to public and activeUntil in the future

<img width="527" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/11dae96a-faf8-49b9-a16b-d6601bda0796">

Click reveal game

<img width="536" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/6cc52eab-735b-428b-976f-ef8ef2a9fd0f">

<img width="632" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/e6d9f028-4e21-41f0-a945-f2dc7c479fc0">

Turn feed back to private, game still on

<img width="533" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/060ceef5-fd66-4db4-b6a4-9bbe80718ef9">

Unsub, game becomes off

<img width="456" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/9ce5896b-75bb-4810-a476-9b4b425948f7">


