### PR TITLE
[frogcrypto] redirect frog img requests

### DIFF
--- a/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
+++ b/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
@@ -12,7 +12,6 @@ import {
   PollFeedResponseValue
 } from "@pcd/passport-interface";
 import express, { Request, Response } from "express";
-import request from "request";
 import urljoin from "url-join";
 import { FrogcryptoService } from "../../services/frogcryptoService";
 import { ApplicationContext, GlobalServices } from "../../types";
@@ -92,16 +91,7 @@ export function initFrogcryptoRoutes(
       throw new PCDHTTPError(503, "FrogCrypto Assets Unavailable");
     }
 
-    req
-      .pipe(
-        request(
-          urljoin(process.env.FROGCRYPTO_ASSETS_URL, `${imageId}.png`)
-        ).on("error", (err) => {
-          logger(`[FrogCrypto] Error fetching FrogCrypto Assets: ${err}`);
-          res.sendStatus(503);
-        })
-      )
-      .pipe(res);
+    res.redirect(urljoin(process.env.FROGCRYPTO_ASSETS_URL, `${imageId}.png`));
   });
 
   app.post("/frogcrypto/admin/frogs", async (req, res) => {


### PR DESCRIPTION
https://github.com/proofcarryingdata/zupass/issues/1057

Instead of piping image request, send client a redirect to the static resources site. We now have a custom domain and okay to show where the frogs are. 

tested locally