### PR TITLE
use minimal ethers dep in ethereum ownership pcd

### DIFF
--- a/packages/ethereum-ownership-pcd/package.json
+++ b/packages/ethereum-ownership-pcd/package.json
@@ -33,13 +33,14 @@
     "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
+    "@ethersproject/address": "^5.7.0",
+    "@ethersproject/wallet": "^5.7.0",
     "@pcd/passport-ui": "0.8.0",
     "@pcd/pcd-types": "0.8.0",
     "@pcd/semaphore-identity-pcd": "0.8.0",
     "@pcd/semaphore-signature-pcd": "0.8.0",
     "@pcd/util": "0.2.0",
     "@semaphore-protocol/identity": "^3.14.0",
-    "ethers": "^5.7.2",
     "json-bigint": "^1.0.0",
     "react": "^18.2.0",
     "styled-components": "^5.3.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,7 +1895,7 @@
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/wallet@5.7.0":
+"@ethersproject/wallet@5.7.0", "@ethersproject/wallet@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.7.0.tgz#4e5d0790d96fe21d61d38fb40324e6c7ef350b2d"
   integrity sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==


### PR DESCRIPTION
ethereum-ownership-pcd no longer depends on ethers

https://github.com/proofcarryingdata/zupass/issues/251

This doesn't fully remove ethers dep because circomlibjs depends on it. We will deal with that separately

<img width="518" alt="Screenshot 2023-11-09 at 8 38 38 PM" src="https://github.com/proofcarryingdata/zupass/assets/4317392/424612c4-dfb5-4b51-8bdd-14970f10008c">
