### PR TITLE
[frogcrypto] fix link button style

### DIFF
--- a/packages/eddsa-frog-pcd/src/CardBody.tsx
+++ b/packages/eddsa-frog-pcd/src/CardBody.tsx
@@ -72,8 +72,11 @@ export function EdDSAFrogCardBody({
     </Container>
   ) : (
     <Container>
-      <LinkButton onClick={() => setShowPCD(true)}>
-        View as proof-carrying data
+      <LinkButton
+        style={{ textAlign: "center" }}
+        onClick={() => setShowPCD(true)}
+      >
+        View as proof&#x2011;carrying data
       </LinkButton>
       <ImageZoom
         src={frogData?.imageUrl}


### PR DESCRIPTION
small fix on the link button centering as well as not break at the hyphen

before
<img width="479" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/6ed95317-101f-42ca-836e-8788f7bce532">


after
<img width="1053" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/d9c078c2-19bf-4e10-a496-89685e27ee80">
