### PR TITLE
[frogcrypto] frog fixes

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/Button.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/Button.tsx
@@ -145,6 +145,7 @@ export const Button = styled.button<{ pending?: boolean }>`
   cursor: pointer;
   flex: 1;
   user-select: none;
+  font-family: monospace;
 
   &:disabled {
     background-color: rgba(var(--white-rgb), 0.2);

--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -2,6 +2,7 @@ import {
   FrogCryptoFolderName,
   IFrogCryptoFeedSchema
 } from "@pcd/passport-interface";
+import _ from "lodash";
 import prettyMilliseconds from "pretty-ms";
 import { useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
@@ -49,9 +50,9 @@ export function FrogFolder({
           </BounceText>
         ))}
       </SuperFunkyFont>
-      {gameOn === false && (
+      {typeof gameOn === "boolean" && (
         <NewFont>
-          <CountDown setGameOn={setGameOn} />
+          <CountDown gameOn={gameOn} setGameOn={setGameOn} />
         </NewFont>
       )}
     </Container>
@@ -106,17 +107,27 @@ function useFetchGameOn(): {
 /**
  * A countdown to a hard coded game start date.
  */
-function CountDown({ setGameOn }: { setGameOn: (gameOn: boolean) => void }) {
+function CountDown({
+  gameOn,
+  setGameOn
+}: {
+  gameOn: boolean;
+  setGameOn: (gameOn: boolean) => void;
+}) {
   const end = useMemo(() => {
     return new Date("13 Nov 2023 23:00:00 PST");
   }, []);
-  const [diffText, setDiffText] = useState("");
+  const [diffText, setDiffText] = useState(
+    gameOn ? _.upperCase("Available Now") : ""
+  );
 
   useEffect(() => {
     const interval = setInterval(() => {
       const now = new Date();
       const diffMs = end.getTime() - now.getTime();
-      if (diffMs < 0) {
+      if (gameOn) {
+        setDiffText(_.upperCase("Available Now"));
+      } else if (diffMs < 0) {
         setDiffText("");
         setGameOn(true);
       } else {
@@ -132,7 +143,7 @@ function CountDown({ setGameOn }: { setGameOn: (gameOn: boolean) => void }) {
     return () => {
       clearInterval(interval);
     };
-  }, [end, setGameOn]);
+  }, [end, gameOn, setGameOn]);
 
   return <>{diffText}</>;
 }

--- a/apps/passport-client/components/screens/FrogScreens/FrogHomeSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogHomeSection.tsx
@@ -74,7 +74,7 @@ export function FrogHomeSection() {
 
       {myScore > 0 && (
         <Score>
-          Score {myScore} | Rank #{userState?.myScore?.rank}
+          Score {myScore} | {scoreToEmoji(myScore)}
         </Score>
       )}
 
@@ -276,3 +276,27 @@ const Score = styled.div`
   font-size: 16px;
   text-align: center;
 `;
+
+const SCORES = [
+  { score: 0, emoji: "⚪️", title: "NOVICE" },
+  { score: 5, emoji: "🟡", title: "APPRENTICE" },
+  { score: 10, emoji: "🟠", title: "JOURNEYMAN" },
+  { score: 19, emoji: "🔴", title: "EXPERT" },
+  { score: 36, emoji: "🟣", title: "MASTER" },
+  { score: 69, emoji: "🔵", title: "GRANDMASTER" },
+  { score: 133, emoji: "🟢", title: "LEGEND" }
+];
+function scoreToEmoji(score: number) {
+  const index = SCORES.findIndex((item) => item.score >= score);
+  if (index === -1) {
+    return `${SCORES[SCORES.length - 1].emoji} ${
+      SCORES[SCORES.length - 1].title
+    }`;
+  }
+  const prev = SCORES[index - 1];
+  const next = SCORES[index];
+  const percent = Math.floor(
+    ((score - prev.score) / (next.score - prev.score)) * 100
+  );
+  return `${prev.emoji} ${prev.title} - ${percent}%`;
+}

--- a/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
@@ -1,4 +1,4 @@
-import { EdDSAFrogPCD, isEdDSAFrogPCD } from "@pcd/eddsa-frog-pcd";
+import { Biome, EdDSAFrogPCD, isEdDSAFrogPCD } from "@pcd/eddsa-frog-pcd";
 import {
   FROG_FREEROLLS,
   FeedSubscriptionManager,
@@ -126,7 +126,7 @@ const SearchButton = ({
     await toast
       .promise(
         new Promise<void>((resolve) => {
-          setTimeout(resolve, 6000);
+          setTimeout(resolve, 4000);
         }).then(
           () =>
             new Promise<void>((resolve, reject) => {
@@ -150,6 +150,12 @@ const SearchButton = ({
                         "Froggy hiccup! Seems like one of our amphibians is playing camouflage. Zoo staff are peeking under every leaf. Hop back later for another try!"
                       );
                     }
+                    if (fetchErrorMsg?.includes("faucet off")) {
+                      subManager.resetError(id);
+                      return reject(
+                        "Froggy hall of fame! You've won... but your lily pad's full. No room for more buddies!"
+                      );
+                    }
                   }
 
                   resolve();
@@ -162,9 +168,15 @@ const SearchButton = ({
         {
           loading: <LoadingMessages biome={feed.name} />,
           success: () => {
-            return `You found a ${
-              getLastFrogRef()?.claim?.data?.name || "new frog"
-            } in ${feed.name}!`;
+            const lastFrog = getLastFrogRef();
+            // nb: this shouldn't happen
+            if (!lastFrog) {
+              return null;
+            }
+            if (lastFrog.claim.data.biome === Biome.Unknown) {
+              return `You found something strange in ${feed.name}. It doesn't appear to be a frog.`;
+            }
+            return `You found a ${lastFrog.claim.data.name} in ${feed.name}!`;
           },
           error: (e) =>
             typeof e === "string" ? e : "Oopsie-toad! Something went wrong."

--- a/apps/passport-server/src/database/queries/frogcrypto.ts
+++ b/apps/passport-server/src/database/queries/frogcrypto.ts
@@ -227,15 +227,16 @@ function toFrogData(dbFrogData: FrogCryptoDbFrogData): FrogCryptoFrogData {
 
 export async function incrementScore(
   client: Client,
-  semaphoreId: string
+  semaphoreId: string,
+  increment = 1
 ): Promise<FrogCryptoScore> {
   const res = await client.query(
     `insert into frogcrypto_user_scores
     (semaphore_id, score)
-    values ($1, 1)
-    on conflict (semaphore_id) do update set score = frogcrypto_user_scores.score + 1
+    values ($1, $2)
+    on conflict (semaphore_id) do update set score = frogcrypto_user_scores.score + $2
     returning *`,
-    [semaphoreId]
+    [semaphoreId, increment]
   );
 
   return res.rows[0];

--- a/apps/passport-server/test/frogcryptodb.spec.ts
+++ b/apps/passport-server/test/frogcryptodb.spec.ts
@@ -154,7 +154,7 @@ describe("database reads and writes for frogcrypto features", function () {
     await upsertFrogData(db, testFrogsAndObjects);
 
     const possibleFrogIds = await getPossibleFrogIds(db);
-    expect(possibleFrogIds).to.deep.eq([1, 2, 3, 7, 8]);
+    expect(possibleFrogIds).to.deep.eq([1, 2, 3, 5, 8, 9]);
   });
 
   step("insert feeds", async function () {

--- a/apps/passport-server/test/util/frogcrypto.ts
+++ b/apps/passport-server/test/util/frogcrypto.ts
@@ -99,29 +99,11 @@ export const testFrogs: FrogCryptoFrogData[] = [
 
 export const testFrogsAndObjects: FrogCryptoFrogData[] = [
   {
-    id: 5,
+    id: 6,
     uuid: uuid(),
     name: "Object 1",
     description: "A object",
-    biome: "N/A",
-    rarity: "object",
-    temperament: undefined,
-    drop_weight: 1,
-    jump_min: 1,
-    jump_max: 1,
-    speed_min: 1,
-    speed_max: 1,
-    intelligence_min: 1,
-    intelligence_max: 1,
-    beauty_min: 1,
-    beauty_max: 1
-  },
-  {
-    id: 6,
-    uuid: uuid(),
-    name: "Object 2",
-    description: "A object",
-    biome: "N/A",
+    biome: "Unknown",
     rarity: "object",
     temperament: undefined,
     drop_weight: 1,
@@ -136,6 +118,24 @@ export const testFrogsAndObjects: FrogCryptoFrogData[] = [
   },
   {
     id: 7,
+    uuid: uuid(),
+    name: "Object 2",
+    description: "A object",
+    biome: "Unknown",
+    rarity: "object",
+    temperament: undefined,
+    drop_weight: 1,
+    jump_min: 1,
+    jump_max: 1,
+    speed_min: 1,
+    speed_max: 1,
+    intelligence_min: 1,
+    intelligence_max: 1,
+    beauty_min: 1,
+    beauty_max: 1
+  },
+  {
+    id: 8,
     uuid: uuid(),
     name: "Frog 7",
     description: "A frog",
@@ -153,7 +153,7 @@ export const testFrogsAndObjects: FrogCryptoFrogData[] = [
     beauty_max: 1
   },
   {
-    id: 8,
+    id: 9,
     uuid: uuid(),
     name: "Frog 8",
     description: "A frog",
@@ -241,6 +241,19 @@ export const testFeeds: FrogCryptoDbFeedData[] = [
       cooldown: 600,
       biomes: {
         TheCapital: { dropWeightScaler: 1 }
+      }
+    }
+  },
+  {
+    uuid: "2e65575e-87b8-4777-a770-22ced16ecba8",
+    feed: {
+      name: "Bat",
+      description: "Bat",
+      private: true,
+      activeUntil: Date.now() / 1000 + 3600, // 1 hour from now
+      cooldown: 600,
+      biomes: {
+        Unknown: { dropWeightScaler: 1 }
       }
     }
   }

--- a/packages/eddsa-frog-pcd/src/CardBody.tsx
+++ b/packages/eddsa-frog-pcd/src/CardBody.tsx
@@ -11,15 +11,6 @@ import {
 } from "./EdDSAFrogPCD";
 import { getEdDSAFrogData } from "./utils";
 
-const RARITY_COLORS = {
-  [Rarity.Common]: "#168675",
-  [Rarity.Rare]: "#1197B5",
-  [Rarity.Epic]: "#6F3BB0",
-  [Rarity.Legendary]: "#FF9900",
-  [Rarity.Unknown]: "#A7967E",
-  [Rarity.Object]: "#A7967E"
-} as const;
-
 export function EdDSAFrogCardBody({
   pcd,
   returnHeader
@@ -44,11 +35,20 @@ export function EdDSAFrogCardBody({
       );
     }
 
+    const rarityColors = {
+      [Rarity.Common]: "#168675",
+      [Rarity.Rare]: "#1197B5",
+      [Rarity.Epic]: "#6F3BB0",
+      [Rarity.Legendary]: "#FF9900",
+      [Rarity.Unknown]: "#A7967E",
+      [Rarity.Object]: "#A7967E"
+    } as const;
+
     return (
       <HeaderContainer
         style={{
           backgroundColor:
-            RARITY_COLORS[frogData.rarity] ?? "var(--bg-dark-primary)"
+            rarityColors[frogData.rarity] ?? "var(--bg-dark-primary)"
         }}
       >
         {`#${frogData.frogId} ${frogData.name}`}

--- a/packages/eddsa-frog-pcd/src/EdDSAFrogPCD.ts
+++ b/packages/eddsa-frog-pcd/src/EdDSAFrogPCD.ts
@@ -316,11 +316,10 @@ export function getDisplayOptions(pcd: EdDSAFrogPCD): DisplayOptions {
     };
   }
 
-  const header = `#${frogData.frogId} ${frogData.name}`;
-
   return {
-    header,
-    displayName: header
+    displayName: `#${String(frogData.frogId).padStart(3, "00")} ${
+      frogData.name
+    }`
   };
 }
 

--- a/packages/passport-interface/src/FrogCrypto.ts
+++ b/packages/passport-interface/src/FrogCrypto.ts
@@ -11,6 +11,13 @@ import { Feed } from "./SubscriptionManager";
 export const FROG_FREEROLLS = 2;
 
 /**
+ * The maximum score that a user can have
+ *
+ * Once a user reaches this score, they will no longer be able to earn more PCDs from this feed
+ */
+export const FROG_SCORE_CAP = 1000;
+
+/**
  * Map of configs for Biome(s) where PCDs can be issued from this feed
  */
 export const FrogCryptoFeedBiomeConfigSchema = z.object({


### PR DESCRIPTION
closes https://github.com/proofcarryingdata/zupass/pull/1183/files
https://github.com/proofcarryingdata/zupass/issues/1057

Fixed
* action button to monospace

Changed
* Countdown now says "available now"
* Replace score rank with levels with emojis
* Slightly reduce delay in getting frog from 6s to 4s
* Getting trash no longer increments your score
* FrogCard QR code now shows hex value of serialized PCD

Added
* A score cap of 1000 to avoid people blowing up their localStorage
* Add a new message when you find something strange
* FrogCard header now shows rarity color

updated test cases for server changes 

<img width="379" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/20802104-f345-4812-b2f7-a0fee551c46b">

<img width="379" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/29ec621d-bfcb-4846-b65d-1bd47a4960a7">

<img width="409" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/2a6b656c-e47c-4cf0-9953-813cbed7e93e">

<img width="394" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/d6f0e2fc-f16a-48d8-bf2a-4c36343120b0">
