### PR TITLE
Remove "white-out" for scanned tickets

### DIFF
--- a/packages/eddsa-ticket-pcd/src/utils.ts
+++ b/packages/eddsa-ticket-pcd/src/utils.ts
@@ -80,7 +80,7 @@ export function getQRCodeColorOverride(
 ): string | undefined {
   const ticketData = getEdDSATicketData(pcd);
 
-  if (!ticketData || ticketData.isConsumed || ticketData.isRevoked) {
+  if (!ticketData || ticketData.isRevoked) {
     return INVALID_TICKET_QR_CODE_COLOR;
   }
 


### PR DESCRIPTION
As per request from Devconnect Team, we will no longer white out tickets that are consumed, as that prevent rescanning the ticket (and we still make sure to gate checking in).