### PR TITLE
Include zero-values in Semaphore API response

### DIFF
--- a/apps/passport-server/src/routing/routes/semaphoreRoutes.ts
+++ b/apps/passport-server/src/routing/routes/semaphoreRoutes.ts
@@ -110,13 +110,6 @@ export function initSemaphoreRoutes(
 
     const result = serializeSemaphoreGroup(namedGroup.group, namedGroup.name);
 
-    // Removing a member from a Semaphore group causes their entry in the
-    // members list to be replaced with a "zero value", so we should filter
-    // out removed members before sending the response.
-    result.members = result.members.filter(
-      (m) => m !== namedGroup.group.zeroValue.toString()
-    );
-
     res.json(result satisfies SerializedSemaphoreGroup);
   });
 }

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -1824,9 +1824,11 @@ describe("devconnect functionality", function () {
     );
     expect(attendeeGroupResult.success).to.be.true;
     if (attendeeGroupResult.success) {
-      expect(attendeeGroupResult.value.members).to.deep.eq([
-        ...loggedInIdentityCommitments
-      ]);
+      expect(
+        attendeeGroupResult.value.members.filter(
+          (member) => member !== attendeeGroupResult.value.zeroValue
+        )
+      ).to.deep.eq([...loggedInIdentityCommitments]);
     }
 
     const organizerGroupResult = await requestSemaphoreGroup(
@@ -1834,9 +1836,11 @@ describe("devconnect functionality", function () {
     );
     expect(organizerGroupResult.success).to.be.true;
     if (organizerGroupResult.success) {
-      expect(organizerGroupResult.value.members).to.deep.eq([
-        ...loggedInIdentityCommitments
-      ]);
+      expect(
+        organizerGroupResult.value.members.filter(
+          (member) => member !== organizerGroupResult.value.zeroValue
+        )
+      ).to.deep.eq([...loggedInIdentityCommitments]);
     }
   });
 

--- a/packages/semaphore-group-pcd/src/SerializedSemaphoreGroup.ts
+++ b/packages/semaphore-group-pcd/src/SerializedSemaphoreGroup.ts
@@ -5,6 +5,7 @@ export interface SerializedSemaphoreGroup {
   name: string;
   members: string[];
   depth: number;
+  zeroValue: string;
 }
 
 export function serializeSemaphoreGroup(
@@ -15,7 +16,8 @@ export function serializeSemaphoreGroup(
     id: group.id.toString(),
     name,
     members: group.members.map((m) => m.toString()),
-    depth: group.depth
+    depth: group.depth,
+    zeroValue: group.zeroValue.toString()
   };
 }
 


### PR DESCRIPTION
Rather than filtering out zero-values from the Semaphore group on the server-side, return the full set of values and also tell the client which one is the zero-value. This allows clients to filter out deleted group members themselves where necessary (e.g. as done in our tests).