### PR TITLE
[frogcrypto]  launch polish

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/Button.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/Button.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
+import { useFrogParticles } from "./useFrogParticles";
 
 /**
  * A button that shows a loading spinner while the action is in progress.
@@ -7,7 +8,8 @@ import styled from "styled-components";
 export function ActionButton({
   children,
   onClick,
-  disabled
+  disabled,
+  ButtonComponent = Button
 }: {
   children: string;
   /**
@@ -16,6 +18,10 @@ export function ActionButton({
    */
   onClick: () => Promise<void>;
   disabled?: boolean;
+  /**
+   * The component to use for the button. Defaults to Button.
+   */
+  ButtonComponent?: React.ComponentType<React.ComponentProps<typeof Button>>;
 }) {
   const [loading, setLoading] = useState(false);
   // Every user click increment the trigger count, which will trigger the
@@ -77,15 +83,55 @@ export function ActionButton({
   }, []);
 
   return (
-    <Button
+    <ButtonComponent
       onClick={handleClick}
       disabled={loading || disabled}
       pending={loading}
     >
       {children}
-    </Button>
+    </ButtonComponent>
   );
 }
+
+/**
+ * The FrogSearchButton allows a frog confetti animation when the button is disabled.
+ */
+export const FrogSearchButton = ({
+  disabled,
+  children,
+  ...props
+}: React.ComponentPropsWithRef<typeof Button>) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const container = useFrogParticles(ref);
+
+  useEffect(() => {
+    if (!container) {
+      return;
+    }
+
+    if (disabled) {
+      container.start();
+    }
+
+    return () => {
+      container.stop();
+    };
+  }, [container, disabled]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "stretch"
+      }}
+      ref={ref}
+    >
+      <Button disabled={disabled} {...props}>
+        {children}
+      </Button>
+    </div>
+  );
+};
 
 export const Button = styled.button<{ pending?: boolean }>`
   font-size: 16px;

--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -5,10 +5,9 @@ import {
 import prettyMilliseconds from "pretty-ms";
 import { useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
-import { loadFull } from "tsparticles";
-import { tsParticles } from "tsparticles-engine";
 import { useSubscriptions } from "../../../src/appHooks";
 import { DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL } from "./FrogHomeSection";
+import { useFrogParticles } from "./useFrogParticles";
 
 /**
  * Render the FrogCrypto folder in the home screen.
@@ -30,7 +29,7 @@ export function FrogFolder({
 }) {
   const divRef = useRef<HTMLDivElement>(null);
   const { gameOn, setGameOn } = useFetchGameOn();
-  useParticles(gameOn === false ? divRef : null);
+  useFrogParticles(gameOn === false ? divRef : null);
 
   return (
     <Container
@@ -136,105 +135,6 @@ function CountDown({ setGameOn }: { setGameOn: (gameOn: boolean) => void }) {
   }, [end, setGameOn]);
 
   return <>{diffText}</>;
-}
-
-function useParticles(ref: React.RefObject<HTMLDivElement> | null) {
-  const [ready, setReady] = useState(false);
-  useEffect(() => {
-    const load = async () => {
-      await loadFull(tsParticles);
-      setReady(true);
-    };
-    load();
-  }, []);
-
-  useEffect(() => {
-    if (!ready || !ref) {
-      return;
-    }
-
-    tsParticles.load({
-      element: ref.current,
-      options: {
-        fullScreen: {
-          enable: true,
-          zIndex: 100
-        },
-        fpsLimit: 120,
-        particles: {
-          number: {
-            value: 0
-          },
-          color: {
-            value: [
-              "#004b23",
-              "#006400",
-              "#007200",
-              "#008000",
-              "#38b000",
-              "#70e000",
-              "#9ef01a",
-              "#ccff33"
-            ],
-            animation: {
-              enable: true,
-              speed: 100,
-              sync: true
-            }
-          },
-          shape: {
-            type: "image",
-            image: {
-              replaceColor: true,
-              src: "/images/frogs/frog.svg"
-            }
-          },
-          opacity: {
-            value: 1
-          },
-          size: {
-            value: { min: 1000, max: 2000 },
-            animation: {
-              enable: true,
-              speed: 10,
-              minimumValue: 1,
-              sync: true,
-              startValue: "min",
-              count: 1
-            }
-          },
-          move: {
-            enable: true,
-            speed: { min: 5, max: 20 },
-            direction: "top",
-            random: true,
-            straight: false,
-            outMode: "bounce-horizontal",
-            gravity: {
-              enable: true
-            }
-          }
-        },
-        interactivity: {
-          detectsOn: "parent",
-          events: {
-            onClick: {
-              enable: true,
-              mode: "trail"
-            },
-            resize: true
-          },
-          modes: {
-            trail: {
-              delay: 0.1,
-              quantity: 10
-            }
-          }
-        },
-        detectRetina: true
-      }
-    });
-  }, [ready, ref]);
 }
 
 const NewFont = styled.div`

--- a/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
@@ -23,17 +23,21 @@ export function ScoreTab({ score }: { score?: FrogCryptoScore }) {
   return (
     <Container>
       <ScoreTable title="You" scores={[score]} />
-      {scores.length > 0 && <ScoreTable title="Leaderboard" scores={scores} />}
+      {scores.length > 0 && (
+        <ScoreTable title="Leaderboard" scores={scores} myScore={score} />
+      )}
     </Container>
   );
 }
 
 function ScoreTable({
   title,
-  scores
+  scores,
+  myScore
 }: {
   title: string;
   scores: FrogCryptoScore[];
+  myScore?: FrogCryptoScore;
 }) {
   return (
     <table>
@@ -51,7 +55,13 @@ function ScoreTable({
       </thead>
       <tbody>
         {scores.map((score) => (
-          <tr key={score.rank}>
+          <tr
+            key={score.rank}
+            style={{
+              fontWeight:
+                score.semaphore_id === myScore?.semaphore_id ? "bold" : "normal"
+            }}
+          >
             <td>{score.rank}</td>
             <td>{getUserShortId(score.semaphore_id)}</td>
             <td style={{ textAlign: "right" }}>{score.score}</td>

--- a/apps/passport-client/components/screens/FrogScreens/TypistText.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/TypistText.tsx
@@ -63,6 +63,6 @@ const FadeIn = styled.div`
 `;
 
 const TypewriterContainer = styled.div`
-  font-size: 18px;
+  font-size: 16px;
   user-select: none;
 `;

--- a/apps/passport-client/components/screens/FrogScreens/useFrogParticles.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/useFrogParticles.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from "react";
+import { loadFull } from "tsparticles";
+import { confetti } from "tsparticles-confetti";
+import { Container, tsParticles } from "tsparticles-engine";
+
+export function useFrogParticles(ref: React.RefObject<HTMLDivElement> | null) {
+  const [ready, setReady] = useState(false);
+  const [container, setContainer] = useState<Container | null>(null);
+  useEffect(() => {
+    const load = async () => {
+      await loadFull(tsParticles);
+      setReady(true);
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (!ready || !ref) {
+      return;
+    }
+
+    tsParticles
+      .load({
+        element: ref.current,
+        options: {
+          fullScreen: {
+            enable: true,
+            zIndex: 100
+          },
+          fpsLimit: 120,
+          particles: {
+            number: {
+              value: 0
+            },
+            color: {
+              value: [
+                "#004b23",
+                "#006400",
+                "#007200",
+                "#008000",
+                "#38b000",
+                "#70e000",
+                "#9ef01a",
+                "#ccff33"
+              ],
+              animation: {
+                enable: true,
+                speed: 100,
+                sync: true
+              }
+            },
+            shape: {
+              type: "image",
+              image: {
+                replaceColor: true,
+                src: "/images/frogs/frog.svg"
+              }
+            },
+            opacity: {
+              value: 1
+            },
+            size: {
+              value: { min: 1000, max: 2000 },
+              animation: {
+                enable: true,
+                speed: 10,
+                minimumValue: 1,
+                sync: true,
+                startValue: "min",
+                count: 1
+              }
+            },
+            move: {
+              enable: true,
+              speed: { min: 5, max: 20 },
+              direction: "top",
+              random: true,
+              straight: false,
+              outMode: "bounce-horizontal",
+              gravity: {
+                enable: true
+              }
+            }
+          },
+          interactivity: {
+            detectsOn: "parent",
+            events: {
+              onClick: {
+                enable: true,
+                mode: "trail"
+              },
+              resize: true
+            },
+            modes: {
+              trail: {
+                delay: 0.1,
+                quantity: 10
+              }
+            }
+          },
+          detectRetina: true
+        }
+      })
+      .then(setContainer);
+  }, [ready, ref]);
+
+  return container;
+}
+
+export function useFrogConfetti() {
+  useEffect(() => {
+    tsParticles.load({
+      preset: "confetti",
+      options: {
+        fullScreen: {
+          enable: true,
+          zIndex: 100
+        },
+        fpsLimit: 120,
+        particles: {
+          color: {
+            value: [
+              "#004b23",
+              "#006400",
+              "#007200",
+              "#008000",
+              "#38b000",
+              "#70e000",
+              "#9ef01a",
+              "#ccff33"
+            ],
+            animation: {
+              enable: true,
+              speed: 100,
+              sync: true
+            }
+          },
+          shape: {
+            type: "image",
+            image: {
+              replaceColor: true,
+              src: "/images/frogs/frog.svg"
+            }
+          },
+          opacity: {
+            value: 1
+          },
+          size: {
+            value: { min: 1000, max: 2000 },
+            animation: {
+              enable: true,
+              speed: 10,
+              minimumValue: 1,
+              sync: true,
+              startValue: "min",
+              count: 1
+            }
+          },
+          move: {
+            enable: true,
+            speed: { min: 5, max: 20 },
+            direction: "top",
+            random: true,
+            straight: false,
+            outMode: "bounce-horizontal",
+            gravity: {
+              enable: true
+            }
+          }
+        },
+        detectRetina: true
+      }
+    });
+  }, []);
+
+  return () => {
+    confetti({
+      spread: 360,
+      ticks: 100,
+      gravity: 1,
+      decay: 0.94,
+      startVelocity: 20,
+      particleCount: 50,
+      scalar: 2,
+      shapes: ["text"],
+      shapeOptions: {
+        text: {
+          value: [
+            "🐸",
+            "🐸",
+            "🐸",
+            "🐸",
+            "🐸",
+            "🐸",
+            "🎉",
+            "✨",
+            "🌟",
+            "🍀",
+            "💧",
+            "🌈",
+            "💚",
+            "🎈",
+            "🌳",
+            "🌲",
+            "🌾",
+            "🌺",
+            "🌻"
+          ]
+        }
+      }
+    });
+  };
+}

--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -55,6 +55,7 @@
     "rollbar": "^2.26.1",
     "styled-components": "^5.3.6",
     "tsparticles": "^2.12.0",
+    "tsparticles-confetti": "^2.12.0",
     "tsparticles-engine": "^2.12.0",
     "typewriter-effect": "^2.21.0",
     "uuid": "^9.0.0",

--- a/packages/eddsa-frog-pcd/src/CardBody.tsx
+++ b/packages/eddsa-frog-pcd/src/CardBody.tsx
@@ -10,8 +10,7 @@ import {
   Biome,
   EdDSAFrogPCD,
   EdDSAFrogPCDPackage,
-  Temperament,
-  initArgs
+  Temperament
 } from "./EdDSAFrogPCD";
 import { getEdDSAFrogData } from "./utils";
 
@@ -39,7 +38,7 @@ export function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
       <LinkButton onClick={() => setShowPCD(true)}>
         View as proof-carrying data
       </LinkButton>
-      <FrogImg src={frogData?.imageUrl} draggable={false} />
+      <FrogImg src={frogData?.imageUrl} draggable={false} loading="lazy" />
       <FrogInfo>
         <FrogAttribute label="JMP" title="Jump" value={frogData.jump} />
         <FrogAttribute
@@ -55,6 +54,9 @@ export function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
         />
         <FrogAttribute label="BTY" title="Beauty" value={frogData.beauty} />
       </FrogInfo>
+      <LinkButton onClick={() => setShowMore(!showMore)}>
+        {showMore ? "Collapse" : "See more"}
+      </LinkButton>
       {showMore && (
         <>
           <Description>{frogData.description}</Description>
@@ -72,9 +74,6 @@ export function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
           </FrogInfo>
         </>
       )}
-      <LinkButton onClick={() => setShowMore(!showMore)}>
-        {showMore ? "Collapse" : "See more"}
-      </LinkButton>
     </Container>
   );
 }
@@ -138,11 +137,12 @@ function FrogQR({ pcd }: { pcd: EdDSAFrogPCD }) {
     const serializedPCD = JSON.stringify(serialized);
     console.log(`[QR] generated proof, length ${serializedPCD.length}`);
     const encodedPCD = encodeQRPayload(serializedPCD);
-    if (!initArgs.makeEncodedVerifyLink) {
-      throw new Error("must provide makeEncodedVerifyLink");
-    }
-    const verificationLink = initArgs.makeEncodedVerifyLink(encodedPCD);
-    return verificationLink;
+    return encodedPCD;
+    // if (!initArgs.makeEncodedVerifyLink) {
+    //   throw new Error("must provide makeEncodedVerifyLink");
+    // }
+    // const verificationLink = initArgs.makeEncodedVerifyLink(encodedPCD);
+    // return verificationLink;
   }, [pcd]);
 
   return (

--- a/packages/passport-ui/src/Core.tsx
+++ b/packages/passport-ui/src/Core.tsx
@@ -27,7 +27,7 @@ export const FieldLabel = styled.span`
 `;
 
 export const LinkButton = styled.a`
-  color: var(--accent-darker);
+  color: var(#e6a50f);
   cursor: pointer;
   text-decoration: none;
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14330,6 +14330,28 @@ tsparticles-basic@^2.12.0:
     tsparticles-updater-out-modes "^2.12.0"
     tsparticles-updater-size "^2.12.0"
 
+tsparticles-confetti@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/tsparticles-confetti/-/tsparticles-confetti-2.12.0.tgz#c576fbc97f6b975d27044f361225468a6e477813"
+  integrity sha512-PsxBL1DjYNNZecFFcymivnPypuxHKh0ePz2/9CctKl6zwS+Z8cHBCoszg8jBx6PJDJkAxIa76taezd54caISYg==
+  dependencies:
+    tsparticles-basic "^2.12.0"
+    tsparticles-engine "^2.12.0"
+    tsparticles-plugin-emitters "^2.12.0"
+    tsparticles-plugin-motion "^2.12.0"
+    tsparticles-shape-cards "^2.12.0"
+    tsparticles-shape-heart "^2.12.0"
+    tsparticles-shape-image "^2.12.0"
+    tsparticles-shape-polygon "^2.12.0"
+    tsparticles-shape-square "^2.12.0"
+    tsparticles-shape-star "^2.12.0"
+    tsparticles-shape-text "^2.12.0"
+    tsparticles-updater-life "^2.12.0"
+    tsparticles-updater-roll "^2.12.0"
+    tsparticles-updater-rotate "^2.12.0"
+    tsparticles-updater-tilt "^2.12.0"
+    tsparticles-updater-wobble "^2.12.0"
+
 tsparticles-engine@^2.12.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/tsparticles-engine/-/tsparticles-engine-2.12.0.tgz#4a52a8de4ab6085180abf27f4720f47caa1455fc"
@@ -14475,10 +14497,31 @@ tsparticles-plugin-emitters@^2.12.0:
   dependencies:
     tsparticles-engine "^2.12.0"
 
+tsparticles-plugin-motion@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/tsparticles-plugin-motion/-/tsparticles-plugin-motion-2.12.0.tgz#bdaa3c41b44a895adaba99dbbe438c68ca99b983"
+  integrity sha512-VeS0VDV5wc9a4t0xkPi3lkHqOvKRlELq4mEEvaIk8WwgOcx05TUZcJIIbhftnNabqgpHrZ4iUP5Nb2wZ3DBwWQ==
+  dependencies:
+    tsparticles-engine "^2.12.0"
+
+tsparticles-shape-cards@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/tsparticles-shape-cards/-/tsparticles-shape-cards-2.12.0.tgz#4bf99d5fecf3ef76b73084d17df2fe71b5f4559c"
+  integrity sha512-4mSV1C7c/7SsSbS4A5HJEZE5tB2fOAEUXm52uagzBVMbL/YI+XkjOpi7L6JtCNcBKrWnZ/IgnnLMyyFGhNc4pA==
+  dependencies:
+    tsparticles-engine "^2.12.0"
+
 tsparticles-shape-circle@^2.12.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/tsparticles-shape-circle/-/tsparticles-shape-circle-2.12.0.tgz#52757d222145c3f80b02d3c51e6158aee0af024c"
   integrity sha512-L6OngbAlbadG7b783x16ns3+SZ7i0SSB66M8xGa5/k+YcY7zm8zG0uPt1Hd+xQDR2aNA3RngVM10O23/Lwk65Q==
+  dependencies:
+    tsparticles-engine "^2.12.0"
+
+tsparticles-shape-heart@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/tsparticles-shape-heart/-/tsparticles-shape-heart-2.12.0.tgz#2031d55261aac35e3aeccbd5e1e343fc194b0fbd"
+  integrity sha512-OK8CJrCY0Z6YAedyfTQh52u7KsurkP8eLNWDW11BhqcvDQkfwJC5g25Y3VrcW9Rwc88hrbNwFQlsKbY6tOn7qA==
   dependencies:
     tsparticles-engine "^2.12.0"
 


### PR DESCRIPTION
https://github.com/proofcarryingdata/zupass/issues/1057

* Add a FrogSearchButton which enables confetti once it's disabled
* Force search frog to take at least one second and shows a pending toast. Successful search gives a confetti fireworks
* Update copy to say `(X remaining)` for free rolls
* Bold my row in leaderboard
* Reduce initial screen font size to better fit mobile screen
* Make image in frog card lazy loading
* Render serialized pcd in frog card QR code
* Move collapse button to stable position
* Make link text darker