### PR TITLE
Cache checkin credentials

### DIFF
--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -150,7 +150,11 @@ class App extends React.Component<object, AppState> {
   generateCheckinCredential = async () => {
     // This ensures that the check-in credential is pre-cached before the
     // first check-in attempt.
-    await getOrGenerateCheckinCredential(this.state.identity);
+    try {
+      await getOrGenerateCheckinCredential(this.state.identity);
+    } catch (e) {
+      console.log("Could not get or generate checkin credential:", e);
+    }
   };
 
   jobCheckConnectivity = async () => {

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -1,7 +1,7 @@
 import {
   createStorageBackedCredentialCache,
-  offlineTickets,
-  offlineTicketsCheckin
+  requestOfflineTickets,
+  requestOfflineTicketsCheckin
 } from "@pcd/passport-interface";
 import { isWebAssemblySupported } from "@pcd/util";
 import { Identity } from "@semaphore-protocol/identity";
@@ -39,6 +39,7 @@ import {
   closeBroadcastChannel,
   setupBroadcastChannel
 } from "../src/broadcastChannel";
+import { getOrGenerateCheckinCredential } from "../src/checkin";
 import {
   Action,
   StateContext,
@@ -143,6 +144,13 @@ class App extends React.Component<object, AppState> {
     this.setupPolling();
     this.startJobSyncOfflineCheckins();
     this.jobCheckConnectivity();
+    this.generateCheckinCredential();
+  };
+
+  generateCheckinCredential = async () => {
+    // This ensures that the check-in credential is pre-cached before the
+    // first check-in attempt.
+    await getOrGenerateCheckinCredential(this.state.identity);
   };
 
   jobCheckConnectivity = async () => {
@@ -263,10 +271,15 @@ class App extends React.Component<object, AppState> {
     }
 
     if (this.state.checkedinOfflineDevconnectTickets.length > 0) {
-      const checkinOfflineTicketsResult = await offlineTicketsCheckin(
+      const checkinOfflineTicketsResult = await requestOfflineTicketsCheckin(
         appConfig.zupassServer,
-        this.state.identity,
-        this.state.checkedinOfflineDevconnectTickets
+        {
+          checkedOfflineInDevconnectTicketIDs:
+            this.state.checkedinOfflineDevconnectTickets.map((t) => t.id),
+          checkerProof: await getOrGenerateCheckinCredential(
+            this.state.identity
+          )
+        }
       );
 
       if (checkinOfflineTicketsResult.success) {
@@ -278,9 +291,11 @@ class App extends React.Component<object, AppState> {
       }
     }
 
-    const offlineTicketsResult = await offlineTickets(
+    const offlineTicketsResult = await requestOfflineTickets(
       appConfig.zupassServer,
-      this.state.identity
+      {
+        checkerProof: await getOrGenerateCheckinCredential(this.state.identity)
+      }
     );
 
     if (offlineTicketsResult.success) {

--- a/apps/passport-client/src/checkin.ts
+++ b/apps/passport-client/src/checkin.ts
@@ -26,7 +26,9 @@ import {
 export async function getOrGenerateCheckinCredential(
   identity: Identity
 ): Promise<SerializedPCD<SemaphoreSignaturePCD>> {
-  let cachedSignaturePCD = loadCheckinCredential();
+  let cachedSignaturePCD = loadCheckinCredential(
+    identity.getCommitment().toString()
+  );
   if (!cachedSignaturePCD) {
     cachedSignaturePCD = await SemaphoreSignaturePCDPackage.serialize(
       await SemaphoreSignaturePCDPackage.prove({
@@ -45,7 +47,10 @@ export async function getOrGenerateCheckinCredential(
       })
     );
 
-    saveCheckinCredential(cachedSignaturePCD);
+    saveCheckinCredential(
+      identity.getCommitment().toString(),
+      cachedSignaturePCD
+    );
   }
 
   return cachedSignaturePCD;

--- a/apps/passport-client/src/localstorage.ts
+++ b/apps/passport-client/src/localstorage.ts
@@ -200,16 +200,20 @@ export function loadUsingLaserScanner() {
 }
 
 export function saveCheckinCredential(
+  key: string,
   serializedPCD: SerializedPCD<SemaphoreSignaturePCD>
 ): void {
-  window.localStorage["checkin_credential"] = JSON.stringify(serializedPCD);
+  window.localStorage[`checkin_credential_${key}`] =
+    JSON.stringify(serializedPCD);
 }
 
-export function loadCheckinCredential():
-  | SerializedPCD<SemaphoreSignaturePCD>
-  | undefined {
+export function loadCheckinCredential(
+  key: string
+): SerializedPCD<SemaphoreSignaturePCD> | undefined {
   try {
-    const serializedPCD = JSON.parse(window.localStorage["checkin_credential"]);
+    const serializedPCD = JSON.parse(
+      window.localStorage[`checkin_credential_${key}`]
+    );
     if (serializedPCD) {
       return serializedPCD;
     }

--- a/apps/passport-client/src/localstorage.ts
+++ b/apps/passport-client/src/localstorage.ts
@@ -7,6 +7,8 @@ import {
   User
 } from "@pcd/passport-interface";
 import { PCDCollection } from "@pcd/pcd-collection";
+import { SerializedPCD } from "@pcd/pcd-types";
+import { SemaphoreSignaturePCD } from "@pcd/semaphore-signature-pcd";
 import { Identity } from "@semaphore-protocol/identity";
 import { z } from "zod";
 import { getPackages } from "./pcdPackages";
@@ -195,4 +197,24 @@ export function saveUsingLaserScanner(usingLaserScanner: boolean) {
 
 export function loadUsingLaserScanner() {
   return window.localStorage["using_laser_scanner"] === "true";
+}
+
+export function saveCheckinCredential(
+  serializedPCD: SerializedPCD<SemaphoreSignaturePCD>
+): void {
+  window.localStorage["checkin_credential"] = JSON.stringify(serializedPCD);
+}
+
+export function loadCheckinCredential():
+  | SerializedPCD<SemaphoreSignaturePCD>
+  | undefined {
+  try {
+    const serializedPCD = JSON.parse(window.localStorage["checkin_credential"]);
+    if (serializedPCD) {
+      return serializedPCD;
+    }
+  } catch (e) {
+    // Do nothing
+  }
+  return undefined;
 }


### PR DESCRIPTION
To speed up check-in, cache the semaphore signature PCD in local storage.

closes https://github.com/proofcarryingdata/zupass/issues/1227