### PR TITLE
[frogcrypto] surface user friendly frog feed error

### DIFF
--- a/apps/passport-client/components/shared/AppContainer.tsx
+++ b/apps/passport-client/components/shared/AppContainer.tsx
@@ -31,7 +31,18 @@ export function AppContainer({
       <GlobalBackground color={col} />
       <Background>
         <Container>
-          {children && <Toaster />}
+          {children && (
+            <Toaster
+              toastOptions={{
+                success: {
+                  duration: 5000
+                },
+                error: {
+                  duration: 8000
+                }
+              }}
+            />
+          )}
           {children ?? <ScreenLoader text="Zupass" />}
           {error && <ErrorPopup error={error} onClose={onClose} />}
         </Container>

--- a/apps/passport-server/test/frogcryptodb.spec.ts
+++ b/apps/passport-server/test/frogcryptodb.spec.ts
@@ -90,7 +90,7 @@ describe("database reads and writes for frogcrypto features", function () {
 
   step("sample a frog from weighted biomes", async function () {
     const frogs = await Promise.all(
-      _.range(0, 100).map(() =>
+      _.range(0, 1000).map(() =>
         sampleFrogData(db, {
           TheCapital: { dropWeightScaler: 100 },
           Desert: { dropWeightScaler: 0.01 },
@@ -99,10 +99,10 @@ describe("database reads and writes for frogcrypto features", function () {
       )
     );
 
-    // sample 100 frogs with Capital frog expect to show up 99.98% chance each time. there is < 1e-14 chance for non capital frog to show up more than seven times
+    // sample 1000 frogs with Capital frog expect to show up 99.98% chance each time. there is < 1e-14 chance for non capital frog to show up more than 10 times
     expect(
       frogs.filter((frog) => frog?.biome === "The Capital").length
-    ).to.be.greaterThanOrEqual(93);
+    ).to.be.greaterThanOrEqual(990);
   });
 
   step("return undefined if there is no frog to sample", async function () {

--- a/packages/passport-interface/src/RequestTypes.ts
+++ b/packages/passport-interface/src/RequestTypes.ts
@@ -697,8 +697,10 @@ export interface OfflineDevconnectTicket {
 }
 
 /**
- * User asks metadata about themselves such as when they can get next frog and
- * how many frogs in Frogedex.
+ * User requests about
+ * 1. for the feeds they are subscribed to, when they can get next frog and
+ *    whether it is active
+ * 2. how many frogs in Frogedex
  *
  * NB: The number of possible frogs are currently not user specific. It is
  * possible that we will introduce series unlock in the future where the number
@@ -706,6 +708,7 @@ export interface OfflineDevconnectTicket {
  */
 export interface FrogCryptoUserStateRequest {
   pcd: SerializedPCD<SemaphoreSignaturePCD>;
+  feedIds: string[];
 }
 
 /**

--- a/packages/passport-interface/src/SubscriptionManager.ts
+++ b/packages/passport-interface/src/SubscriptionManager.ts
@@ -165,7 +165,8 @@ export class FeedSubscriptionManager {
       });
     } catch (e) {
       this.setError(subscription.id, {
-        type: SubscriptionErrorType.FetchError
+        type: SubscriptionErrorType.FetchError,
+        e: e instanceof Error ? e : undefined
       });
     }
 
@@ -476,6 +477,7 @@ export interface SubscriptionPermissionError {
 
 export interface SubscriptionFetchError {
   type: SubscriptionErrorType.FetchError;
+  e: Error | undefined;
 }
 
 export type SubscriptionError =

--- a/packages/passport-interface/src/api/requestFrogCryptoGetUserState.ts
+++ b/packages/passport-interface/src/api/requestFrogCryptoGetUserState.ts
@@ -32,7 +32,8 @@ export async function requestFrogCryptoGetUserState(
 export async function frogCryptoGetUserState(
   zupassServerUrl: string,
   identity: Identity,
-  signedMessage: string
+  signedMessage: string,
+  feedIds: string[]
 ): Promise<FrogCryptoUserStateResult> {
   return requestFrogCryptoGetUserState(zupassServerUrl, {
     pcd: await SemaphoreSignaturePCDPackage.serialize(
@@ -50,7 +51,8 @@ export async function frogCryptoGetUserState(
           value: signedMessage
         }
       })
-    )
+    ),
+    feedIds
   });
 }
 


### PR DESCRIPTION
fixes https://github.com/proofcarryingdata/zupass/issues/1143
https://github.com/proofcarryingdata/zupass/issues/1057

Smoothly hopping various expected/unexpected errors
* Surface whether feed is `active` in user state endpoint. 
    * While we have the same information in `/feed/:feedId`, it's much easier for the frontend to be able to pull them by batch
    * We need to pass a list of feed ids to this endpoint so that we can return information about private feeds that user have subscribed to but not yet fetched thus has a feed state in the database.
* handle feed polling error by saving and consuming feed error using subscription manager

updated the tests to cover new behavior

get a frog with some cooldown (e.g. 60s), immediately turn up the feed cooldown way up  (e.g. 600s), try to get frog again to trigger the cooldown message
<img width="520" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/c7555194-638c-4d78-9d07-e85fb5245ef4">

ready to get a frog on ui, turn feed to inactive at the backend, try get frog to get feed vanished message
<img width="480" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/9e1ba907-2dba-48e9-bca5-fe18aef8f65c">

turn all feeds to inactive
<img width="499" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/f31c56b7-0fd2-413f-ac84-6879a3b8c053">

If for some unexpected reason, no public feeds are found when user initiates the experience "light fire"
<img width="520" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/d329362d-69be-4d9c-b057-5bd78897a142">


