### PR TITLE
[frogcrypto] slow down confetti

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/useFrogParticles.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/useFrogParticles.tsx
@@ -186,8 +186,8 @@ export function useFrogConfetti() {
         acceleration: 9.81
       },
       speed: {
-        min: 30,
-        max: 60
+        min: 20,
+        max: 40
       },
       decay: 0.05,
       direction: "none",


### PR DESCRIPTION
https://github.com/proofcarryingdata/zupass/pull/1219 make confetti a little too explosive but was on the right direction. This should tone it down a bit.