### PR TITLE
Make laser keystroke scanning more robust

### DIFF
--- a/apps/passport-client/components/screens/DevconnectCheckinByIdScreen.tsx
+++ b/apps/passport-client/components/screens/DevconnectCheckinByIdScreen.tsx
@@ -7,7 +7,11 @@ import { Spacer, decodeQRPayload } from "@pcd/passport-ui";
 import { ZKEdDSAEventTicketPCDPackage } from "@pcd/zk-eddsa-event-ticket-pcd";
 import { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
-import { useQuery, useStateContext } from "../../src/appHooks";
+import {
+  useLaserScannerKeystrokeInput,
+  useQuery,
+  useStateContext
+} from "../../src/appHooks";
 import {
   devconnectCheckByIdWithOffline,
   devconnectCheckInByIdWithOffline
@@ -24,6 +28,7 @@ import {
 } from "../shared/PCDCard";
 
 export function DevconnectCheckinByIdScreen() {
+  useLaserScannerKeystrokeInput();
   const { loading: verifyingTicketId, ticketId } = useTicketId();
 
   let content = null;

--- a/apps/passport-client/src/appHooks.ts
+++ b/apps/passport-client/src/appHooks.ts
@@ -20,7 +20,7 @@ import { loadUsingLaserScanner } from "./localstorage";
 import { AppError, AppState } from "./state";
 import { useSelector } from "./subscribe";
 import { hasSetupPassword } from "./user";
-import { getLastValidURL, maybeRedirect } from "./util";
+import { getLastValidVerifyUrl, maybeRedirect } from "./util";
 
 export function usePCDCollectionWithHash(): {
   pcds: PCDCollection;
@@ -208,11 +208,13 @@ export function useLaserScannerKeystrokeInput() {
     function handleKeyDown(event: KeyboardEvent) {
       if (!usingLaserScanner) return;
       if (event.key === "Enter") {
-        // Check URL regex and navigate to the last match, if it exists
-        const url = getLastValidURL(typedText);
-        const newLoc = maybeRedirect(url);
-        if (newLoc) {
-          nav(newLoc);
+        // Get the verify URL from the keystroke input and navigate to the last match, if it exists
+        const url = getLastValidVerifyUrl(typedText);
+        if (url) {
+          const newLoc = maybeRedirect(url);
+          if (newLoc) {
+            nav(newLoc);
+          }
         }
       }
       // Ignore characters that could not be in a valid URL

--- a/apps/passport-client/src/util.ts
+++ b/apps/passport-client/src/util.ts
@@ -2,6 +2,7 @@ import { FrogCryptoFolderName } from "@pcd/passport-interface";
 import { splitPath } from "@pcd/pcd-collection";
 import { sleep } from "@pcd/util";
 import validator from "email-validator";
+import _ from "lodash";
 import { v4 as uuid } from "uuid";
 import { Dispatcher } from "./dispatch";
 
@@ -57,20 +58,8 @@ export function validateEmail(email: string): boolean {
   return validator.validate(email);
 }
 
-// Given an input string, fetches the last substring that matches a valid http(s) URL
-export function getLastValidURL(inputString: string) {
-  const urlRegex = /(https?:\/\/[^\s/$.?#].[^\s]*)$/i;
-  const matches = inputString.match(urlRegex);
-
-  if (matches) {
-    return matches[matches.length - 1];
-  } else {
-    return null;
-  }
-}
-
-export function maybeRedirect(text: string): string | null {
-  const verifyUrlPrefixes = [
+function getVerifyUrlPrefixes(): string[] {
+  return [
     `${window.location.origin}/#/verify`,
     `${window.location.origin}#/verify`,
     `${window.location.origin}/#/checkin`,
@@ -78,7 +67,23 @@ export function maybeRedirect(text: string): string | null {
     `${window.location.origin}/#/checkin-by-id`,
     `${window.location.origin}#/checkin-by-id`
   ];
-  if (verifyUrlPrefixes.find((prefix) => text.startsWith(prefix))) {
+}
+
+// Given an input string, check if there exists a ticket verify URL within it.
+// If so, return the last occurance of a verify URL. If not, return null.
+export function getLastValidVerifyUrl(inputString: string) {
+  const lastValidUrlStartIdx = _.chain(getVerifyUrlPrefixes())
+    .map((verifyUrlPrefix) => inputString.lastIndexOf(verifyUrlPrefix))
+    .max()
+    .value();
+  if (lastValidUrlStartIdx !== -1) {
+    return inputString.slice(lastValidUrlStartIdx);
+  }
+  return null;
+}
+
+export function maybeRedirect(text: string): string | null {
+  if (getVerifyUrlPrefixes().find((prefix) => text.startsWith(prefix))) {
     const hash = text.substring(text.indexOf("#") + 1);
     console.log(`Redirecting to ${hash}`);
     return hash;

--- a/apps/passport-client/test/util.spec.ts
+++ b/apps/passport-client/test/util.spec.ts
@@ -1,0 +1,51 @@
+import assert from "assert";
+import { getLastValidVerifyUrl } from "../src/util";
+
+describe("util", async function () {
+  const mockOrigin = "https://zupass.org";
+  const verifyUrl = `${mockOrigin}/#/verify?id=asdf`;
+  const checkinUrl = `${mockOrigin}/#/checkin?id=asdf`;
+  const checkinByIdUrl = `${mockOrigin}/#/checkin-by-id?id=asdf`;
+  const otherZupassUrl = `${mockOrigin}/#/login`;
+
+  beforeEach(() => {
+    Object.defineProperty(global, "window", {
+      value: {
+        location: {
+          origin: mockOrigin
+        }
+      }
+    });
+  });
+
+  afterEach(() => {
+    delete global.window.location;
+  });
+
+  it("getLastValidVerifyUrl: function works as intended", function () {
+    assert.equal(getLastValidVerifyUrl(""), null);
+    assert.equal(getLastValidVerifyUrl(`${otherZupassUrl}`), null);
+    assert.equal(getLastValidVerifyUrl(`${verifyUrl}`), verifyUrl);
+    assert.equal(getLastValidVerifyUrl(`asdf${verifyUrl}`), verifyUrl);
+    assert.equal(
+      getLastValidVerifyUrl(`asdf${verifyUrl}${verifyUrl}`),
+      verifyUrl
+    );
+    assert.equal(
+      getLastValidVerifyUrl(
+        `...${otherZupassUrl}${checkinByIdUrl}${verifyUrl}`
+      ),
+      verifyUrl
+    );
+    assert.equal(
+      getLastValidVerifyUrl(
+        `${otherZupassUrl}${checkinByIdUrl}zxvc${checkinByIdUrl}`
+      ),
+      checkinByIdUrl
+    );
+    assert.equal(
+      getLastValidVerifyUrl(`${checkinByIdUrl}${otherZupassUrl}${checkinUrl}`),
+      checkinUrl
+    );
+  });
+});


### PR DESCRIPTION
This PR does two things
1. It makes the function for reading keystrokes far more robust. Previously, the regex was failing is certain keystrokes were entered. Added tests for completeness.
2. Enables laser scanning on the Devconnect check in screen, as it's somewhat easy to forget to press the "Scan another ticket" button on that screen to go back to the main scan screen.