### PR TITLE
[frogcrypto] feed deeplink

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/Button.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/Button.tsx
@@ -23,7 +23,7 @@ export function ActionButton({
    * The action to perform when the button is clicked. This should return a
    * promise that resolves when the action is complete.
    */
-  onClick: () => Promise<void>;
+  onClick: () => Promise<unknown>;
   disabled?: boolean;
   /**
    * The component to use for the button. Defaults to Button.

--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -4,10 +4,8 @@ import prettyMilliseconds from "pretty-ms";
 import { useEffect, useMemo, useState } from "react";
 import styled, { keyframes } from "styled-components";
 import { useSubscriptions } from "../../../src/appHooks";
-import {
-  DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL,
-  useUserFeedState
-} from "./FrogHomeSection";
+import { useUserFeedState } from "./FrogHomeSection";
+import { DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL } from "./useFrogFeed";
 
 /**
  * Render the FrogCrypto folder in the home screen.

--- a/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
@@ -1,7 +1,7 @@
 import { requestFrogCryptoGetScoreboard } from "@pcd/passport-interface";
 import { FrogCryptoScore } from "@pcd/passport-interface/src/FrogCrypto";
 import _ from "lodash";
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";
 import { RippleLoader } from "../../core/RippleLoader";
@@ -68,9 +68,9 @@ function ScoreTable({
       <tbody>
         {scoresByLevel.map((group) => {
           return (
-            <>
+            <Fragment key={group.title}>
               {myScore && (
-                <tr key={group.title}>
+                <tr>
                   <td
                     colSpan={3}
                     style={{ textAlign: "center", padding: "4px 0" }}
@@ -97,7 +97,7 @@ function ScoreTable({
                   <td style={{ textAlign: "right" }}>{score.score}</td>
                 </tr>
               ))}
-            </>
+            </Fragment>
           );
         })}
       </tbody>

--- a/apps/passport-client/components/screens/FrogScreens/useFrogFeed.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/useFrogFeed.tsx
@@ -1,0 +1,151 @@
+import {
+  Feed,
+  FrogCryptoFolderName,
+  IFrogCryptoFeedSchema,
+  requestListFeeds
+} from "@pcd/passport-interface";
+import { useCallback, useEffect, useMemo } from "react";
+import toast from "react-hot-toast";
+import { useSearchParams } from "react-router-dom";
+import urljoin from "url-join";
+import { appConfig } from "../../../src/appConfig";
+import { useDispatch, useSubscriptions } from "../../../src/appHooks";
+
+export const DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL = `${appConfig.zupassServer}/frogcrypto/feeds`;
+
+/**
+ * Returns a callback to register the default frog subscription provider and
+ * subscribes to all public frog feeds and optionally a specific feed.
+ */
+export function useInitializeFrogSubscriptions(): (
+  feedId?: string
+) => Promise<Feed | null> {
+  const dispatch = useDispatch();
+  const { value: subs } = useSubscriptions();
+
+  const initializeFrogSubscriptions = useCallback(
+    async (feedId?: string): Promise<Feed | null> => {
+      subs.getOrAddProvider(
+        DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL,
+        FrogCryptoFolderName
+      );
+
+      function parseAndAddFeed(feed: Feed): boolean {
+        // skip any feeds that are already subscribed to
+        if (
+          subs.getSubscriptionsByProviderAndFeedId(
+            DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL,
+            feed.id
+          ).length > 0
+        ) {
+          return false;
+        }
+
+        const parsed = IFrogCryptoFeedSchema.safeParse(feed);
+        if (parsed.success) {
+          dispatch({
+            type: "add-subscription",
+            providerUrl: DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL,
+            providerName: FrogCryptoFolderName,
+            feed
+          });
+
+          if (parsed.data.activeUntil > Date.now() / 1000) {
+            // don't show toast if feedId is specified
+            if (feed.id !== feedId) {
+              toast.success(
+                `Croak and awe! The ${feed.name} awaits your adventurous leap!`,
+                {
+                  icon: "🏕️"
+                }
+              );
+            }
+
+            return true;
+          }
+        } else {
+          console.error(
+            "Failed to parse feed as FrogFeed",
+            feed,
+            parsed["error"]
+          );
+        }
+
+        return false;
+      }
+
+      const { feeds } = await subs.listFeeds(
+        DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL
+      );
+      if (!feedId && feeds.length === 0) {
+        toast.error(
+          "Hop, hop, hooray! But wait – the adventure isn't ready to ignite just yet. The fireflies haven't finished their dance. Come back shortly, and we'll leap into the fun together!"
+        );
+        return null;
+      }
+      feeds
+        // remove any feeds that we want to custom add
+        .filter((feed) => feed.id !== feedId)
+        .forEach(parseAndAddFeed);
+
+      if (feedId) {
+        try {
+          const res = await requestListFeeds(
+            urljoin(
+              DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL,
+              encodeURIComponent(feedId)
+            )
+          );
+          const feed = res?.value?.feeds?.[0];
+          if (feed) {
+            return parseAndAddFeed(feed) ? feed : null;
+          } else {
+            throw new Error(res?.error || "Feed not found");
+          }
+        } catch (e) {
+          console.error("Failed to fetch feed", feedId, e);
+          throw new Error("Unable to fetch feed");
+        }
+      }
+
+      return null;
+    },
+    [dispatch, subs]
+  );
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const feedId = useMemo(() => {
+    const param = searchParams.get("feedId");
+    return param ? decodeURIComponent(param) : null;
+  }, [searchParams]);
+  useEffect(() => {
+    if (feedId) {
+      toast.promise(
+        new Promise((resolve) => setTimeout(resolve, 3000)).then(() => {
+          setSearchParams((prev) => {
+            prev.delete("feedId");
+            return prev;
+          });
+
+          return initializeFrogSubscriptions(feedId);
+        }),
+        {
+          loading:
+            "Unearthing hidden paths and mystical biomes! Brace yourself for a leap into wonder. Hold on to your lily pads...",
+          success: (feed: Feed | null) =>
+            feed ? (
+              <span>
+                Leapin' lily pads! You've found a secret froggy passage to{" "}
+                <b>{feed.name}</b>. New adventures are just a hop away.
+              </span>
+            ) : (
+              <>You look familiar. Have we met before? No need to leap again.</>
+            ),
+          error: "Seems like this froggy code is a tadpole tad off."
+        }
+      );
+    }
+  }, [feedId, initializeFrogSubscriptions, setSearchParams]);
+
+  return initializeFrogSubscriptions;
+}

--- a/apps/passport-client/components/screens/FrogScreens/useFrogFeed.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/useFrogFeed.tsx
@@ -43,14 +43,15 @@ export function useInitializeFrogSubscriptions(): (
 
         const parsed = IFrogCryptoFeedSchema.safeParse(feed);
         if (parsed.success) {
-          dispatch({
-            type: "add-subscription",
-            providerUrl: DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL,
-            providerName: FrogCryptoFolderName,
-            feed
-          });
-
           if (parsed.data.activeUntil > Date.now() / 1000) {
+            // only add a feed if it is active
+            dispatch({
+              type: "add-subscription",
+              providerUrl: DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL,
+              providerName: FrogCryptoFolderName,
+              feed
+            });
+
             // don't show toast if feedId is specified
             if (feed.id !== feedId) {
               toast.success(
@@ -62,6 +63,16 @@ export function useInitializeFrogSubscriptions(): (
             }
 
             return true;
+          } else if (feed.id === feedId) {
+            // if we are adding an expired from deeplink, show error toast
+            toast.error(
+              <span>
+                Oh no! You've found a secret froggy passage to{" "}
+                <b>{feed.name}</b>. But our fireflies are in another castle.
+                Maybe explore elsewhere and return here when the stars align?
+              </span>
+            );
+            throw new Error("Feed no longer available");
           }
         } else {
           console.error(

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -339,7 +339,7 @@ function RouterImpl() {
           <Route path="subscriptions" element={<SubscriptionsScreen />} />
           <Route path="add-subscription" element={<AddSubscriptionScreen />} />
           <Route path="telegram" element={<HomeScreen />} />
-          <Route path="frog-admin" element={<FrogManagerScreen />} />
+          <Route path="pond-control" element={<FrogManagerScreen />} />
           <Route path="*" element={<MissingScreen />} />
         </Route>
       </Routes>

--- a/apps/passport-client/src/util.ts
+++ b/apps/passport-client/src/util.ts
@@ -95,7 +95,7 @@ export function isFrogCryptoFolder(folderPath: string): boolean {
 }
 
 export function bigintToUint8Array(bigint: bigint): Uint8Array {
-  const hex = bigint.toString(16).padStart(32, "0");
+  const hex = bigint.toString(16).padStart(64, "0");
   const bytes = [];
   for (let i = 0; i < hex.length; i += 2) {
     bytes.push(parseInt(hex.slice(i, i + 2), 16));


### PR DESCRIPTION
Add feed deeplink capability to FrogCryptoHomeScreen. I was originally adding a new deeplink screen but it turns out the toast was hard to manage when navigate between screens.

re-tested initial onboarding experience

Adding a feed already exists

https://github.com/proofcarryingdata/zupass/assets/4317392/e2e9dbdd-5f4f-4335-a16f-3db40ea2da19

Adding an invalid feed

https://github.com/proofcarryingdata/zupass/assets/4317392/3332894b-e809-492b-8d4a-7e55752c39ac

Adding a new feed

https://github.com/proofcarryingdata/zupass/assets/4317392/087a5888-9916-47fe-a174-4abef9184527

