### PR TITLE
[frogcrypto] wire frog qr codes

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/FrogSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogSubscriptionScreen.tsx
@@ -1,13 +1,44 @@
+import { FrogCryptoFolderName } from "@pcd/passport-interface";
 import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { useIsSyncSettled, useSubscriptions } from "../../../src/appHooks";
+import { useSyncE2EEStorage } from "../../../src/useSyncE2EEStorage";
+import { RippleLoader } from "../../core/RippleLoader";
+import { DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL } from "./useFrogFeed";
+
+export const FROM_SUBSCRIPTION_PARAM_KEY = "fromFrogSubscription";
 
 /**
  * A screen where the user can subscribe to new frog feeds via deeplink.
  */
 export function FrogSubscriptionScreen() {
-  useEffect(() => {
-    // redirect to the frog manager screen
-    window.location.replace("/#/?folder=FrogCrypto");
-  }, []);
+  useSyncE2EEStorage();
+  const syncSettled = useIsSyncSettled();
 
-  return <></>;
+  // get current frog subscriptions
+  const { value: subs } = useSubscriptions();
+  const frogSubs = subs.getSubscriptionsForProvider(
+    DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL
+  );
+  const hasFrogSubs = frogSubs.length > 0;
+
+  const { feedCode } = useParams();
+
+  useEffect(() => {
+    if (syncSettled) {
+      // if the user has no frog subscriptions,
+      // redirect to the frog manager screen
+      if (!hasFrogSubs || !feedCode) {
+        window.location.replace(
+          `/#/?folder=${FrogCryptoFolderName}&${FROM_SUBSCRIPTION_PARAM_KEY}=true`
+        );
+      } else {
+        window.location.replace(
+          `/#/?folder=${FrogCryptoFolderName}&feedId=${feedCode}`
+        );
+      }
+    }
+  }, [feedCode, hasFrogSubs, syncSettled]);
+
+  return <RippleLoader />;
 }

--- a/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
@@ -231,7 +231,11 @@ function feedParser(data: string): FrogCryptoDbFeedData[] {
         private: Boolean(rawFeed.private),
         activeUntil: Math.round(new Date(rawFeed.activeUntil).getTime() / 1000),
         cooldown: Number.parseInt(rawFeed.cooldown),
-        biomes: parseBiomes(rawFeed)
+        biomes: parseBiomes(rawFeed),
+        codes: rawFeed.codes
+          ?.split(",")
+          ?.map((code: string) => code.trim())
+          ?.filter(Boolean)
       }
     } satisfies FrogCryptoDbFeedData;
 
@@ -271,7 +275,8 @@ function feedUnparser(feeds: FrogCryptoDbFeedData[]): string {
           return acc;
         },
         {} as Record<string, any>
-      )
+      ),
+      codes: feed.feed.codes?.join(",")
     })),
     null,
     2
@@ -370,6 +375,19 @@ export function DataTable({
                 <p key={biome}>
                   {biome}: {JSON.stringify(biomes[biome])}
                 </p>
+              ))}
+            </div>
+          );
+        },
+        codes: (row) => {
+          const codes = row["codes"];
+          if (!codes) {
+            return "<undefined>";
+          }
+          return (
+            <div>
+              {codes.map((code) => (
+                <p key={code}>{code}</p>
               ))}
             </div>
           );

--- a/apps/passport-client/components/screens/FrogScreens/useFrogFeed.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/useFrogFeed.tsx
@@ -1,13 +1,14 @@
 import {
   Feed,
   FrogCryptoFolderName,
-  IFrogCryptoFeedSchema,
+  IFrogCryptoClientFeedSchema,
   requestListFeeds
 } from "@pcd/passport-interface";
 import { useCallback, useEffect, useMemo } from "react";
 import toast from "react-hot-toast";
 import { useSearchParams } from "react-router-dom";
 import urljoin from "url-join";
+import { validate } from "uuid";
 import { appConfig } from "../../../src/appConfig";
 import { useDispatch, useSubscriptions } from "../../../src/appHooks";
 
@@ -30,7 +31,7 @@ export function useInitializeFrogSubscriptions(): (
         FrogCryptoFolderName
       );
 
-      function parseAndAddFeed(feed: Feed): boolean {
+      function parseAndAddFeed(feed: Feed, deeplink: boolean): boolean {
         // skip any feeds that are already subscribed to
         if (
           subs.getSubscriptionsByProviderAndFeedId(
@@ -41,7 +42,7 @@ export function useInitializeFrogSubscriptions(): (
           return false;
         }
 
-        const parsed = IFrogCryptoFeedSchema.safeParse(feed);
+        const parsed = IFrogCryptoClientFeedSchema.safeParse(feed);
         if (parsed.success) {
           if (parsed.data.activeUntil > Date.now() / 1000) {
             // only add a feed if it is active
@@ -53,7 +54,7 @@ export function useInitializeFrogSubscriptions(): (
             });
 
             // don't show toast if feedId is specified
-            if (feed.id !== feedId) {
+            if (!deeplink) {
               toast.success(
                 `Croak and awe! The ${feed.name} awaits your adventurous leap!`,
                 {
@@ -63,7 +64,7 @@ export function useInitializeFrogSubscriptions(): (
             }
 
             return true;
-          } else if (feed.id === feedId) {
+          } else if (deeplink) {
             // if we are adding an expired from deeplink, show error toast
             toast.error(
               <span>
@@ -97,7 +98,7 @@ export function useInitializeFrogSubscriptions(): (
       feeds
         // remove any feeds that we want to custom add
         .filter((feed) => feed.id !== feedId)
-        .forEach(parseAndAddFeed);
+        .forEach((feed) => parseAndAddFeed(feed, false));
 
       if (feedId) {
         try {
@@ -109,7 +110,7 @@ export function useInitializeFrogSubscriptions(): (
           );
           const feed = res?.value?.feeds?.[0];
           if (feed) {
-            return parseAndAddFeed(feed) ? feed : null;
+            return parseAndAddFeed(feed, true) ? feed : null;
           } else {
             throw new Error(res?.error || "Feed not found");
           }
@@ -133,10 +134,15 @@ export function useInitializeFrogSubscriptions(): (
     if (feedId) {
       toast.promise(
         new Promise((resolve) => setTimeout(resolve, 3000)).then(() => {
-          setSearchParams((prev) => {
-            prev.delete("feedId");
-            return prev;
-          });
+          setSearchParams(
+            (prev) => {
+              prev.delete("feedId");
+              return prev;
+            },
+            {
+              replace: true
+            }
+          );
 
           return initializeFrogSubscriptions(feedId);
         }),
@@ -152,7 +158,9 @@ export function useInitializeFrogSubscriptions(): (
             ) : (
               <>You look familiar. Have we met before? No need to leap again.</>
             ),
-          error: "Seems like this froggy code is a tadpole tad off."
+          error: validate(feedId)
+            ? "Seems like this froggy code is a tadpole off."
+            : "We tried to look for this froggy code, but we got lost in the mist. Maybe come back after a few bug snacks?"
         }
       );
     }

--- a/apps/passport-client/components/screens/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen.tsx
@@ -46,16 +46,20 @@ export function HomeScreenImpl() {
   const pcdCollection = usePCDCollection();
   const [searchParams, setSearchParams] = useSearchParams();
   const defaultBrowsingFolder = useMemo(() => {
-    let folderPathFromQuery = decodeURIComponent(
+    const folderPathFromQuery = decodeURIComponent(
       searchParams.get(FOLDER_QUERY_PARAM)
     );
-    if (
-      !folderPathFromQuery ||
-      !pcdCollection.isValidFolder(folderPathFromQuery)
-    ) {
-      folderPathFromQuery = "";
+    if (!folderPathFromQuery) {
+      return "";
     }
-    return folderPathFromQuery;
+    // FrogCrypto is always valid even if user doesn't have any FrogPCD
+    if (folderPathFromQuery === FrogCryptoFolderName) {
+      return folderPathFromQuery;
+    }
+
+    return pcdCollection.isValidFolder(folderPathFromQuery)
+      ? folderPathFromQuery
+      : "";
   }, [pcdCollection, searchParams]);
 
   const [browsingFolder, setBrowsingFolder] = useState(defaultBrowsingFolder);

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -361,7 +361,7 @@ function RouterImpl() {
           <Route path="telegram" element={<HomeScreen />} />
           <Route path="pond-control" element={<FrogManagerScreen />} />
           <Route
-            path="frogscriptions/:feedAlias"
+            path="frogscriptions/:feedCode"
             element={<FrogSubscriptionScreen />}
           />
           <Route path="*" element={<MissingScreen />} />

--- a/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
+++ b/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
@@ -64,10 +64,13 @@ export function initFrogcryptoRoutes(
   app.get("/frogcrypto/feeds/:feedId", async (req: Request, res: Response) => {
     checkFrogcryptoServiceStarted(frogcryptoService);
     const feedId = checkUrlParam(req, "feedId");
-    if (!frogcryptoService.hasFeedWithId(feedId)) {
+    const result = await frogcryptoService.handleListSingleFeedRequest({
+      feedId
+    });
+    if (result.feeds.length === 0) {
       throw new PCDHTTPError(404);
     }
-    res.json(await frogcryptoService.handleListSingleFeedRequest({ feedId }));
+    res.json(result);
   });
 
   app.get("/frogcrypto/scoreboard", async (req, res) => {

--- a/apps/passport-server/test/frogcrypto.spec.ts
+++ b/apps/passport-server/test/frogcrypto.spec.ts
@@ -80,7 +80,57 @@ describe("frogcrypto functionality", function () {
     const feed = feeds[0] as FrogCryptoFeed;
     expectToExist(feed);
     expect(feed.activeUntil).to.be.greaterThan(Date.now() / 1000);
+    expect(feed.autoPoll).to.be.false;
     expect(feed.private).to.be.false;
+    // secret value is not returned
+    expect(feed.biomes).to.be.undefined;
+  });
+
+  it("should be able to look up feed even it is private", async function () {
+    const feed = feeds[5];
+    expect(feed.activeUntil).to.be.greaterThan(Date.now() / 1000);
+    expect(feed.private).to.be.true;
+
+    const response = await requestListFeeds(
+      `${application.expressContext.localEndpoint}/frogcrypto/feeds/${feed.id}`
+    );
+    expect(response.success).to.be.true;
+    const resFeeds = response.value?.feeds;
+    expectToExist(resFeeds);
+    expect(resFeeds.length).to.eq(1);
+    const resFeed = resFeeds[0] as FrogCryptoFeed;
+    expectToExist(resFeed);
+    expect(resFeed.id).to.eq(feed.id);
+    expect(resFeed.activeUntil).to.be.greaterThan(Date.now() / 1000);
+    expect(feed.autoPoll).to.be.false;
+    expect(resFeed.private).to.be.true;
+    // secret value is not returned
+    expect(resFeed.codes).to.be.undefined;
+    expect(resFeed.biomes).to.be.undefined;
+  });
+
+  it("should be able to look up feed by its secret code", async function () {
+    const feed = feeds[5];
+    expect(feed.activeUntil).to.be.greaterThan(Date.now() / 1000);
+    expect(feed.private).to.be.true;
+    const code = feed.codes?.[1];
+    expectToExist(code);
+
+    const response = await requestListFeeds(
+      `${application.expressContext.localEndpoint}/frogcrypto/feeds/${code}`
+    );
+    expect(response.success).to.be.true;
+    const resFeeds = response.value?.feeds;
+    expectToExist(resFeeds);
+    expect(resFeeds.length).to.eq(1);
+    const resFeed = resFeeds[0] as FrogCryptoFeed;
+    expectToExist(resFeed);
+    expect(resFeed.id).to.eq(feed.id);
+    expect(resFeed.activeUntil).to.be.greaterThan(Date.now() / 1000);
+    expect(resFeed.private).to.be.true;
+    // secret value is not returned
+    expect(resFeed.codes).to.be.undefined;
+    expect(resFeed.biomes).to.be.undefined;
   });
 
   it("should be able to get frog", async () => {

--- a/apps/passport-server/test/util/frogcrypto.ts
+++ b/apps/passport-server/test/util/frogcrypto.ts
@@ -269,7 +269,8 @@ export const testFeeds: FrogCryptoDbFeedData[] = [
       cooldown: 600,
       biomes: {
         Unknown: { dropWeightScaler: 1 }
-      }
+      },
+      codes: ["imbatman", "imbatman2"]
     }
   }
 ];

--- a/packages/passport-interface/src/FrogCrypto.ts
+++ b/packages/passport-interface/src/FrogCrypto.ts
@@ -75,7 +75,20 @@ export const IFrogCryptoFeedSchema = z.object({
   /**
    * Map of configs for Biome(s) where PCDs can be issued from this feed
    */
-  biomes: FrogCryptoFeedBiomeConfigsSchema
+  biomes: FrogCryptoFeedBiomeConfigsSchema,
+  /**
+   * A list of secret codes that can be used to look up this feed
+   */
+  codes: z.array(z.string()).optional()
+});
+
+/**
+ * A subset of `IFrogCryptoFeed` that is exposed to the client
+ */
+export const IFrogCryptoClientFeedSchema = z.object({
+  private: IFrogCryptoFeedSchema.shape.private,
+  activeUntil: IFrogCryptoFeedSchema.shape.activeUntil,
+  cooldown: IFrogCryptoFeedSchema.shape.cooldown
 });
 
 /**
@@ -85,6 +98,12 @@ export const IFrogCryptoFeedSchema = z.object({
  */
 export type FrogCryptoFeed = Feed<typeof EdDSAFrogPCDPackage> &
   z.infer<typeof IFrogCryptoFeedSchema>;
+
+/**
+ * FrogCrypto specific feed configuration that is exposed to the client
+ */
+export type FrogCryptoClientFeed = Feed<typeof EdDSAFrogPCDPackage> &
+  z.infer<typeof IFrogCryptoClientFeedSchema>;
 
 /**
  * DB schema for feed data
@@ -97,7 +116,8 @@ export const FrogCryptoDbFeedDataSchema = z.object({
     private: z.boolean(),
     activeUntil: z.number().nonnegative().int(),
     cooldown: z.number().nonnegative().int(),
-    biomes: FrogCryptoFeedBiomeConfigsSchema
+    biomes: FrogCryptoFeedBiomeConfigsSchema,
+    codes: z.array(z.string()).optional()
   })
 });
 


### PR DESCRIPTION
* add retreat option to new experience
* add a new `codes` fields to feed data model where user can look up feed with secret code
* redact feed fields that we don't necessarily want users to see
* add redirection from qr code links to feed deeplink
* add copy to new user experience if they scan the qr code
* fix bug to drop user into frogcrypto if they scan the qr code even if they don't have frogs
* 


retreat option

<img width="546" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/9e7ad0f9-2b73-48f5-9bcb-982acfda9e61">

new user from qr code

<img width="488" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/2ac8d279-faa1-49fc-9fa3-22a0e11f3735">

good qr code

<img width="509" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/9c1fd989-c41f-4c92-a19f-2dc9a8fb26b6">


bad qr code

<img width="493" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/7642a7a7-658f-47ff-a470-fc8399de9c17">

bad uuid

<img width="472" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/67a2c204-be0c-42ad-919a-7465fca49868">


good qr code but feed isn't active (wish we can make this even nicer without two toasts)

<img width="599" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/b079b5d4-562f-4f26-b30c-184b9b09fd34">
