### PR TITLE
Periodic fetch of feeds in background.

### DIFF
--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -241,10 +241,14 @@ class App extends React.Component<object, AppState> {
       console.log("[JOB] failed poll user", e);
     }
 
-    // Trigger sync of E2EE storage, but only if the first-time sync had time
-    // to complete.
+    // Trigger extra download from E2EE storage, and extra fetch of
+    // subscriptions, but only if the first-time sync had time to complete.
     if (this.state.completedFirstSync) {
-      this.update({ ...this.state, extraDownloadRequested: true });
+      this.update({
+        ...this.state,
+        extraDownloadRequested: true,
+        extraSubscriptionFetchRequested: true
+      });
     }
   };
 

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -709,7 +709,10 @@ async function doSync(
     }
   }
 
-  if (!state.loadedIssuedPCDs) {
+  if (
+    !state.loadedIssuedPCDs ||
+    (state.completedFirstSync && state.extraSubscriptionFetchRequested)
+  ) {
     update({ loadingIssuedPCDs: true });
     try {
       console.log("[SYNC] loading issued pcds");
@@ -740,6 +743,7 @@ async function doSync(
     return {
       loadedIssuedPCDs: true,
       loadingIssuedPCDs: false,
+      extraSubscriptionFetchRequested: false,
       pcds: state.pcds,
       subscriptions: state.subscriptions
     };

--- a/apps/passport-client/src/state.ts
+++ b/apps/passport-client/src/state.ts
@@ -60,6 +60,7 @@ export interface AppState {
   loadingIssuedPCDs?: boolean; // Used only to update UI
   completedFirstSync?: boolean;
   extraDownloadRequested?: boolean;
+  extraSubscriptionFetchRequested?: boolean;
 
   // Persistent sync state-machine fields, saved in local storage as a
   // PersistentSyncStatus object.  This is structured to allow for more

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -837,7 +837,7 @@ export class IssuanceService {
   }
 
   private async issueFrogPCDs(): Promise<SerializedPCD[]> {
-    const FROG_INTERVAL_MS = 1000 * 60 * 10; // one new frog every ten minutes
+    const FROG_INTERVAL_MS = 1000 * 60 * 60 * 24; // one new frog every 24h
     // Images are served from passport-client's web host
     const imageServerUrl = process.env.PASSPORT_CLIENT_URL;
 


### PR DESCRIPTION
Add an extra fetch of subscription feeds each time the periodic poll is triggered (every 60s while the app is visible).

The mechanism within the client is identical to what's already done for downloads from E2EE storage, so should be pretty sfae..  The difference is that feeds don't have anything in the network protocol to avoid re-downloading the same actions.  However the use of hashes in the client is now stable enough that applying the same actions repeatedly won't make the PCD collection appear to be different, so won't trigger any extra uploads which could clobber changes.

With that in mind, I also reduced the frequency of the legacy "Frogs" feed to 24h so it doesn't fill a user's Zupass with frogs generated by background polls.  We may want to remove that feed entirely now that Frogcrypto is live, but that's outside the scope of this PR.
