### PR TITLE
[frogcrypto] add free rolls, polish, bug fixes

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -260,6 +260,7 @@ export const SuperFunkyFont = styled.div`
   font-family: "SuperFunky";
   font-size: 20px;
   display: flex;
+  user-select: none;
 
   * {
     background-size: 100%;

--- a/apps/passport-client/components/screens/FrogScreens/FrogHomeSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogHomeSection.tsx
@@ -1,6 +1,7 @@
 import { isEdDSAFrogPCD } from "@pcd/eddsa-frog-pcd";
 import {
   CredentialManager,
+  FROG_FREEROLLS,
   FrogCryptoFolderName,
   FrogCryptoUserStateResponseValue,
   IFrogCryptoFeedSchema,
@@ -24,6 +25,7 @@ import { DexTab } from "./DexTab";
 import { SuperFunkyFont } from "./FrogFolder";
 import { GetFrogTab } from "./GetFrogTab";
 import { ScoreTab } from "./ScoreTab";
+import { TypistText } from "./TypistText";
 
 const TABS = [
   {
@@ -47,6 +49,7 @@ type TabId = (typeof TABS)[number]["tab"];
 export function FrogHomeSection() {
   const frogPCDs = usePCDsInFolder(FrogCryptoFolderName).filter(isEdDSAFrogPCD);
   const { userState, refreshUserState } = useUserFeedState();
+  const hasFreeRolls = (userState?.myScore?.score ?? 0) > FROG_FREEROLLS;
   const subs = useSubscriptions();
   const frogSubs = useMemo(
     () =>
@@ -64,30 +67,65 @@ export function FrogHomeSection() {
         <H1 style={{ margin: "0 auto" }}>{FrogCryptoFolderName}</H1>
       </SuperFunkyFont>
 
-      {userState?.myScore?.score && (
+      {userState?.myScore?.score > 0 && (
         <Score>Score {userState?.myScore?.score}</Score>
       )}
 
       {frogSubs.length === 0 && (
-        <ActionButton onClick={initFrog}>light fire</ActionButton>
+        <TypistText
+          onInit={(typewriter) =>
+            typewriter
+              .typeString(
+                "You are walking through the Anatolian wetlands when you come upon a damp, misty swamp.<br>"
+              )
+              .pauseFor(500)
+              .typeString("Will you dive headfirst")
+              .deleteChars("dive headfirst".length)
+              .typeString("cross the threshold into this world of wonder?")
+          }
+        >
+          <ActionButton onClick={initFrog}>Enter Bog</ActionButton>
+        </TypistText>
       )}
+
       {frogSubs.length > 0 &&
-        (frogPCDs.length === 0 ? (
-          <GetFrogTab
-            subscriptions={frogSubs}
-            userState={userState}
-            refreshUserState={refreshUserState}
-            pcds={frogPCDs}
-          />
+        (frogPCDs.length === 0 && !userState?.myScore?.score ? (
+          <>
+            <TypistText
+              onInit={(typewriter) =>
+                typewriter
+                  .typeString(
+                    "You're certain you saw a frog wearing a monocle."
+                  )
+                  .pauseFor(500)
+                  .changeDeleteSpeed(20)
+                  .deleteAll()
+                  .typeString("You enter the bog.")
+              }
+            >
+              <GetFrogTab
+                subscriptions={frogSubs}
+                userState={userState}
+                refreshUserState={refreshUserState}
+                pcds={frogPCDs}
+              />
+            </TypistText>
+          </>
         ) : (
           <>
-            <ButtonGroup>
-              {TABS.map(({ tab: t, label }) => (
-                <Button key={t} disabled={tab === t} onClick={() => setTab(t)}>
-                  {label}
-                </Button>
-              ))}
-            </ButtonGroup>
+            {!hasFreeRolls && (
+              <ButtonGroup>
+                {TABS.map(({ tab: t, label }) => (
+                  <Button
+                    key={t}
+                    disabled={tab === t}
+                    onClick={() => setTab(t)}
+                  >
+                    {label}
+                  </Button>
+                ))}
+              </ButtonGroup>
+            )}
 
             {tab === "get" && (
               <GetFrogTab

--- a/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
@@ -1,5 +1,6 @@
 import { EdDSAFrogPCD } from "@pcd/eddsa-frog-pcd";
 import {
+  FROG_FREEROLLS,
   FrogCryptoUserStateResponseValue,
   Subscription
 } from "@pcd/passport-interface";
@@ -47,6 +48,7 @@ export function GetFrogTab({
               sub={sub}
               refreshUserState={refreshUserState}
               nextFetchAt={userFeedState?.nextFetchAt}
+              score={userState?.myScore?.score}
             />
           );
         })}
@@ -76,11 +78,13 @@ export function GetFrogTab({
 const SearchButton = ({
   sub: { id, feed },
   nextFetchAt,
-  refreshUserState
+  refreshUserState,
+  score
 }: {
   sub: Subscription;
   nextFetchAt?: number;
   refreshUserState: () => Promise<void>;
+  score: number | undefined;
 }) => {
   const dispatch = useDispatch();
   const countDown = useCountDown(nextFetchAt || 0);
@@ -105,10 +109,13 @@ const SearchButton = ({
     [dispatch, feed.name, id, refreshUserState]
   );
   const name = useMemo(() => _.upperCase(`Search ${feed.name}`), [feed.name]);
+  const freerolls = FROG_FREEROLLS + 1 - score;
 
   return (
     <ActionButton key={id} onClick={onClick} disabled={!canFetch}>
-      {canFetch ? name : `${name}${countDown}`}
+      {canFetch
+        ? `${name}${freerolls > 0 ? ` (${freerolls})` : ""}`
+        : `${name}${countDown}`}
     </ActionButton>
   );
 };

--- a/apps/passport-client/components/screens/FrogScreens/TypistText.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/TypistText.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import styled from "styled-components";
+import Typewriter, { TypewriterClass } from "typewriter-effect";
+
+/**
+ * TypistText is a component that renders text with a typewriter effect. Any
+ * children will be faded in after the typewriter effect is complete.
+ */
+export function TypistText({
+  onInit,
+  children
+}: {
+  /**
+   * onInit will be called when the typewriter is ready.
+   */
+  onInit: (typewriter: TypewriterClass) => TypewriterClass;
+  /**
+   * Action button with the label will be rendered at the end of the adventure text.
+   */
+  children: React.ReactNode;
+}) {
+  const [ready, setReady] = useState(false);
+
+  return (
+    <>
+      <TypewriterContainer>
+        <Typewriter
+          onInit={(typewriter) => {
+            onInit(typewriter)
+              .callFunction(() => {
+                setReady(true);
+              })
+              .start();
+          }}
+          options={{
+            delay: 20
+          }}
+        />
+      </TypewriterContainer>
+      {ready && <FadeIn>{children}</FadeIn>}
+    </>
+  );
+}
+
+const FadeIn = styled.div`
+  animation: fadeIn 0.5s ease-in forwards;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+  width: 100%;
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+  gap: 32px;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const TypewriterContainer = styled.div`
+  font-size: 18px;
+  user-select: none;
+`;

--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -55,6 +55,7 @@
     "styled-components": "^5.3.6",
     "tsparticles": "^2.12.0",
     "tsparticles-engine": "^2.12.0",
+    "typewriter-effect": "^2.21.0",
     "uuid": "^9.0.0",
     "zxcvbn": "^4.4.2"
   },

--- a/apps/passport-server/src/services/frogcryptoService.ts
+++ b/apps/passport-server/src/services/frogcryptoService.ts
@@ -1,5 +1,6 @@
 import { Biome, IFrogData, Rarity } from "@pcd/eddsa-frog-pcd";
 import {
+  FROG_FREEROLLS,
   FrogCryptoComputedUserState,
   FrogCryptoDeleteFrogsRequest,
   FrogCryptoDeleteFrogsResponseValue,
@@ -204,7 +205,16 @@ export class FrogcryptoService {
         if (!frogData) {
           throw new PCDHTTPError(404, "Frog Not Found");
         }
-        await incrementScore(client, semaphoreId);
+        const { score:scoreAfterRoll } = await incrementScore(client, semaphoreId);
+        // rollback last fetched timestamp if user has free rolls left
+        if (scoreAfterRoll <= FROG_FREEROLLS) {
+          await updateUserFeedState(
+            client,
+            semaphoreId,
+            feed.id,
+            lastFetchedAt.toUTCString()
+          );
+        }
 
         return this.generateFrogData(frogData, semaphoreId);
       }

--- a/apps/passport-server/src/util/frogcrypto.ts
+++ b/apps/passport-server/src/util/frogcrypto.ts
@@ -1,8 +1,4 @@
-import {
-  TEMPERAMENT_MAX,
-  TEMPERAMENT_MIN,
-  Temperament
-} from "@pcd/eddsa-frog-pcd";
+import { COMMON_TEMPERAMENT_SET, Temperament } from "@pcd/eddsa-frog-pcd";
 import {
   FeedHost,
   FrogCryptoFeed,
@@ -123,7 +119,7 @@ export function parseFrogEnum(
 
 export function parseFrogTemperament(value?: string): Temperament {
   if (!value) {
-    return _.random(TEMPERAMENT_MIN, TEMPERAMENT_MAX);
+    return _.sample(COMMON_TEMPERAMENT_SET) ?? Temperament.N_A; // fallback makes TS happy
   }
   if (value === "N/A") {
     return Temperament.N_A;

--- a/apps/passport-server/test/frogcryptodb.spec.ts
+++ b/apps/passport-server/test/frogcryptodb.spec.ts
@@ -79,6 +79,25 @@ describe("database reads and writes for frogcrypto features", function () {
     expect(frog?.biome).to.eq("Jungle");
   });
 
+  step("sample a frog from complexly named biome", async function () {
+    const frog = await sampleFrogData(db, {
+      TheCapital: { dropWeightScaler: 1 }
+    });
+
+    expect(frog?.biome).to.eq("The Capital");
+  });
+
+  step("sample a frog from weighted biomes", async function () {
+    const frog = await sampleFrogData(db, {
+      TheCapital: { dropWeightScaler: 1000 },
+      Desert: { dropWeightScaler: 0.001 },
+      Jungle: { dropWeightScaler: 0 } // 0 weight should be ignored
+    });
+
+    // statistically guranteed to be TheCapital
+    expect(frog?.biome).to.eq("The Capital");
+  });
+
   step("return undefined if there is no frog to sample", async function () {
     const frog = await sampleFrogData(db, {});
 

--- a/apps/passport-server/test/util/frogcrypto.ts
+++ b/apps/passport-server/test/util/frogcrypto.ts
@@ -76,6 +76,24 @@ export const testFrogs: FrogCryptoFrogData[] = [
     intelligence_max: 1,
     beauty_min: 1,
     beauty_max: 1
+  },
+  {
+    id: 5,
+    uuid: uuid(),
+    name: "Frog 5",
+    description: "A frog",
+    biome: "The Capital",
+    rarity: "rare",
+    temperament: "MEOW",
+    drop_weight: 1,
+    jump_min: 1,
+    jump_max: 1,
+    speed_min: 1,
+    speed_max: 1,
+    intelligence_min: 1,
+    intelligence_max: 1,
+    beauty_min: 1,
+    beauty_max: 1
   }
 ];
 

--- a/packages/eddsa-frog-pcd/src/CardBody.tsx
+++ b/packages/eddsa-frog-pcd/src/CardBody.tsx
@@ -41,10 +41,10 @@ export function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
       </LinkButton>
       <FrogImg src={frogData?.imageUrl} draggable={false} />
       <FrogInfo>
-        <FrogAttribute label="JUMP" title="Jump" value={frogData.jump} />
+        <FrogAttribute label="JMP" title="Jump" value={frogData.jump} />
         <FrogAttribute
-          label="TMPT"
-          title="Temperament"
+          label="VIB"
+          title="Vibe"
           value={temperamentValue(frogData.temperament)}
         />
         <FrogAttribute label="SPD" title="Speed" value={frogData?.speed} />
@@ -53,7 +53,7 @@ export function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
           title="Intelligence"
           value={frogData.intelligence}
         />
-        <FrogAttribute label="BUTY" title="Beauty" value={frogData.beauty} />
+        <FrogAttribute label="BTY" title="Beauty" value={frogData.beauty} />
       </FrogInfo>
       {showMore && (
         <>
@@ -91,7 +91,9 @@ function FrogAttribute({
   return (
     <Attribute>
       <AttrTitle title={title}>{label}</AttrTitle>
-      <AttrValue style={{ color: attrColor(value) }}>{value}</AttrValue>
+      <AttrValue style={{ color: attrColor(value) }}>
+        {formatAttrValue(value)}
+      </AttrValue>
     </Attribute>
   );
 }
@@ -105,6 +107,13 @@ function attrColor(value: string | number | undefined) {
       return "#206b5e";
     }
   }
+}
+
+function formatAttrValue(value: string | number | undefined) {
+  if (typeof value === "number") {
+    return String(value).padStart(2, "0");
+  }
+  return value;
 }
 
 function temperamentValue(temperament: Temperament) {
@@ -192,6 +201,7 @@ const Attribute = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 4px;
+  font-family: monospace;
 `;
 
 const AttrTitle = styled.div`

--- a/packages/eddsa-frog-pcd/src/EdDSAFrogPCD.ts
+++ b/packages/eddsa-frog-pcd/src/EdDSAFrogPCD.ts
@@ -74,8 +74,16 @@ export enum Temperament {
   YOLO
 }
 
-export const TEMPERAMENT_MIN = Temperament.ANGY;
-export const TEMPERAMENT_MAX = Temperament.YOLO;
+export const COMMON_TEMPERAMENT_SET = [
+  Temperament.HNGY,
+  Temperament.ANGY,
+  Temperament.SADG,
+  Temperament.CALM,
+  Temperament.BORD,
+  Temperament.DARK,
+  Temperament.SLPY,
+  Temperament.CALM
+];
 
 /**
  * FROGCRYPTO Data Model

--- a/packages/passport-interface/src/FrogCrypto.ts
+++ b/packages/passport-interface/src/FrogCrypto.ts
@@ -4,6 +4,13 @@ import { z } from "zod";
 import { Feed } from "./SubscriptionManager";
 
 /**
+ * Number of free rolls that a user globally
+ *
+ * User's lastFetchedAt is set to 0 if their score is less than this value
+ */
+export const FROG_FREEROLLS = 2;
+
+/**
  * Map of configs for Biome(s) where PCDs can be issued from this feed
  */
 export const FrogCryptoFeedBiomeConfigSchema = z.object({

--- a/yarn.lock
+++ b/yarn.lock
@@ -12519,6 +12519,13 @@ r1csfile@0.0.45:
     fastfile "0.0.20"
     ffjavascript "0.2.57"
 
+raf@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -14877,6 +14884,14 @@ typescript@5.1.6, typescript@^4.5.2, typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typewriter-effect@^2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/typewriter-effect/-/typewriter-effect-2.21.0.tgz#7150f12fd2c188248ab2b2b031f77c0663d24c54"
+  integrity sha512-Y3VL1fuJpUBj0gS4OTXBLzy1gnYTYaBuVuuO99tGNyTkkub5CXi+b/hsV7Og9fp6HlhogOwWJwgq7iXI5sQlEg==
+  dependencies:
+    prop-types "^15.8.1"
+    raf "^3.4.1"
 
 ua-parser-js@^0.7.30:
   version "0.7.37"


### PR DESCRIPTION
https://github.com/proofcarryingdata/zupass/issues/1057

## Leaping into v0

UI
* added typist effect to initial user experience for a more gradual and delightful initiation

Issuance
* only sample from 8 common temperaments 
* two free rolls (gated by user score)
* sampling was broken
    * incorrect handling with biome with space in name
    * incorrect ordering of the dice (weighting was reversed)

frog card
* all stat fonts a monospace font (label + value)
* 3-char label JMP / VIB / SPD / INT / BTY and temperament => vibe)
* stat values should have a leading 0 if they aren't 10 (so they are always 2digit)


test cases have been updated for all server logic changes 


https://github.com/proofcarryingdata/zupass/assets/4317392/978b6115-edd9-4b25-8517-84f1e41946ae
