### PR TITLE
[frogcrypto] show owned on dextab

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/Button.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/Button.tsx
@@ -182,6 +182,7 @@ export const Button = styled.button<{ pending?: boolean }>`
 
 export const ButtonGroup = styled.div`
   display: flex;
+  align-items: center;
   gap: 8px;
 `;
 

--- a/apps/passport-client/components/screens/FrogScreens/DexTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/DexTab.tsx
@@ -51,7 +51,10 @@ export function DexTab({
 
   return (
     <>
-      <ButtonGroup style={{ marginLeft: "auto", maxWidth: "100px" }}>
+      <ButtonGroup style={{ marginLeft: "auto" }}>
+        <span style={{ marginRight: "16px" }}>
+          Owned: {Object.keys(groupedPCDs).length.toString().padStart(3, "0")}
+        </span>
         <Button onClick={() => setMode("list")} disabled={mode === "list"}>
           <img
             src={icons.inputObject}
@@ -80,8 +83,10 @@ export function DexTab({
       )}
 
       {focusedFrogs && (
-        <FrogsModal pcds={focusedFrogs} onClose={() => setFocusedFrogs(null)}
-        color={RARITIES[focusedFrogs[0].claim.data.rarity].color}
+        <FrogsModal
+          pcds={focusedFrogs}
+          onClose={() => setFocusedFrogs(null)}
+          color={RARITIES[focusedFrogs[0].claim.data.rarity].color}
         />
       )}
     </>


### PR DESCRIPTION
<img width="494" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/ca028a07-7b83-47ff-b2af-293b21c36983">
