### PR TITLE
ZK mode verification

### DIFF
--- a/apps/passport-client/components/screens/DevconnectCheckinByIdScreen.tsx
+++ b/apps/passport-client/components/screens/DevconnectCheckinByIdScreen.tsx
@@ -132,7 +132,6 @@ function useTicketId(): TicketId {
 function TicketErrorContent({ error }: { error: TicketError }) {
   let errorContent = null;
 
-  console.log(error);
   switch (error.name) {
     case "AlreadyCheckedIn":
       errorContent = (
@@ -203,7 +202,7 @@ function TicketErrorContent({ error }: { error: TicketError }) {
   return <ErrorContainer>{errorContent}</ErrorContainer>;
 }
 
-function TicketError({ error }: { error: TicketError }) {
+export function TicketError({ error }: { error: TicketError }) {
   const usingLaserScanner = loadUsingLaserScanner();
   return (
     <>
@@ -248,7 +247,7 @@ function Home() {
   );
 }
 
-function UserReadyForCheckin({
+export function UserReadyForCheckin({
   ticketData,
   ticketId
 }: {
@@ -263,7 +262,7 @@ function UserReadyForCheckin({
   );
 }
 
-function useCheckTicketById(ticketId: string | undefined):
+export function useCheckTicketById(ticketId: string | undefined):
   | {
       loading: true;
       result: undefined;

--- a/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
+++ b/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
@@ -190,7 +190,7 @@ export function SecondPartyTicketVerifyScreen() {
         <ZKNoticeContainer>
           <h2>Zero-knowledge ticket</h2>
           <p>
-            You can't check this ticket in, as you're not an organizer for the
+            You can't check this ticket in, as you're not event staff for the
             event.
           </p>
           <p>However, you can see the following ticket information:</p>

--- a/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
+++ b/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
@@ -161,7 +161,7 @@ export function SecondPartyTicketVerifyScreen() {
         <Container>
           <TextCenter>
             <ZKCheckinNotice>
-              As an event organizer, you can see this check-in information from
+              As event staff, you can see this check-in information from
               the Pretix API:
             </ZKCheckinNotice>
             {checkResult.success && (

--- a/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
+++ b/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
@@ -220,6 +220,19 @@ export function SecondPartyTicketVerifyScreen() {
               </>
             )}
           </dl>
+          <p>
+            The following information is <strong>NOT</strong> revealed:
+          </p>
+          <dl>
+            <dt>Ticket-holder email</dt>
+            <dd>
+              <strong>HIDDEN</strong>
+            </dd>
+            <dt>Ticket-holder name</dt>
+            <dd>
+              <strong>HIDDEN</strong>
+            </dd>
+          </dl>
         </ZKNoticeContainer>
       </AppContainer>
     );
@@ -457,6 +470,7 @@ const ZKNoticeContainer = styled.div`
     display: inline-block;
     width: 30%;
     vertical-align: top;
+    margin-bottom: 8px;
   }
 
   dd {

--- a/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
+++ b/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
@@ -160,6 +160,10 @@ export function SecondPartyTicketVerifyScreen() {
       <AppContainer bg={"primary"}>
         <Container>
           <TextCenter>
+            <ZKCheckinNotice>
+              As an event organizer, you can see this check-in information from
+              the Pretix API:
+            </ZKCheckinNotice>
             {checkResult.success && (
               <UserReadyForCheckin
                 ticketData={checkResult.value}
@@ -228,12 +232,11 @@ export function SecondPartyTicketVerifyScreen() {
       <TextCenter>
         <img draggable="false" width="90" height="90" src={icon} />
         <Spacer h={24} />
-        {checkResult.success === false &&
-          verifyResult.outcome === VerifyOutcome.KnownTicketType && (
-            <>
-              <H4 col="var(--accent-dark)">PROOF VERIFIED.</H4>
-            </>
-          )}
+        {verifyResult.outcome === VerifyOutcome.KnownTicketType && (
+          <>
+            <H4 col="var(--accent-dark)">PROOF VERIFIED.</H4>
+          </>
+        )}
 
         {verifyResult.outcome === VerifyOutcome.NotVerified && (
           <>
@@ -257,14 +260,12 @@ export function SecondPartyTicketVerifyScreen() {
         )}
       </Placeholder>
       <Spacer h={64} />
-      {checkResult.success === false && (
-        <CenterColumn w={280}>
-          <LinkButton to="/scan">Verify another</LinkButton>
-          <Spacer h={8} />
-          <LinkButton to="/">Back to Zupass</LinkButton>
-          <Spacer h={24} />
-        </CenterColumn>
-      )}
+      <CenterColumn w={280}>
+        <LinkButton to="/scan">Verify another</LinkButton>
+        <Spacer h={8} />
+        <LinkButton to="/">Back to Zupass</LinkButton>
+        <Spacer h={24} />
+      </CenterColumn>
     </AppContainer>
   );
 }
@@ -319,8 +320,6 @@ function VerifiedAndKnownTicket({
 }
 
 function useDecodedPayload(encodedQRPayload: string) {
-  // decodedPCD is a JSON.stringify'd {@link SerializedPCD}
-  const decodedPayload = decodeQRPayload(encodedQRPayload);
   const [pcd, setPcd] = useState(null);
   const [serializedPCD, setSerializedPCD] = useState(null);
   const pcds = usePCDCollection();
@@ -328,15 +327,19 @@ function useDecodedPayload(encodedQRPayload: string) {
   useEffect(() => {
     (async () => {
       try {
-        const serializedPCD = JSON.parse(decodedPayload);
-        const pcd = await pcds.deserialize(serializedPCD);
-        setPcd(pcd);
-        setSerializedPCD(serializedPCD);
+        if (encodedQRPayload) {
+          // decodedPCD is a JSON.stringify'd {@link SerializedPCD}
+          const decodedPayload = decodeQRPayload(encodedQRPayload);
+          const serializedPCD = JSON.parse(decodedPayload);
+          const pcd = await pcds.deserialize(serializedPCD);
+          setPcd(pcd);
+          setSerializedPCD(serializedPCD);
+        }
       } catch (e) {
         console.log("Could not deserialize PCD:", e);
       }
     })();
-  }, [decodedPayload, pcds]);
+  }, [encodedQRPayload, pcds]);
 
   return { pcd, serializedPCD };
 }
@@ -462,4 +465,9 @@ const ZKNoticeContainer = styled.div`
     color: var(--accent-lite);
     margin-bottom: 8px;
   }
+`;
+
+const ZKCheckinNotice = styled.div`
+  margin-bottom: 16px;
+  color: var(--accent-dark);
 `;

--- a/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
+++ b/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
@@ -191,16 +191,10 @@ export function SecondPartyTicketVerifyScreen() {
           </p>
           <p>However, you can see the following ticket information:</p>
           <dl>
-            {verifyResult.ticketId && (
+            {pcd.claim.partialTicket.ticketId && (
               <>
                 <dt>Ticket ID</dt>
-                <dd>{verifyResult.ticketId}</dd>
-              </>
-            )}
-            {verifyResult.ticketName && (
-              <>
-                <dt>Ticket name</dt>
-                <dd>{verifyResult.ticketName}</dd>
+                <dd>{pcd.claim.partialTicket.ticketId}</dd>
               </>
             )}
             {pcd.claim.partialTicket.eventId && (
@@ -213,12 +207,6 @@ export function SecondPartyTicketVerifyScreen() {
               <>
                 <dt>Product ID</dt>
                 <dd>{pcd.claim.partialTicket.productId}</dd>
-              </>
-            )}
-            {verifyResult.ticketName && (
-              <>
-                <dt>Ticket name</dt>
-                <dd>{verifyResult.ticketName}</dd>
               </>
             )}
             {verifyResult.publicKeyName && (

--- a/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
+++ b/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
@@ -119,7 +119,7 @@ export function SecondPartyTicketVerifyScreen() {
         setCheckResult(result);
       }
     })();
-  }, [setCheckResult, pcd, stateContext]);
+  }, [pcd, stateContext]);
 
   const bg = checkResult && checkResult.success === true ? "primary" : "gray";
 

--- a/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
+++ b/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
@@ -6,7 +6,7 @@ import {
   requestVerifyTicketById
 } from "@pcd/passport-interface";
 import { decodeQRPayload } from "@pcd/passport-ui";
-import { PCD } from "@pcd/pcd-types";
+import { PCD, SerializedPCD } from "@pcd/pcd-types";
 import { isZKEdDSAEventTicketPCD } from "@pcd/zk-eddsa-event-ticket-pcd";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
@@ -333,8 +333,8 @@ function VerifiedAndKnownTicket({
 }
 
 function useDecodedPayload(encodedQRPayload: string) {
-  const [pcd, setPcd] = useState(null);
-  const [serializedPCD, setSerializedPCD] = useState(null);
+  const [pcd, setPcd] = useState<PCD>(null);
+  const [serializedPCD, setSerializedPCD] = useState<SerializedPCD>(null);
   const pcds = usePCDCollection();
 
   useEffect(() => {
@@ -343,7 +343,7 @@ function useDecodedPayload(encodedQRPayload: string) {
         if (encodedQRPayload) {
           // decodedPCD is a JSON.stringify'd {@link SerializedPCD}
           const decodedPayload = decodeQRPayload(encodedQRPayload);
-          const serializedPCD = JSON.parse(decodedPayload);
+          const serializedPCD: SerializedPCD = JSON.parse(decodedPayload);
           const pcd = await pcds.deserialize(serializedPCD);
           setPcd(pcd);
           setSerializedPCD(serializedPCD);
@@ -365,7 +365,10 @@ function useDecodedPayload(encodedQRPayload: string) {
  *
  * Returns a {@link VerifyResult}
  */
-async function verify(pcd: PCD, serializedPCD: string): Promise<VerifyResult> {
+async function verify(
+  pcd: PCD,
+  serializedPCD: SerializedPCD
+): Promise<VerifyResult> {
   const result = await requestVerifyTicket(appConfig.zupassServer, {
     pcd: JSON.stringify(serializedPCD)
   });

--- a/apps/passport-client/components/shared/cards/DevconnectTicket.tsx
+++ b/apps/passport-client/components/shared/cards/DevconnectTicket.tsx
@@ -4,9 +4,9 @@ import {
   getQRCodeColorOverride
 } from "@pcd/eddsa-ticket-pcd";
 import {
-  encodeQRPayload,
   QRDisplayWithRegenerateAndStorage,
-  Spacer
+  Spacer,
+  encodeQRPayload
 } from "@pcd/passport-ui";
 import { ArgumentTypeName } from "@pcd/pcd-types";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
@@ -26,9 +26,9 @@ function makeTicketIdVerifyLink(ticketId: string): string {
 }
 
 function makeTicketIdPCDVerifyLink(pcdStr: string): string {
-  const link = `${
-    window.location.origin
-  }/#/checkin-by-id?pcd=${encodeURIComponent(pcdStr)}`;
+  const link = `${window.location.origin}/#/verify?pcd=${encodeURIComponent(
+    pcdStr
+  )}`;
   return link;
 }
 
@@ -61,7 +61,8 @@ function TicketQR({ pcd, zk }: { pcd: EdDSATicketPCD; zk: boolean }) {
           value: {
             revealEventId: true,
             revealProductId: true,
-            revealTicketId: true
+            revealTicketId: true,
+            revealTicketCategory: true
           },
           argumentType: ArgumentTypeName.ToggleList
         },

--- a/apps/passport-client/components/shared/cards/ZKTicket.tsx
+++ b/apps/passport-client/components/shared/cards/ZKTicket.tsx
@@ -6,9 +6,9 @@ import {
 } from "@pcd/eddsa-ticket-pcd";
 import { ZUCONNECT_23_DAY_PASS_PRODUCT_ID } from "@pcd/passport-interface";
 import {
-  encodeQRPayload,
   QRDisplayWithRegenerateAndStorage,
-  Spacer
+  Spacer,
+  encodeQRPayload
 } from "@pcd/passport-ui";
 import { ArgumentTypeName } from "@pcd/pcd-types";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";

--- a/apps/passport-client/src/sharedConstants.ts
+++ b/apps/passport-client/src/sharedConstants.ts
@@ -2,7 +2,7 @@
  * Single constant shared between the service worker and the page code which
  * registers it.
  */
-export const SERVICE_WORKER_ENABLED = true; // process.env.NODE_ENV !== "development";
+export const SERVICE_WORKER_ENABLED = process.env.NODE_ENV !== "development";
 
 /** Start time of Devconnect 2023, from https://devconnect.org/schedule */
 export const DEVCONNECT_2023_START = Date.parse(

--- a/apps/passport-client/src/sharedConstants.ts
+++ b/apps/passport-client/src/sharedConstants.ts
@@ -2,7 +2,7 @@
  * Single constant shared between the service worker and the page code which
  * registers it.
  */
-export const SERVICE_WORKER_ENABLED = process.env.NODE_ENV !== "development";
+export const SERVICE_WORKER_ENABLED = true; // process.env.NODE_ENV !== "development";
 
 /** Start time of Devconnect 2023, from https://devconnect.org/schedule */
 export const DEVCONNECT_2023_START = Date.parse(

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -526,31 +526,6 @@ export class IssuanceService {
         };
       }
 
-      if (ticketInDb.is_deleted) {
-        return {
-          error: {
-            name: "TicketRevoked",
-            revokedTimestamp: Date.now(),
-            detailedMessage:
-              "The ticket has been revoked. Please check with the event host."
-          },
-          success: false
-        };
-      }
-
-      if (ticketInDb.is_consumed) {
-        return {
-          error: {
-            name: "AlreadyCheckedIn",
-            checker: ticketInDb.checker ?? undefined,
-            checkinTimestamp: (
-              ticketInDb.zupass_checkin_timestamp ?? new Date()
-            ).toISOString()
-          },
-          success: false
-        };
-      }
-
       if (
         !(await SemaphoreSignaturePCDPackage.verify(signature)) ||
         signature.claim.signedMessage !== ISSUANCE_STRING
@@ -596,6 +571,31 @@ export class IssuanceService {
             name: "NotSuperuser",
             detailedMessage:
               "You do not have permission to check this ticket in. Please check with the event host."
+          },
+          success: false
+        };
+      }
+
+      if (ticketInDb.is_deleted) {
+        return {
+          error: {
+            name: "TicketRevoked",
+            revokedTimestamp: Date.now(),
+            detailedMessage:
+              "The ticket has been revoked. Please check with the event host."
+          },
+          success: false
+        };
+      }
+
+      if (ticketInDb.is_consumed) {
+        return {
+          error: {
+            name: "AlreadyCheckedIn",
+            checker: ticketInDb.checker ?? undefined,
+            checkinTimestamp: (
+              ticketInDb.zupass_checkin_timestamp ?? new Date()
+            ).toISOString()
           },
           success: false
         };
@@ -1274,7 +1274,6 @@ export class IssuanceService {
     req: VerifyTicketRequest
   ): Promise<VerifyTicketResult> {
     const pcdStr = req.pcd;
-
     try {
       return this.verifyZuconnect23OrZuzalu23Ticket(JSON.parse(pcdStr));
     } catch (e) {


### PR DESCRIPTION
Closes #1201 

When scanning a ZK QR code users now see:

Devconnect, non-superuser:
<img width="550" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/aca86782-7e93-49b4-b8f0-ad3c0efe9ff3">

Devconnect, superuser:
<img width="448" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/9d4f6455-2fac-49ef-8647-4c146d6584d5">

ZuConnect ticket, all user types:
<img width="476" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/b5cbb03e-a56c-4b49-8e64-d4c69bcedaf6">

Non-ZK ticket scanning is not changed.