### PR TITLE
[frogcrypto] option to reveal tg name

### DIFF
--- a/apps/passport-client/components/core/Button.tsx
+++ b/apps/passport-client/components/core/Button.tsx
@@ -51,7 +51,7 @@ const buttonStyle = `
   }
 `;
 
-const BtnBase = styled.button<{ size?: "large" | "small" }>`
+export const BtnBase = styled.button<{ size?: "large" | "small" }>`
   ${buttonStyle}
   ${({ disabled }) =>
     disabled === true

--- a/apps/passport-client/components/modals/FrogCryptoUpdateTelegramModal.tsx
+++ b/apps/passport-client/components/modals/FrogCryptoUpdateTelegramModal.tsx
@@ -1,0 +1,100 @@
+import { requestFrogCryptoUpdateTelegramHandleSharing } from "@pcd/passport-interface";
+import toast from "react-hot-toast";
+import styled from "styled-components";
+import { appConfig } from "../../src/appConfig";
+import { useCredentialManager, useDispatch } from "../../src/appHooks";
+import { H3 } from "../core";
+import { BtnBase } from "../core/Button";
+import { ActionButton } from "../screens/FrogScreens/Button";
+
+export function FrogCryptoUpdateTelegramModal({
+  revealed,
+  refreshAll
+}: {
+  revealed: boolean;
+  refreshAll: () => Promise<void>;
+}) {
+  const credentialManager = useCredentialManager();
+  const dispatch = useDispatch();
+
+  return (
+    <Container>
+      <H3>
+        {revealed
+          ? "Your Telegram Username Sharing"
+          : "Share Your Telegram Username?"}
+      </H3>
+      <>
+        {revealed ? (
+          <>
+            <p>
+              Your Telegram username is shared with FrogCrypto via ZuKat and is
+              visible on the leaderboard.
+            </p>
+            <p>
+              If you prefer more privacy, you can choose to hide your Telegram
+              username at any time. When hidden, you'll be assigned a
+              pseudo-anonymous name based on your Semaphore ID.
+            </p>
+          </>
+        ) : (
+          <>
+            <p>
+              You're currently using a pseudo-anonymous name based on your
+              Semaphore ID.
+            </p>
+            <p>
+              You can share your Telegram username with FrogCrypto via ZuKat.
+              ZuKat will have access to your username only if you've joined a
+              ZuKat-gated Telegram chat. You can revert to a pseudo-anonymous
+              name anytime.
+            </p>
+          </>
+        )}
+      </>
+      <ActionButton
+        ButtonComponent={BtnBase}
+        onClick={async () => {
+          try {
+            await requestFrogCryptoUpdateTelegramHandleSharing(
+              appConfig.zupassServer,
+              {
+                pcd: await credentialManager.requestCredential({
+                  signatureType: "sempahore-signature-pcd"
+                }),
+                reveal: !revealed
+              }
+            );
+
+            // once user preference is updated, we need to refetch both user's
+            // score and leaderboard to fetch TG username
+            await refreshAll();
+          } catch (e) {
+            console.error(e);
+            toast.error(
+              "There was an error updating your Telegram username. Maybe try again?"
+            );
+            return;
+          }
+
+          dispatch({
+            type: "set-modal",
+            modal: {
+              modalType: "none"
+            }
+          });
+        }}
+      >
+        {revealed ? "Hide My Telegram Username" : "Share My Telegram Username"}
+      </ActionButton>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 32px;
+  margin: 0 16px;
+`;

--- a/apps/passport-client/components/modals/Modal.tsx
+++ b/apps/passport-client/components/modals/Modal.tsx
@@ -9,6 +9,7 @@ import { icons } from "../icons";
 import { AnotherDeviceChangedPasswordModal } from "./AnotherDeviceChangedPasswordModal";
 import { ChangedPasswordModal } from "./ChangedPasswordModal";
 import { ConfirmSkipSetupModal } from "./ConfirmSkipSetupModal";
+import { FrogCryptoUpdateTelegramModal } from "./FrogCryptoUpdateTelegramModal";
 import { InfoModal } from "./InfoModal";
 import { InvalidUserModal } from "./InvalidUserModal";
 import { PrivacyNoticeModal } from "./PrivacyNoticeModal";
@@ -95,6 +96,13 @@ function getModalBody(modal: AppState["modal"], isProveOrAddScreen: boolean) {
       return <RequireAddPasswordModal />;
     case "privacy-notice":
       return <PrivacyNoticeModal />;
+    case "frogcrypto-update-telegram":
+      return (
+        <FrogCryptoUpdateTelegramModal
+          revealed={modal.revealed}
+          refreshAll={modal.refreshAll}
+        />
+      );
     case "none":
       return null;
     default:

--- a/apps/passport-client/components/screens/FrogScreens/Button.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/Button.tsx
@@ -74,7 +74,7 @@ export function ActionButton({
   //
   // This would be incorrect and is handled by the abortController below.
   useEffect(() => {
-    if (!inViewRef.current) {
+    if (!inViewRef.current || document.visibilityState === "hidden") {
       return;
     }
 
@@ -493,15 +493,18 @@ const WrithingImage = styled.div<{ visible: boolean }>`
   opacity: ${({ visible }) => (visible ? "100%" : "20%")};
   width: ${({ visible }) => (visible ? "min(80vw, 80vh)" : "0")};
   height: ${({ visible }) => (visible ? "min(80vw, 80vh)" : "0")};
-  box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.2) inset,
+  box-shadow:
+    0 0 0 0 rgba(255, 255, 255, 0.2) inset,
     0 0 0 0 rgba(255, 255, 255, 0.2);
 
   transition: ${({ visible }) =>
     visible
       ? "width 16s ease-in, height 16s ease-in, opacity 4s ease-in"
       : "all 4s cubic-bezier(1,0,1,.6)"};
-  animation: ${rotating} 600s linear infinite,
+  animation:
+    ${rotating} 600s linear infinite,
     ${pulse} 8s linear ${({ visible }) => (visible ? "16s infinite" : "0")};
-  -webkit-animation: ${rotating} 600s linear infinite,
+  -webkit-animation:
+    ${rotating} 600s linear infinite,
     ${pulse} 8s linear ${({ visible }) => (visible ? "16s infinite" : "0")};
 `;

--- a/apps/passport-client/components/screens/FrogScreens/FrogHomeSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogHomeSection.tsx
@@ -1,6 +1,5 @@
 import { isEdDSAFrogPCD } from "@pcd/eddsa-frog-pcd";
 import {
-  CredentialManager,
   FrogCryptoFolderName,
   FrogCryptoUserStateResponseValue,
   Subscription,
@@ -11,9 +10,7 @@ import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";
 import {
-  useCredentialCache,
-  useIdentity,
-  usePCDCollection,
+  useCredentialManager,
   usePCDsInFolder,
   useSubscriptions
 } from "../../../src/appHooks";
@@ -186,7 +183,12 @@ export function FrogHomeSection() {
                 pcds={frogPCDs}
               />
             )}
-            {tab === "score" && <ScoreTab score={userState?.myScore} />}
+            {tab === "score" && (
+              <ScoreTab
+                score={userState?.myScore}
+                refreshScore={refreshUserState}
+              />
+            )}
             {tab === "dex" && (
               <DexTab possibleFrogs={userState.possibleFrogs} pcds={frogPCDs} />
             )}
@@ -202,13 +204,7 @@ export function FrogHomeSection() {
 export function useUserFeedState(subscriptions: Subscription[]) {
   const [userState, setUserState] =
     useState<FrogCryptoUserStateResponseValue | null>(null);
-  const identity = useIdentity();
-  const pcds = usePCDCollection();
-  const credentialCache = useCredentialCache();
-  const credentialManager = useMemo(
-    () => new CredentialManager(identity, pcds, credentialCache),
-    [credentialCache, identity, pcds]
-  );
+  const credentialManager = useCredentialManager();
   // coerce to string to avoid unnecessary rerenders
   const feedIdsString = useMemo(
     () => JSON.stringify(subscriptions.map((sub) => sub.feed.id)),

--- a/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
@@ -284,7 +284,16 @@ const LoadingMessages = ({ biome }: { biome: string }) => {
       `Frogs, where are you?`,
       `Pond-ering where the frogs are hiding...`,
       `DID YOU KNOW? Frogs are amphibians!`,
-      `DID YOU KNOW? You can only get a frog once every 15 minutes.`
+      `DID YOU KNOW? You can only search the swamp once every 15 minutes.`,
+      `Tip: Welcome to Summoner's Rift.`,
+      `Tip: Try jumping.`,
+      `Tip: Timing is everything. Wait for the gap, then hop to it!`,
+      `Tip: Remember, rivers are trickier than they look. Watch out for those logs!`,
+      `DID YOU KNOW? There are over five unique biomes, each a home to diverse frog species.`,
+      `DID YOU KNOW? Frogs come in rarities: Common, Rare, Epic, Legendary, and Mythic.`,
+      `DID YOU KNOW? Each Frog is a PCD (Proof Carry Data), with attributes securely signed by Zupass, making them tamper-proof.`,
+      `DID YOU KNOW? End-to-end encryption protects your FrogPCDs. Remember, your password is key and cannot be reset; without it, recovery is impossible.`,
+      `Have you visited the Frog Lounge? It's a great place to meet other froggers! https://bit.ly/frogholders`
     ],
     [biome]
   );

--- a/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
@@ -132,11 +132,6 @@ const SearchButton = ({
   const getLastFrogRef = useGetLastFrog();
 
   const onClick = useCallback(async () => {
-    // nb: special case for doomy writhing void
-    if (feed.name === "The Writhing Void") {
-      await new Promise((resolve) => setTimeout(resolve, 16 * 1000));
-    }
-
     await toast
       .promise(
         new Promise<void>((resolve) => {

--- a/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
@@ -1,6 +1,5 @@
 import { Biome } from "@pcd/eddsa-frog-pcd";
 import {
-  CredentialManager,
   FrogCryptoDbFeedData,
   FrogCryptoDbFeedDataSchema,
   FrogCryptoFeedBiomeConfigs,
@@ -14,11 +13,7 @@ import { useEffect, useMemo, useState } from "react";
 import Table from "react-table-lite";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";
-import {
-  useCredentialCache,
-  useIdentity,
-  usePCDCollection
-} from "../../../src/appHooks";
+import { useCredentialManager } from "../../../src/appHooks";
 import { ErrorMessage } from "../../core/error";
 import { useAdminError } from "./useAdminError";
 
@@ -107,13 +102,7 @@ function useFeeds(): {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>();
 
-  const identity = useIdentity();
-  const pcds = usePCDCollection();
-  const credentialCache = useCredentialCache();
-  const credentialManager = useMemo(
-    () => new CredentialManager(identity, pcds, credentialCache),
-    [credentialCache, identity, pcds]
-  );
+  const credentialManager = useCredentialManager();
   const [pcd, setPcd] = useState<SerializedPCD>();
   useEffect(() => {
     const fetchPcd = async () => {

--- a/apps/passport-client/components/screens/FrogScreens/ManageFrogsSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ManageFrogsSection.tsx
@@ -1,5 +1,4 @@
 import {
-  CredentialManager,
   FrogCryptoFrogData,
   FrogCryptoFrogDataSchema,
   requestFrogCryptoDeleteFrogs,
@@ -8,15 +7,11 @@ import {
 import { Separator } from "@pcd/passport-ui";
 import { SerializedPCD } from "@pcd/pcd-types";
 import _ from "lodash";
-import { Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import Table from "react-table-lite";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";
-import {
-  useCredentialCache,
-  useIdentity,
-  usePCDCollection
-} from "../../../src/appHooks";
+import { useCredentialManager } from "../../../src/appHooks";
 import { ErrorMessage } from "../../core/error";
 import { useAdminError } from "./useAdminError";
 
@@ -112,13 +107,7 @@ function useFrogs(): {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>();
 
-  const identity = useIdentity();
-  const pcds = usePCDCollection();
-  const credentialCache = useCredentialCache();
-  const credentialManager = useMemo(
-    () => new CredentialManager(identity, pcds, credentialCache),
-    [credentialCache, identity, pcds]
-  );
+  const credentialManager = useCredentialManager();
   const [pcd, setPcd] = useState<SerializedPCD>();
   useEffect(() => {
     const fetchPcd = async () => {

--- a/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
@@ -1,22 +1,39 @@
-import { requestFrogCryptoGetScoreboard } from "@pcd/passport-interface";
+import {
+  requestFrogCryptoGetScoreboard,
+  requestFrogCryptoUpdateTelegramHandleSharing
+} from "@pcd/passport-interface";
 import { FrogCryptoScore } from "@pcd/passport-interface/src/FrogCrypto";
 import _ from "lodash";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";
+import { useCredentialManager } from "../../../src/appHooks";
+import { H2 } from "../../core";
 import { RippleLoader } from "../../core/RippleLoader";
+import { AdhocModal } from "../../modals/AdhocModal";
+import { ActionButton } from "./Button";
 import { useUsernameGenerator } from "./useUsername";
 
 /**
  * The Score tab shows the user their score and the leaderboard.
  */
-export function ScoreTab({ score }: { score?: FrogCryptoScore }) {
+export function ScoreTab({
+  score,
+  refreshScore
+}: {
+  score?: FrogCryptoScore;
+  refreshScore: () => Promise<void>;
+}) {
   const [scores, setScores] = useState<FrogCryptoScore[]>([]);
-  useEffect(() => {
+  const refreshScores = useCallback(async () => {
     requestFrogCryptoGetScoreboard(appConfig.zupassServer).then((res) => {
       setScores(res.value || []);
     });
   }, []);
+  useEffect(() => {
+    refreshScores();
+  }, [refreshScores]);
+
   const getUsername = useUsernameGenerator();
 
   if (!score || !getUsername) {
@@ -25,6 +42,17 @@ export function ScoreTab({ score }: { score?: FrogCryptoScore }) {
 
   return (
     <Container>
+      {
+        // only show share button if user has a telegram username
+        score.has_telegram_username && (
+          <TelegramShareButton
+            score={score}
+            refreshAll={async () => {
+              Promise.all([refreshScore(), refreshScores()]);
+            }}
+          />
+        )
+      }
       <ScoreTable title="You" scores={[score]} getUsername={getUsername} />
       {scores.length > 0 && (
         <ScoreTable
@@ -69,22 +97,25 @@ function ScoreTable({
         {scoresByLevel.map((group) => {
           return (
             <Fragment key={group.title}>
-              {myScore && (
-                <tr>
-                  <td
-                    colSpan={3}
-                    style={{ textAlign: "center", padding: "4px 0" }}
-                  >
-                    {group.emoji} {group.title}
-                  </td>
-                </tr>
-              )}
+              {
+                // if myScore is not provided, we are showing the user only view
+                myScore && (
+                  <tr>
+                    <td
+                      colSpan={3}
+                      style={{ textAlign: "center", padding: "4px 0" }}
+                    >
+                      {group.emoji} {group.title}
+                    </td>
+                  </tr>
+                )
+              }
 
               {group.scores.map((score) => (
                 <tr
-                  key={score.semaphore_id}
+                  key={score.semaphore_id_hash}
                   style={
-                    score.semaphore_id === myScore?.semaphore_id
+                    score.semaphore_id_hash === myScore?.semaphore_id_hash
                       ? {
                           fontWeight: "bold",
                           color: "var(--accent-darker)"
@@ -93,7 +124,10 @@ function ScoreTable({
                   }
                 >
                   <td>{score.rank}</td>
-                  <td>{getUsername(score.semaphore_id)}</td>
+                  <td>
+                    {score.telegram_username ??
+                      getUsername(score.semaphore_id_hash)}
+                  </td>
                   <td style={{ textAlign: "right" }}>{score.score}</td>
                 </tr>
               ))}
@@ -102,6 +136,77 @@ function ScoreTable({
         })}
       </tbody>
     </table>
+  );
+}
+
+/**
+ * Share button and modal for telegram username.
+ */
+function TelegramShareButton({
+  score,
+  refreshAll
+}: {
+  score: FrogCryptoScore;
+  refreshAll: () => Promise<void>;
+}) {
+  const [showModal, setShowModal] = useState(false);
+  const credentialManager = useCredentialManager();
+  const revealed = !!score.telegram_username;
+
+  return (
+    <>
+      <ActionButton
+        onClick={async () => {
+          setShowModal(true);
+        }}
+      >
+        {score.telegram_username
+          ? "Hide Telegram Username"
+          : "Pubilsh Telegram Username"}
+      </ActionButton>
+
+      <AdhocModal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        closeOnEsc
+      >
+        <Container>
+          <H2>
+            {revealed
+              ? "Your Telegram Username Sharing"
+              : "Share Your Telegram Username?"}
+          </H2>
+          <div>
+            {revealed
+              ? "Your Telegram username is shared with FrogCrypto via ZuKat and is visible on the leaderboard. If you prefer more privacy, you can choose to hide your Telegram username at any time. When hidden, you'll be assigned a pseudo-anonymous name based on your Semaphore ID."
+              : "You're currently using a pseudo-anonymous name based on your Semaphore ID. You can share your Telegram username with FrogCrypto via ZuKat. ZuKat will have access to your username only if you've joined a ZuKat-gated Telegram chat. You can revert to a pseudo-anonymous name anytime."}
+          </div>
+          <ActionButton
+            onClick={async () => {
+              await requestFrogCryptoUpdateTelegramHandleSharing(
+                appConfig.zupassServer,
+                {
+                  pcd: await credentialManager.requestCredential({
+                    signatureType: "sempahore-signature-pcd"
+                  }),
+                  reveal: !revealed
+                }
+              );
+
+              // once user preference is updated, we need to refetch both user's
+              // score and leaderboard to fetch TG username
+              await refreshAll();
+
+              setShowModal(false);
+            }}
+          >
+            {revealed
+              ? "Hide My Telegram Username"
+              : "Share My Telegram Username"}
+          </ActionButton>
+        </Container>
+      </AdhocModal>
+    </>
   );
 }
 
@@ -151,7 +256,10 @@ export function scoreToEmoji(score: number) {
  * Group the scores by level.
  */
 export function groupScores(scores: FrogCryptoScore[]) {
-  const groups = SCORES.map((item) => ({ ...item, scores: [] })).reverse();
+  const groups = SCORES.map((item) => ({
+    ...item,
+    scores: [] as FrogCryptoScore[]
+  })).reverse();
 
   _.orderBy(scores, ["score"], ["desc"]).forEach((score) => {
     const index = SCORES.findIndex((item) => item.score > score.score);

--- a/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
@@ -1,16 +1,11 @@
-import {
-  requestFrogCryptoGetScoreboard,
-  requestFrogCryptoUpdateTelegramHandleSharing
-} from "@pcd/passport-interface";
+import { requestFrogCryptoGetScoreboard } from "@pcd/passport-interface";
 import { FrogCryptoScore } from "@pcd/passport-interface/src/FrogCrypto";
 import _ from "lodash";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";
-import { useCredentialManager } from "../../../src/appHooks";
-import { H2 } from "../../core";
+import { useDispatch } from "../../../src/appHooks";
 import { RippleLoader } from "../../core/RippleLoader";
-import { AdhocModal } from "../../modals/AdhocModal";
 import { ActionButton } from "./Button";
 import { useUsernameGenerator } from "./useUsername";
 
@@ -149,64 +144,26 @@ function TelegramShareButton({
   score: FrogCryptoScore;
   refreshAll: () => Promise<void>;
 }) {
-  const [showModal, setShowModal] = useState(false);
-  const credentialManager = useCredentialManager();
   const revealed = !!score.telegram_username;
+  const dispatch = useDispatch();
 
   return (
-    <>
-      <ActionButton
-        onClick={async () => {
-          setShowModal(true);
-        }}
-      >
-        {score.telegram_username
-          ? "Hide Telegram Username"
-          : "Pubilsh Telegram Username"}
-      </ActionButton>
-
-      <AdhocModal
-        open={showModal}
-        onClose={() => setShowModal(false)}
-        closeOnEsc
-      >
-        <Container>
-          <H2>
-            {revealed
-              ? "Your Telegram Username Sharing"
-              : "Share Your Telegram Username?"}
-          </H2>
-          <div>
-            {revealed
-              ? "Your Telegram username is shared with FrogCrypto via ZuKat and is visible on the leaderboard. If you prefer more privacy, you can choose to hide your Telegram username at any time. When hidden, you'll be assigned a pseudo-anonymous name based on your Semaphore ID."
-              : "You're currently using a pseudo-anonymous name based on your Semaphore ID. You can share your Telegram username with FrogCrypto via ZuKat. ZuKat will have access to your username only if you've joined a ZuKat-gated Telegram chat. You can revert to a pseudo-anonymous name anytime."}
-          </div>
-          <ActionButton
-            onClick={async () => {
-              await requestFrogCryptoUpdateTelegramHandleSharing(
-                appConfig.zupassServer,
-                {
-                  pcd: await credentialManager.requestCredential({
-                    signatureType: "sempahore-signature-pcd"
-                  }),
-                  reveal: !revealed
-                }
-              );
-
-              // once user preference is updated, we need to refetch both user's
-              // score and leaderboard to fetch TG username
-              await refreshAll();
-
-              setShowModal(false);
-            }}
-          >
-            {revealed
-              ? "Hide My Telegram Username"
-              : "Share My Telegram Username"}
-          </ActionButton>
-        </Container>
-      </AdhocModal>
-    </>
+    <ActionButton
+      onClick={async () => {
+        dispatch({
+          type: "set-modal",
+          modal: {
+            modalType: "frogcrypto-update-telegram",
+            revealed,
+            refreshAll
+          }
+        });
+      }}
+    >
+      {score.telegram_username
+        ? "Hide Telegram Username"
+        : "Pubilsh Telegram Username"}
+    </ActionButton>
   );
 }
 

--- a/apps/passport-client/components/screens/FrogScreens/useFrogParticles.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/useFrogParticles.tsx
@@ -6,6 +6,7 @@ import {
   IOpacity,
   IRangedCoordinates,
   IShape,
+  ParticlesOptions,
   RecursivePartial,
   tsParticles
 } from "tsparticles-engine";
@@ -462,58 +463,63 @@ export function useWrithingVoidParticles(
       return;
     }
 
+    const absorberBaseSize =
+      Math.min(window.innerWidth, window.innerHeight) / 5 ?? 50;
+    const particles: RecursivePartial<ParticlesOptions> = {
+      shape: {
+        type: "image",
+        image: {
+          replaceColor: true,
+          src: "/images/frogs/frog.svg"
+        }
+      },
+      color: {
+        value: [
+          "#004b23",
+          "#006400",
+          "#007200",
+          "#008000",
+          "#38b000",
+          "#70e000",
+          "#9ef01a",
+          "#ccff33"
+        ],
+        animation: {
+          h: {
+            enable: false,
+            speed: 0
+          },
+          s: {
+            enable: false,
+            speed: 0
+          },
+          l: {
+            enable: true,
+            speed: 5,
+            sync: false,
+            offset: {
+              min: 0,
+              max: 80
+            }
+          }
+        }
+      },
+      lineLinked: {
+        enable: false
+      },
+      size: {
+        value: 10,
+        random: {
+          enable: true,
+          minimumValue: 5
+        }
+      }
+    };
     const emitter = (
       move: RecursivePartial<IMove>
     ): RecursivePartial<Emitter> => ({
       particles: {
-        shape: {
-          type: "image",
-          image: {
-            replaceColor: true,
-            src: "/images/frogs/frog.svg"
-          }
-        },
-        color: {
-          value: [
-            "#004b23",
-            "#006400",
-            "#007200",
-            "#008000",
-            "#38b000",
-            "#70e000",
-            "#9ef01a",
-            "#ccff33"
-          ],
-          animation: {
-            h: {
-              enable: false,
-              speed: 0
-            },
-            s: {
-              enable: false,
-              speed: 0
-            },
-            l: {
-              enable: true,
-              speed: 5,
-              sync: false,
-              offset: {
-                min: 0,
-                max: 80
-              }
-            }
-          }
-        },
-        lineLinked: {
-          enable: false
-        },
-        size: {
-          value: 10,
-          random: {
-            enable: true,
-            minimumValue: 5
-          }
-        },
+        ...particles,
         move: {
           enable: true,
           speed: {
@@ -545,6 +551,18 @@ export function useWrithingVoidParticles(
         zIndex: 2000
       },
       particles: {
+        ...particles,
+        move: {
+          enable: true,
+          speed: {
+            min: 5,
+            max: 10
+          },
+          direction: "none",
+          random: false,
+          straight: false,
+          outModes: "none"
+        },
         number: {
           value: 0
         }
@@ -552,10 +570,9 @@ export function useWrithingVoidParticles(
       absorbers: {
         size: {
           density: 15,
-          value: Math.min(window.innerWidth, window.innerHeight) / 4 ?? 75,
+          value: absorberBaseSize,
           limit: {
-            radius:
-              (Math.min(window.innerWidth, window.innerHeight) * 0.8) / 2 ?? 100
+            radius: absorberBaseSize * 2
           }
         },
         position: {
@@ -564,6 +581,28 @@ export function useWrithingVoidParticles(
         },
         opacity: 0,
         orbit: true
+      },
+      interactivity: {
+        detectsOn: "canvas",
+        events: {
+          onHover: {
+            enable: true,
+            mode: "repulse"
+          },
+          onClick: {
+            enable: true,
+            mode: "push"
+          },
+          resize: true
+        },
+        modes: {
+          repulse: {
+            distance: 100
+          },
+          push: {
+            quantity: 20
+          }
+        }
       },
       emitters: [
         {

--- a/apps/passport-client/components/screens/FrogScreens/useUsername.ts
+++ b/apps/passport-client/components/screens/FrogScreens/useUsername.ts
@@ -13,29 +13,32 @@ export function useUsernameGenerator():
 
   const generator = useCallback(
     (sempahoreId: string) => {
-      if (!pcdCrypto) {
-        throw new Error("pcdCrypto is not initialized");
-      }
+      try {
+        if (!pcdCrypto) {
+          throw new Error("pcdCrypto is not initialized");
+        }
 
-      const randomBytes = pcdCrypto.randombytesDeterministic(
-        32,
-        bigintToUint8Array(BigInt(sempahoreId))
-      );
-      if (!randomBytes) {
+        const randomBytes = pcdCrypto.randombytesDeterministic(
+          32,
+          bigintToUint8Array(BigInt(sempahoreId))
+        );
+        const randomBigInt = uint8arrayToBigint(randomBytes);
+
+        const randomAdjective: string =
+          adjectives[
+            Number(
+              (randomBigInt / BigInt(animals.length)) %
+                BigInt(adjectives.length)
+            )
+          ];
+        const randomAnimal: string =
+          animals[Number(randomBigInt % BigInt(animals.length))];
+
+        return _.startCase(`${randomAdjective} ${randomAnimal}`);
+      } catch (e) {
+        console.debug("Error in useUsernameGenerator", e);
         return "An Unknown Toad";
       }
-      const randomBigInt = uint8arrayToBigint(randomBytes);
-
-      const randomAdjective: string =
-        adjectives[
-          Number(
-            (randomBigInt / BigInt(animals.length)) % BigInt(adjectives.length)
-          )
-        ];
-      const randomAnimal: string =
-        animals[Number(randomBigInt % BigInt(animals.length))];
-
-      return _.startCase(`${randomAdjective} ${randomAnimal}`);
     },
     [pcdCrypto]
   );

--- a/apps/passport-client/src/appHooks.ts
+++ b/apps/passport-client/src/appHooks.ts
@@ -1,6 +1,7 @@
 import { wrap, Wrapper } from "@pcd/emitter";
 import {
   CredentialCache,
+  CredentialManager,
   FeedSubscriptionManager,
   LATEST_PRIVACY_NOTICE,
   User
@@ -8,7 +9,7 @@ import {
 import { PCDCollection } from "@pcd/pcd-collection";
 import { PCD } from "@pcd/pcd-types";
 import { Identity } from "@semaphore-protocol/identity";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
   Dispatcher,
@@ -149,6 +150,16 @@ export function useResolvingSubscriptionId(): string | undefined {
 
 export function useCredentialCache(): CredentialCache {
   return useSelector<CredentialCache>((s) => s.credentialCache);
+}
+
+export function useCredentialManager(): CredentialManager {
+  const identity = useIdentity();
+  const pcds = usePCDCollection();
+  const credentialCache = useCredentialCache();
+  return useMemo(
+    () => new CredentialManager(identity, pcds, credentialCache),
+    [credentialCache, identity, pcds]
+  );
 }
 
 export function useQuery(): URLSearchParams | undefined {

--- a/apps/passport-client/src/state.ts
+++ b/apps/passport-client/src/state.ts
@@ -35,7 +35,12 @@ export interface AppState {
     | { modalType: "confirm-setup-later"; onConfirm: () => void }
     | { modalType: "require-add-password" }
     | { modalType: "privacy-notice" }
-    | { modalType: "none" };
+    | { modalType: "none" }
+    | {
+        modalType: "frogcrypto-update-telegram";
+        revealed: boolean;
+        refreshAll: () => Promise<void>;
+      };
 
   // User metadata.
   self?: User;

--- a/apps/passport-server/migrations/57_frogcrypto_tg.sql
+++ b/apps/passport-server/migrations/57_frogcrypto_tg.sql
@@ -1,0 +1,5 @@
+-- add a new column to store preference to share TG info
+ALTER TABLE
+  frogcrypto_user_scores
+ADD
+  COLUMN telegram_sharing_allowed BOOLEAN NULL;

--- a/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
+++ b/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
@@ -1,6 +1,8 @@
 import {
   FrogCryptoDeleteFrogsRequest,
   FrogCryptoDeleteFrogsResponseValue,
+  FrogCryptoShareTelegramHandleRequest,
+  FrogCryptoShareTelegramHandleResponseValue,
   FrogCryptoUpdateFeedsRequest,
   FrogCryptoUpdateFeedsResponseValue,
   FrogCryptoUpdateFrogsRequest,
@@ -77,6 +79,14 @@ export function initFrogcryptoRoutes(
     checkFrogcryptoServiceStarted(frogcryptoService);
     const result = await frogcryptoService.getScoreboard();
     res.json(result);
+  });
+
+  app.post("/frogcrypto/telegram-handle-sharing", async (req, res) => {
+    checkFrogcryptoServiceStarted(frogcryptoService);
+    const result = await frogcryptoService.updateTelegramHandleSharing(
+      req.body as FrogCryptoShareTelegramHandleRequest
+    );
+    res.json(result satisfies FrogCryptoShareTelegramHandleResponseValue);
   });
 
   app.post("/frogcrypto/user-state", async (req, res) => {

--- a/apps/passport-server/src/services/frogcryptoService.ts
+++ b/apps/passport-server/src/services/frogcryptoService.ts
@@ -9,6 +9,8 @@ import {
   FrogCryptoFolderName,
   FrogCryptoFrogData,
   FrogCryptoScore,
+  FrogCryptoShareTelegramHandleRequest,
+  FrogCryptoShareTelegramHandleResponseValue,
   FrogCryptoUpdateFeedsRequest,
   FrogCryptoUpdateFeedsResponseValue,
   FrogCryptoUpdateFrogsRequest,
@@ -39,6 +41,7 @@ import {
   initializeUserFeedState,
   sampleFrogData,
   updateUserFeedState,
+  updateUserScoreboardPreference,
   upsertFeedData,
   upsertFrogData
 } from "../database/queries/frogcrypto";
@@ -161,6 +164,27 @@ export class FrogcryptoService {
       ),
       possibleFrogs: await getPossibleFrogs(this.context.dbPool),
       myScore: await getUserScore(this.context.dbPool, semaphoreId)
+    };
+  }
+
+  public async updateTelegramHandleSharing(
+    req: FrogCryptoShareTelegramHandleRequest
+  ): Promise<FrogCryptoShareTelegramHandleResponseValue> {
+    const semaphoreId = await this.cachedVerifyPCDAndGetSemaphoreId(req.pcd);
+
+    await updateUserScoreboardPreference(
+      this.context.dbPool,
+      semaphoreId,
+      req.reveal
+    );
+
+    const myScore = await getUserScore(this.context.dbPool, semaphoreId);
+    if (!myScore) {
+      throw new PCDHTTPError(404, "User not found");
+    }
+
+    return {
+      myScore
     };
   }
 

--- a/packages/passport-interface/src/FrogCrypto.ts
+++ b/packages/passport-interface/src/FrogCrypto.ts
@@ -174,7 +174,9 @@ export const FrogCryptoFolderName = "FrogCrypto";
  * User score data and computed rank
  */
 export interface FrogCryptoScore {
-  semaphore_id: string;
+  semaphore_id_hash: string;
+  telegram_username?: string;
+  has_telegram_username: boolean;
   score: number;
   rank: number;
 }

--- a/packages/passport-interface/src/RequestTypes.ts
+++ b/packages/passport-interface/src/RequestTypes.ts
@@ -736,6 +736,21 @@ export interface FrogCryptoUserStateResponseValue {
 }
 
 /**
+ * Request to reveal or redact telegram handle of a user on the leaderboard.
+ */
+export interface FrogCryptoShareTelegramHandleRequest {
+  pcd: SerializedPCD<SemaphoreSignaturePCD>;
+  reveal: boolean;
+}
+
+/**
+ * Response to {@link FrogCryptoShareTelegramHandleRequest}
+ */
+export interface FrogCryptoShareTelegramHandleResponseValue {
+  myScore: FrogCryptoScore;
+}
+
+/**
  * Admin request to manage frogs in the databse.
  */
 export type FrogCryptoUpdateFrogsRequest = {

--- a/packages/passport-interface/src/api/requestFrogCryptoUpdateTelegramSharing.ts
+++ b/packages/passport-interface/src/api/requestFrogCryptoUpdateTelegramSharing.ts
@@ -1,0 +1,58 @@
+import { ArgumentTypeName } from "@pcd/pcd-types";
+import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
+import { SemaphoreSignaturePCDPackage } from "@pcd/semaphore-signature-pcd";
+import { Identity } from "@semaphore-protocol/identity";
+import urlJoin from "url-join";
+import {
+  FrogCryptoShareTelegramHandleRequest,
+  FrogCryptoShareTelegramHandleResponseValue
+} from "../RequestTypes";
+import { APIResult } from "./apiResult";
+import { httpPostSimple } from "./makeRequest";
+
+/**
+ * Update the Telegram handle sharing status of a user.
+ */
+export async function requestFrogCryptoUpdateTelegramHandleSharing(
+  zupassServerUrl: string,
+  req: FrogCryptoShareTelegramHandleRequest
+): Promise<FrogCryptoShareTelegramHandleResult> {
+  return httpPostSimple(
+    urlJoin(zupassServerUrl, "/frogcrypto/telegram-handle-sharing"),
+    async (resText) => ({
+      value: JSON.parse(resText) as FrogCryptoShareTelegramHandleResponseValue,
+      success: true
+    }),
+    req
+  );
+}
+
+export async function frogCryptoUpdateTelegramHandleSharing(
+  zupassServerUrl: string,
+  identity: Identity,
+  signedMessage: string,
+  reveal: boolean
+): Promise<FrogCryptoShareTelegramHandleResult> {
+  return requestFrogCryptoUpdateTelegramHandleSharing(zupassServerUrl, {
+    pcd: await SemaphoreSignaturePCDPackage.serialize(
+      await SemaphoreSignaturePCDPackage.prove({
+        identity: {
+          argumentType: ArgumentTypeName.PCD,
+          value: await SemaphoreIdentityPCDPackage.serialize(
+            await SemaphoreIdentityPCDPackage.prove({
+              identity
+            })
+          )
+        },
+        signedMessage: {
+          argumentType: ArgumentTypeName.String,
+          value: signedMessage
+        }
+      })
+    ),
+    reveal
+  });
+}
+
+export type FrogCryptoShareTelegramHandleResult =
+  APIResult<FrogCryptoShareTelegramHandleResponseValue>;

--- a/packages/passport-interface/src/index.ts
+++ b/packages/passport-interface/src/index.ts
@@ -32,6 +32,7 @@ export * from "./api/requestFrogCryptoGetScoreboard";
 export * from "./api/requestFrogCryptoGetUserState";
 export * from "./api/requestFrogCryptoUpdateFeeds";
 export * from "./api/requestFrogCryptoUpdateFrogs";
+export * from "./api/requestFrogCryptoUpdateTelegramSharing";
 export * from "./api/requestIssuanceServiceEnabled";
 export * from "./api/requestKnownTickets";
 export * from "./api/requestListFeeds";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4869,28 +4869,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.22", "@types/react@^18.2.6":
+"@types/react@*", "@types/react@18.0.22", "@types/react@18.2.20", "@types/react@^18.0.22", "@types/react@^18.2.6":
   version "18.2.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
   integrity sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@18.0.22":
-  version "18.0.22"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.22.tgz#97782d995d999617de116cf61f437f1351036fc7"
-  integrity sha512-4yWc5PyCkZN8ke8K9rQHkTXxHIWHxLzzW6RI1kXVoepkD3vULpKzC2sDtAMKn78h92BRYuzf+7b/ms7ajE6hFw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@18.2.20":
-  version "18.2.20"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.20.tgz#1605557a83df5c8a2cc4eeb743b3dfc0eb6aaeb2"
-  integrity sha512-WKNtmsLWJM/3D5mG4U84cysVY31ivmyw85dE84fOCk5Hx78wezB/XEjVPWl2JTZ5FkEeaTJf+VgUAUn3PE7Isw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -14840,12 +14822,7 @@ typedoc@^0.25.1:
     minimatch "^9.0.3"
     shiki "^0.14.1"
 
-typescript@5.1.6:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
-
-typescript@^4.5.2, typescript@^4.9.5:
+typescript@5.1.6, typescript@^4.5.2, typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
Add an option to reveal username in the leaderboard 

* add a new db column that alllows user to set whether they want to reveal their TG username
* add necessary routes that let user toggle on/off TG username sharing
* instead of returning semaphore_id, return `sha256(semaphore_id)` as the seed to pseudo random username. This avoids unnecessarily revealing link between semaphore id and TG username in the leaderboard.
* create a new `useCredentialManager` hook to streamline getting semaphore signature PCD, basically all used by frogcrypto

if you don't have TG username entry to publish

<img width="636" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/bafa822b-02e4-47e4-801d-44ad16372618">

has TG user name to share
<img width="440" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/d3cdb6b1-776f-4ac9-a291-903b43bd4014">

<img width="663" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/f4cd2be2-6b8b-4faa-b2a4-f416de1a9ad4">

TG username shared

<img width="507" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/99c746ba-6095-4270-addf-fdb719313d59">

<img width="720" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/5c8925c7-762d-4005-8748-f333acf03e62">

