### PR TITLE
[frogcrypto] fix feed qr redirect

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -5,7 +5,6 @@ import { useEffect, useMemo, useState } from "react";
 import styled, { keyframes } from "styled-components";
 import { useSubscriptions } from "../../../src/appHooks";
 import { useUserFeedState } from "./FrogHomeSection";
-import { DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL } from "./useFrogFeed";
 
 /**
  * Render the FrogCrypto folder in the home screen.
@@ -58,7 +57,9 @@ function useFetchTimestamp(): number | null {
   const { value: subs } = useSubscriptions();
   const frogSubs = useMemo(
     () =>
-      subs.getSubscriptionsForProvider(DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL),
+      subs
+        .getActiveSubscriptions()
+        .filter((sub) => sub.providerUrl.includes("frogcrypto")),
     [subs]
   );
   const { userState } = useUserFeedState(frogSubs);

--- a/apps/passport-client/components/screens/FrogScreens/FrogSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogSubscriptionScreen.tsx
@@ -4,7 +4,6 @@ import { useParams } from "react-router-dom";
 import { useIsSyncSettled, useSubscriptions } from "../../../src/appHooks";
 import { useSyncE2EEStorage } from "../../../src/useSyncE2EEStorage";
 import { RippleLoader } from "../../core/RippleLoader";
-import { DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL } from "./useFrogFeed";
 
 export const FROM_SUBSCRIPTION_PARAM_KEY = "fromFrogSubscription";
 
@@ -17,9 +16,9 @@ export function FrogSubscriptionScreen() {
 
   // get current frog subscriptions
   const { value: subs } = useSubscriptions();
-  const frogSubs = subs.getSubscriptionsForProvider(
-    DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL
-  );
+  const frogSubs = subs
+    .getActiveSubscriptions()
+    .filter((sub) => sub.providerUrl.includes("frogcrypto"));
   const hasFrogSubs = frogSubs.length > 0;
 
   const { feedCode } = useParams();

--- a/apps/passport-client/components/screens/FrogScreens/useFrogFeed.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/useFrogFeed.tsx
@@ -12,7 +12,7 @@ import { validate } from "uuid";
 import { appConfig } from "../../../src/appConfig";
 import { useDispatch, useSubscriptions } from "../../../src/appHooks";
 
-export const DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL = `${appConfig.zupassServer}/frogcrypto/feeds`;
+export const DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL = `${appConfig.frogCryptoServer}/frogcrypto/feeds`;
 
 /**
  * Returns a callback to register the default frog subscription provider and
@@ -32,12 +32,11 @@ export function useInitializeFrogSubscriptions(): (
       );
 
       function parseAndAddFeed(feed: Feed, deeplink: boolean): boolean {
-        // skip any feeds that are already subscribed to
+        // skip any feeds that are already subscribed to.
+        // due to a merge conflict, we have users who have subscribed to a different feed provider url.
+        // because frog feed is uuid, it is safe to compare across the feeds.
         if (
-          subs.getSubscriptionsByProviderAndFeedId(
-            DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL,
-            feed.id
-          ).length > 0
+          subs.getActiveSubscriptions().find((sub) => sub.feed.id === feed.id)
         ) {
           return false;
         }


### PR DESCRIPTION
Due to an unfortunate merge conflict below, I accidentally changed the default frogcrypto provider url to the zupass server. This resulted some users with "wrong" feedhost url and rendered the finding frog subscriptions giving unexpected results.

This PR makes a workaround where we look at /frogcrypto url parts or compare feed id directly when appropriate. This is required to immediately unblock QR code redirect because we want to redirect them to new user experience if they don't have feeds. With the bug, they are just redirected to the frog folder. I missed this in testing because local dev both URLs are the same.

I would like to properly clean up separately with more time to thoroughly test https://github.com/proofcarryingdata/zupass/issues/1247

### testing

I tested locally by adding staging feeds to verified redirect and folder countdown works. Basically I added staging feedhost as a "mistake" feedhost and the only frog feeds. I am now able to get the redirect experience as expected.

### merge conflict

https://github.com/proofcarryingdata/zupass/pull/1215/files#diff-ca4750669dc9235cf1a324644f88d010d6e6974a2c7ded8bb3fde1dedaa35373L216

https://github.com/proofcarryingdata/zupass/pull/1215/files#diff-e1bb5c065547fd6892370519a9609ddadde3350f17227aa651df910e50633c99R14