### PR TITLE
Track server-storage-hash persistently to avoid extra uploads

### DIFF
--- a/apps/passport-client/components/modals/RequireAddPasswordModal.tsx
+++ b/apps/passport-client/components/modals/RequireAddPasswordModal.tsx
@@ -1,7 +1,7 @@
 import { sleep } from "@pcd/util";
 import { useCallback, useState } from "react";
 import styled from "styled-components";
-import { useDispatch, useSelf } from "../../src/appHooks";
+import { useDispatch, useSelf, useUpdate } from "../../src/appHooks";
 import { loadEncryptionKey } from "../../src/localstorage";
 import { setPassword } from "../../src/password";
 import { BigInput, H2, Spacer } from "../core";
@@ -15,6 +15,7 @@ import { ScreenLoader } from "../shared/ScreenLoader";
 export function RequireAddPasswordModal() {
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();
+  const update = useUpdate();
   const self = useSelf();
 
   const [newPassword, setNewPassword] = useState("");
@@ -28,7 +29,7 @@ export function RequireAddPasswordModal() {
     await sleep();
     try {
       const currentEncryptionKey = loadEncryptionKey();
-      await setPassword(newPassword, currentEncryptionKey, dispatch);
+      await setPassword(newPassword, currentEncryptionKey, dispatch, update);
 
       dispatch({
         type: "set-modal",
@@ -39,7 +40,7 @@ export function RequireAddPasswordModal() {
     } finally {
       setLoading(false);
     }
-  }, [loading, newPassword, dispatch]);
+  }, [loading, newPassword, dispatch, update]);
 
   if (loading) {
     return <ScreenLoader text="Adding your password..." />;

--- a/apps/passport-client/components/modals/UpgradeAccountModal.tsx
+++ b/apps/passport-client/components/modals/UpgradeAccountModal.tsx
@@ -40,7 +40,7 @@ export function UpgradeAccountModal() {
     } finally {
       setLoading(false);
     }
-  }, [loading, newPassword, dispatch]);
+  }, [loading, newPassword, dispatch, update]);
 
   if (loading) {
     return <ScreenLoader text="Adding your password..." />;

--- a/apps/passport-client/components/modals/UpgradeAccountModal.tsx
+++ b/apps/passport-client/components/modals/UpgradeAccountModal.tsx
@@ -1,7 +1,7 @@
 import { sleep } from "@pcd/util";
 import { useCallback, useState } from "react";
 import styled from "styled-components";
-import { useDispatch, useSelf } from "../../src/appHooks";
+import { useDispatch, useSelf, useUpdate } from "../../src/appHooks";
 import { loadEncryptionKey } from "../../src/localstorage";
 import { setPassword } from "../../src/password";
 import { BigInput, H2, Spacer } from "../core";
@@ -15,6 +15,7 @@ import { ScreenLoader } from "../shared/ScreenLoader";
 export function UpgradeAccountModal() {
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();
+  const update = useUpdate();
   const self = useSelf();
 
   const [newPassword, setNewPassword] = useState("");
@@ -28,7 +29,7 @@ export function UpgradeAccountModal() {
     await sleep();
     try {
       const currentEncryptionKey = loadEncryptionKey();
-      await setPassword(newPassword, currentEncryptionKey, dispatch);
+      await setPassword(newPassword, currentEncryptionKey, dispatch, update);
 
       dispatch({
         type: "set-modal",

--- a/apps/passport-client/components/screens/ChangePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/ChangePasswordScreen.tsx
@@ -3,7 +3,12 @@ import { requestPasswordSalt } from "@pcd/passport-interface";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { appConfig } from "../../src/appConfig";
-import { useDispatch, useHasSetupPassword, useSelf } from "../../src/appHooks";
+import {
+  useDispatch,
+  useHasSetupPassword,
+  useSelf,
+  useUpdate
+} from "../../src/appHooks";
 import { loadEncryptionKey } from "../../src/localstorage";
 import { setPassword } from "../../src/password";
 import { CenterColumn, H2, HR, Spacer, TextCenter } from "../core";
@@ -22,6 +27,7 @@ export function ChangePasswordScreen() {
   // after a password is set for the first time.
   const [isChangePassword] = useState(hasSetupPassword);
   const dispatch = useDispatch();
+  const update = useUpdate();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [currentPassword, setCurrentPassword] = useState("");
@@ -60,7 +66,7 @@ export function ChangePasswordScreen() {
           saltResult.value
         );
       }
-      await setPassword(newPassword, currentEncryptionKey, dispatch);
+      await setPassword(newPassword, currentEncryptionKey, dispatch, update);
 
       setFinished(true);
 

--- a/apps/passport-client/components/screens/ChangePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/ChangePasswordScreen.tsx
@@ -80,6 +80,7 @@ export function ChangePasswordScreen() {
     currentPassword,
     newPassword,
     dispatch,
+    update,
     loading,
     self.email,
     isChangePassword

--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -39,6 +39,7 @@
     "broadcast-channel": "^5.3.0",
     "dotenv": "^16.0.3",
     "email-validator": "^2.0.4",
+    "fast-json-stable-stringify": "^2.1.0",
     "handlebars": "^4.7.7",
     "isomorphic-timers-promises": "^1.0.1",
     "lodash": "^4.17.21",

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -417,7 +417,8 @@ async function loadInitialState(): Promise<AppState> {
     offlineTickets,
     checkedinOfflineDevconnectTickets: checkedInOfflineDevconnectTickets,
     offline: !window.navigator.onLine,
-    serverStorageRevision: persistentSyncStatus.serverStorageRevision
+    serverStorageRevision: persistentSyncStatus.serverStorageRevision,
+    serverStorageHash: persistentSyncStatus.serverStorageHash
   };
 }
 

--- a/apps/passport-client/src/appHooks.ts
+++ b/apps/passport-client/src/appHooks.ts
@@ -10,7 +10,12 @@ import { PCD } from "@pcd/pcd-types";
 import { Identity } from "@semaphore-protocol/identity";
 import { useContext, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Dispatcher, StateContext, StateContextValue } from "./dispatch";
+import {
+  Dispatcher,
+  StateContext,
+  StateContextValue,
+  ZuUpdate
+} from "./dispatch";
 import { loadUsingLaserScanner } from "./localstorage";
 import { AppError, AppState } from "./state";
 import { useSelector } from "./subscribe";
@@ -67,6 +72,11 @@ export function useIdentity(): Identity {
 export function useDispatch(): Dispatcher {
   const { dispatch } = useContext(StateContext);
   return dispatch;
+}
+
+export function useUpdate(): ZuUpdate {
+  const { update } = useContext(StateContext);
+  return update;
 }
 
 export function useIsOffline(): boolean {
@@ -131,10 +141,6 @@ export function useIsSyncSettled(): boolean {
 
 export function useIsLoggedIn(): boolean {
   return useSelector<boolean | undefined>((s) => s.self !== undefined, []);
-}
-
-export function useUploadedId(): string | undefined {
-  return useSelector<string | undefined>((s) => s.uploadedUploadId, []);
 }
 
 export function useResolvingSubscriptionId(): string | undefined {

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -5,12 +5,12 @@ import {
   CredentialManager,
   deserializeStorage,
   Feed,
-  FeedSubscriptionManager,
   KnownTicketTypesAndKeys,
   LATEST_PRIVACY_NOTICE,
   requestCreateNewUser,
   requestLogToServer,
   requestUser,
+  serializeStorage,
   StorageWithRevision,
   User
 } from "@pcd/passport-interface";
@@ -46,7 +46,11 @@ import { getPackages } from "./pcdPackages";
 import { hasPendingRequest } from "./sessionStorage";
 import { AppError, AppState, GetState, StateEmitter } from "./state";
 import { hasSetupPassword } from "./user";
-import { downloadStorage, uploadStorage } from "./useSyncE2EEStorage";
+import {
+  downloadStorage,
+  uploadSerializedStorage,
+  uploadStorage
+} from "./useSyncE2EEStorage";
 import { assertUnreachable } from "./util";
 
 export type Dispatcher = (action: Action) => void;
@@ -358,11 +362,10 @@ async function finishAccountCreation(
     state.subscriptions
   );
   if (uploadResult.success) {
-    const uploadId = await makeUploadId(state.pcds, state.subscriptions);
     update({
       modal: { modalType: "none" },
-      uploadedUploadId: uploadId,
-      serverStorageRevision: uploadResult.value.revision
+      serverStorageRevision: uploadResult.value.revision,
+      serverStorageHash: uploadResult.value.storageHash
     });
   }
 
@@ -490,7 +493,7 @@ async function loadAfterLogin(
   storage: StorageWithRevision,
   update: ZuUpdate
 ) {
-  const { pcds, subscriptions } = await deserializeStorage(
+  const { pcds, subscriptions, storageHash } = await deserializeStorage(
     storage.storage,
     await getPackages()
   );
@@ -530,7 +533,10 @@ async function loadAfterLogin(
 
   await savePCDs(pcds);
   await saveSubscriptions(subscriptions);
-  savePersistentSyncStatus({ serverStorageRevision: storage.revision });
+  savePersistentSyncStatus({
+    serverStorageRevision: storage.revision,
+    serverStorageHash: storageHash
+  });
   saveEncryptionKey(encryptionKey);
   saveSelf(userResponse.value);
   saveIdentity(identityPCD.claim.identity);
@@ -538,7 +544,9 @@ async function loadAfterLogin(
   update({
     encryptionKey,
     pcds,
+    subscriptions,
     serverStorageRevision: storage.revision,
+    serverStorageHash: storageHash,
     identity: identityPCD.claim.identity,
     self: userResponse.value,
     modal
@@ -575,7 +583,7 @@ async function saveNewPasswordAndBroadcast(
   saveSelf(newSelf);
   saveEncryptionKey(newEncryptionKey);
   notifyPasswordChangeToOtherTabs();
-  return update({
+  update({
     encryptionKey: newEncryptionKey,
     self: newSelf
   });
@@ -593,13 +601,6 @@ function anotherDeviceChangedPassword(update: ZuUpdate) {
     anotherDeviceChangedPassword: true,
     modal: { modalType: "another-device-changed-password" }
   });
-}
-
-async function makeUploadId(
-  pcds: PCDCollection,
-  subscriptions: FeedSubscriptionManager
-): Promise<string> {
-  return `${await pcds.getHash()}-${await subscriptions.getHash()}`;
 }
 
 /**
@@ -687,21 +688,13 @@ async function doSync(
     // on the last revision we downloaded.
     const dlRes = await downloadStorage(state.serverStorageRevision);
     if (dlRes.success && dlRes.value != null) {
-      const { pcds, subscriptions, revision } = dlRes.value;
-
-      // Calculating this ID tracks that there's no need to upload what we
-      // just downloaded, which reduces unnecessary revision conflicts.
-      // TODO(artwyman): Tracking the "dirty" state corresponding to this
-      // variable in local storage would allow us to avoid unnecessary
-      // uploads even when download is skipped.
-      const uploadedUploadId = await makeUploadId(pcds, subscriptions);
-
+      const { pcds, subscriptions, revision, storageHash } = dlRes.value;
       return {
         downloadedPCDs: true,
-        uploadedUploadId,
         pcds,
         subscriptions,
         serverStorageRevision: revision,
+        serverStorageHash: storageHash,
         extraDownloadRequested: false
       };
     } else {
@@ -752,22 +745,25 @@ async function doSync(
     };
   }
 
-  // Generate an upload ID from the state of PCDs and subscriptions.
-  // Upload only if the ID is different, meaning changes to upload.
-  const uploadId = await makeUploadId(state.pcds, state.subscriptions);
-  if (state.uploadedUploadId !== uploadId) {
+  // Generate a hash from our in-memory state.  Upload only if the hash is
+  // different, meaning there are some changes to upload.
+  const appStorage = await serializeStorage(
+    state.self,
+    state.pcds,
+    state.subscriptions
+  );
+  if (state.serverStorageHash !== appStorage.storageHash) {
     console.log("[SYNC] sync action: upload");
-    // TODO(artwyman): Add serverStorageRevision input here, but only after
-    // we're able to respond to a conflict by downloading.
-    const upRes = await uploadStorage(
-      state.self,
-      state.pcds,
-      state.subscriptions
+    // TODO(artwyman): Add serverStorageRevision input as knownRevision here,
+    // but only after we're able to respond to a conflict by downloading.
+    const upRes = await uploadSerializedStorage(
+      appStorage.serializedStorage,
+      appStorage.storageHash
     );
     if (upRes.success) {
       return {
-        uploadedUploadId: uploadId,
-        serverStorageRevision: upRes.value.revision
+        serverStorageRevision: upRes.value.revision,
+        serverStorageHash: upRes.value.storageHash
       };
     } else {
       return {

--- a/apps/passport-client/src/localstorage.ts
+++ b/apps/passport-client/src/localstorage.ts
@@ -152,11 +152,20 @@ export function savePrivacyNoticeAgreed(version: number): void {
 const PersistentSyncStatusSchema = z.object({
   /**
    * Represents the most recent revision returned by the server when
-   * downloading E2EE storage.  Should change once that download has been
-   * integrated and saved into local storage.  Can be used to detect changes
-   * on future download, and conflicts on future upload.
+   * downloading or uploading E2EE storage.  Should change in local storage
+   * after upload is complete, or once that download has been integrated and
+   * saved into local storage.  Can be used to allow the server to detect
+   * changes on future download, and conflicts on future upload.
    */
-  serverStorageRevision: z.string().optional()
+  serverStorageRevision: z.string().optional(),
+
+  /**
+   * The client-calculated hash of the most recent storage uploaded to or
+   * downloaded from the server.  Should always correspond to the same contents
+   * as serverStorage Revision.  Can be used by the client to know whether
+   * its local state has changed since it was last in sync with the server.
+   */
+  serverStorageHash: z.string().optional()
 });
 export type PersistentSyncStatus = z.infer<typeof PersistentSyncStatusSchema>;
 

--- a/apps/passport-client/src/password.ts
+++ b/apps/passport-client/src/password.ts
@@ -1,13 +1,13 @@
 import { HexString, PCDCrypto } from "@pcd/passport-crypto";
 import zxcvbn from "zxcvbn";
-import { Dispatcher } from "./dispatch";
+import { Dispatcher, ZuUpdate } from "./dispatch";
 import { updateBlobKeyForEncryptedStorage } from "./useSyncE2EEStorage";
 
 // From https://dropbox.tech/security/zxcvbn-realistic-password-strength-estimation.
 export enum PasswordStrength {
-  WEAK = 0, 
+  WEAK = 0,
   MODERATE = 1,
-  STRONG = 2 
+  STRONG = 2
 }
 
 export const checkPasswordStrength = (password: string): boolean => {
@@ -21,7 +21,8 @@ export const PASSWORD_MINIMUM_LENGTH = 8;
 export const setPassword = async (
   newPassword: string,
   currentEncryptionKey: HexString,
-  dispatch: Dispatcher
+  dispatch: Dispatcher,
+  update: ZuUpdate
 ) => {
   const crypto = await PCDCrypto.newInstance();
   const { salt: newSalt, key: newEncryptionKey } =
@@ -47,5 +48,9 @@ export const setPassword = async (
     type: "change-password",
     newEncryptionKey,
     newSalt
+  });
+  update({
+    serverStorageRevision: res.value.revision,
+    serverStorageHash: res.value.storageHash
   });
 };

--- a/apps/passport-client/src/state.ts
+++ b/apps/passport-client/src/state.ts
@@ -55,7 +55,6 @@ export interface AppState {
   // TODO(artwyman): The parts of this not needed by the rest of the app
   // might be better stored elsewhere, to avoid issues with reentrancy
   // and stale snapshots delivered via dispatch().
-  uploadedUploadId?: string;
   downloadedPCDs?: boolean;
   loadedIssuedPCDs?: boolean;
   loadingIssuedPCDs?: boolean; // Used only to update UI
@@ -67,6 +66,7 @@ export interface AppState {
   // fields to be added later.  See the docs in that type for the meaning of
   // individual fields.
   serverStorageRevision?: string;
+  serverStorageHash?: string;
 
   knownTicketTypes?: KnownTicketType[];
   knownPublicKeys?: Record<string, Record<string, KnownPublicKey>>;

--- a/apps/passport-client/src/useSyncE2EEStorage.tsx
+++ b/apps/passport-client/src/useSyncE2EEStorage.tsx
@@ -1,18 +1,19 @@
 import { getHash, passportEncrypt } from "@pcd/passport-crypto";
 import {
   APIResult,
-  ChangeBlobKeyResult,
+  ChangeBlobKeyError,
   FeedSubscriptionManager,
-  SyncedEncryptedStorageV2,
-  SyncedEncryptedStorageV3,
-  UploadEncryptedStorageResult,
+  NamedAPIError,
+  SyncedEncryptedStorage,
   User,
   deserializeStorage,
   requestChangeBlobKey,
   requestDownloadAndDecryptUpdatedStorage,
-  requestUploadEncryptedStorage
+  requestUploadEncryptedStorage,
+  serializeStorage
 } from "@pcd/passport-interface";
 import { PCDCollection } from "@pcd/pcd-collection";
+import stringify from "fast-json-stable-stringify";
 import { useCallback, useContext, useEffect } from "react";
 import { appConfig } from "./appConfig";
 import { StateContext } from "./dispatch";
@@ -20,6 +21,7 @@ import {
   loadEncryptionKey,
   loadPCDs,
   loadSelf,
+  loadSubscriptions,
   savePCDs,
   savePersistentSyncStatus,
   saveSubscriptions
@@ -27,35 +29,74 @@ import {
 import { getPackages } from "./pcdPackages";
 import { useOnStateChange } from "./subscribe";
 
+export type UpdateBlobKeyStorageInfo = {
+  revision: string;
+  storageHash: string;
+};
+export type UpdateBlobKeyResult = APIResult<
+  UpdateBlobKeyStorageInfo,
+  ChangeBlobKeyError
+>;
+
 export async function updateBlobKeyForEncryptedStorage(
   oldEncryptionKey: string,
   newEncryptionKey: string,
   newSalt: string
-): Promise<ChangeBlobKeyResult> {
-  const user = loadSelf();
+): Promise<UpdateBlobKeyResult> {
+  const oldUser = loadSelf();
+  const newUser = { ...oldUser, salt: newSalt };
   const pcds = await loadPCDs();
+  const subscriptions = await loadSubscriptions();
 
+  const { serializedStorage, storageHash } = await serializeStorage(
+    newUser,
+    pcds,
+    subscriptions
+  );
   const encryptedStorage = await passportEncrypt(
-    JSON.stringify({
-      pcds: await pcds.serializeCollection(),
-      self: user,
-      _storage_version: "v2"
-    } satisfies SyncedEncryptedStorageV2),
+    stringify(serializedStorage),
     newEncryptionKey
   );
 
   const oldBlobKey = await getHash(oldEncryptionKey);
   const newBlobKey = await getHash(newEncryptionKey);
 
-  return requestChangeBlobKey(
+  // TODO(artwyman): Pass in knownRevison here, but only once this code is
+  // ready to respond to a conflict.  For now, without a revision, this
+  // password change could clobber PCD changed which haven't downloaded yet.
+  const changeResult = await requestChangeBlobKey(
     appConfig.zupassServer,
     oldBlobKey,
     newBlobKey,
-    user.uuid,
+    newUser.uuid,
     newSalt,
     encryptedStorage
   );
+  if (changeResult.success) {
+    console.log(
+      `[SYNC] changed e2ee storage key (revision ${changeResult.value.revision})`
+    );
+    savePersistentSyncStatus({
+      serverStorageRevision: changeResult.value.revision,
+      serverStorageHash: storageHash
+    });
+    return {
+      success: true,
+      value: { revision: changeResult.value.revision, storageHash: storageHash }
+    };
+  } else {
+    console.error(
+      "[SYNC] failed to change e2ee storage key",
+      changeResult.error
+    );
+    return { success: false, error: changeResult.error };
+  }
 }
+
+export type UploadStorageResult = APIResult<
+  { revision: string; storageHash: string },
+  NamedAPIError
+>;
 
 /**
  * Uploads the state of this passport which is contained in localstorage
@@ -65,17 +106,28 @@ export async function uploadStorage(
   user: User,
   pcds: PCDCollection,
   subscriptions: FeedSubscriptionManager
-): Promise<UploadEncryptedStorageResult> {
+): Promise<UploadStorageResult> {
+  const { serializedStorage, storageHash } = await serializeStorage(
+    user,
+    pcds,
+    subscriptions
+  );
+  return uploadSerializedStorage(serializedStorage, storageHash);
+}
+
+/**
+ * Uploads the state of this passport, in serialied form as produced by
+ * serializeStorage().
+ */
+export async function uploadSerializedStorage(
+  serializedStorage: SyncedEncryptedStorage,
+  storageHash: string
+): Promise<UploadStorageResult> {
   const encryptionKey = loadEncryptionKey();
   const blobKey = await getHash(encryptionKey);
 
   const encryptedStorage = await passportEncrypt(
-    JSON.stringify({
-      pcds: await pcds.serializeCollection(),
-      self: user,
-      subscriptions: subscriptions.serialize(),
-      _storage_version: "v3"
-    } satisfies SyncedEncryptedStorageV3),
+    stringify(serializedStorage),
     encryptionKey
   );
 
@@ -92,12 +144,17 @@ export async function uploadStorage(
       `[SYNC] uploaded e2ee storage (revision ${uploadResult.value.revision})`
     );
     savePersistentSyncStatus({
-      serverStorageRevision: uploadResult.value.revision
+      serverStorageRevision: uploadResult.value.revision,
+      serverStorageHash: storageHash
     });
+    return {
+      success: true,
+      value: { revision: uploadResult.value.revision, storageHash: storageHash }
+    };
   } else {
     console.error("[SYNC] failed to upload e2ee storage", uploadResult.error);
+    return { success: false, error: uploadResult.error };
   }
-  return uploadResult;
 }
 
 export type SyncStorageResult = APIResult<
@@ -105,6 +162,7 @@ export type SyncStorageResult = APIResult<
     pcds: PCDCollection;
     subscriptions: FeedSubscriptionManager;
     revision: string;
+    storageHash: string;
   } | null,
   null
 >;
@@ -141,20 +199,26 @@ export async function downloadStorage(
   }
 
   try {
-    const { pcds, subscriptions } = await deserializeStorage(
+    const { pcds, subscriptions, storageHash } = await deserializeStorage(
       storageResult.value.storage,
       await getPackages()
     );
     await savePCDs(pcds);
     await saveSubscriptions(subscriptions);
     savePersistentSyncStatus({
-      serverStorageRevision: storageResult.value.revision
+      serverStorageRevision: storageResult.value.revision,
+      serverStorageHash: storageHash
     });
     console.log(
       `[SYNC] downloaded e2ee storage (revision ${storageResult.value.revision})`
     );
     return {
-      value: { pcds, subscriptions, revision: storageResult.value.revision },
+      value: {
+        pcds,
+        subscriptions,
+        revision: storageResult.value.revision,
+        storageHash: storageHash
+      },
       success: true
     };
   } catch (e) {

--- a/packages/passport-interface/package.json
+++ b/packages/passport-interface/package.json
@@ -34,6 +34,7 @@
     "@semaphore-protocol/group": "^3.14.0",
     "@semaphore-protocol/identity": "^3.14.0",
     "@semaphore-protocol/proof": "^3.14.0",
+    "fast-json-stable-stringify": "^2.1.0",
     "js-sha256": "^0.9.0",
     "react": "^18.2.0",
     "url-join": "4.0.1",

--- a/packages/passport-interface/src/SubscriptionManager.ts
+++ b/packages/passport-interface/src/SubscriptionManager.ts
@@ -8,6 +8,7 @@ import {
 } from "@pcd/pcd-collection";
 import { ArgsOf, PCDPackage, PCDTypeNameOf } from "@pcd/pcd-types";
 import { isFulfilled } from "@pcd/util";
+import stringify from "fast-json-stable-stringify";
 import { v4 as uuid } from "uuid";
 import { CredentialManagerAPI } from "./CredentialManager";
 import { IFeedApi } from "./FeedAPI";
@@ -386,7 +387,7 @@ export class FeedSubscriptionManager {
   }
 
   public serialize(): string {
-    return JSON.stringify({
+    return stringify({
       providers: this.providers,
       subscribedFeeds: this.activeSubscriptions,
       _storage_version: "v1"

--- a/packages/pcd-collection/package.json
+++ b/packages/pcd-collection/package.json
@@ -24,6 +24,7 @@
     "@pcd/pcd-types": "0.8.0",
     "@pcd/semaphore-identity-pcd": "0.8.0",
     "chai": "^4.3.7",
+    "fast-json-stable-stringify": "^2.1.0",
     "lodash": "^4.17.21",
     "uuid": "^9.0.0"
   },

--- a/packages/pcd-collection/src/PCDCollection.ts
+++ b/packages/pcd-collection/src/PCDCollection.ts
@@ -1,6 +1,7 @@
 import { Emitter } from "@pcd/emitter";
 import { getHash } from "@pcd/passport-crypto";
 import { PCD, PCDPackage, SerializedPCD } from "@pcd/pcd-types";
+import stringify from "fast-json-stable-stringify";
 import _ from "lodash";
 import {
   AppendToFolderAction,
@@ -326,7 +327,7 @@ export class PCDCollection {
   }
 
   public async serializeCollection(): Promise<string> {
-    return JSON.stringify({
+    return stringify({
       pcds: await Promise.all(this.pcds.map(this.serialize.bind(this))),
       folders: this.folders
     } satisfies SerializedPCDCollection);


### PR DESCRIPTION
Introduces server-storage-hash as replacement for uploadId.  It is calculated directly from the serialized (unencrypted) blob, so should be more certain to match what's changed, and not miss things (such as the user object).  It's stored in AppState and local storage, beside server-storage-revision.  I added an explicitly-stable JSON serializer for the top-level structures to help ensure the hash stays consistent, though note that I haven't applied it in the PCDs themselves, so we're still relying on them not being dynamically updated in a way which would change serialization order.

With these changes it's finally to go through reloads, logoff, and login without ever doing an extra upload/download, and thus without risking clobbering changes.  The revision number remains unchanged through those operations.  Password change does one revision change (to change the blob key) but no extra ones.  Closes #1073.

I'm concerned that the tracking of sync status in AppState leads to delayed updates which can be unpredictable.  The final hack I used to fix the password change flow (via using update() rather than dispatch() to perform updates) was to fix an issue of that type.  I think there's a cleaner long-term design, but I don't want to upset the overall design too much at this point in prod rollout.
