### PR TITLE
[frogcrypto] Fix image zoom

### DIFF
--- a/packages/eddsa-frog-pcd/src/CardBody.tsx
+++ b/packages/eddsa-frog-pcd/src/CardBody.tsx
@@ -82,7 +82,7 @@ export function EdDSAFrogCardBody({
         src={frogData?.imageUrl}
         draggable={false}
         loading="lazy"
-        style={{ width: "100%", height: "auto" }}
+        style={{ width: "100%", height: "auto", zIndex: "1000" }}
         options={{
           background: "rgba(0, 0, 0, 0.5)"
         }}


### PR DESCRIPTION
![image](https://github.com/proofcarryingdata/zupass/assets/10219618/5b818ceb-d220-4e52-9683-c346b7759bd8)

When you try to expand the image in the modal, this happens because the modal has a z-index of 999, so making the z-index 1000 for the image fixes that issue.

I was not able to run this because I couldn't install turbo, so please check it first. I have no idea if this will work.