### PR TITLE
[frogcrypto] export frogs

### DIFF
--- a/apps/passport-client/components/modals/FrogCryptoExportPCDsModal.tsx
+++ b/apps/passport-client/components/modals/FrogCryptoExportPCDsModal.tsx
@@ -17,17 +17,17 @@ export function FrogCryptoExportPCDsModal() {
       <H3>Export Your FrogPCDs</H3>
 
       <p>
-        Each Frog is a PCD (Proof Carry Data), with attributes securely signed
-        by Zupass, making them tamper-proof. They are end-to-end encrypted,
-        meaning they cannot be recovered without your password, including by
-        Zupass.
+        Each Frog is a PCD (Proof Carrying Data), with attributes securely
+        signed by Zupass, making them tamper-proof. They are end-to-end
+        encrypted, meaning they cannot be recovered without your password,
+        including by Zupass.
       </p>
       <p>
         By clicking Download, you will receive an unencrypted, plaintext copy of
         all your Frogs. Although this file contains minimal sensitive
         information, we recommend safeguarding it for privacy reasons. It can be
         used to recover your FrogPCDs in case you forget your password or
-        encounter a glitch in the universe.
+        encounter a glitch in the Zuniverse.
       </p>
 
       <ActionButton

--- a/apps/passport-client/components/modals/FrogCryptoExportPCDsModal.tsx
+++ b/apps/passport-client/components/modals/FrogCryptoExportPCDsModal.tsx
@@ -1,0 +1,76 @@
+import { EdDSAFrogPCDPackage } from "@pcd/eddsa-frog-pcd";
+import { FrogCryptoFolderName } from "@pcd/passport-interface";
+import stringify from "fast-json-stable-stringify";
+import toast from "react-hot-toast";
+import styled from "styled-components";
+import { useDispatch, usePCDsInFolder } from "../../src/appHooks";
+import { H3 } from "../core";
+import { BtnBase } from "../core/Button";
+import { ActionButton } from "../screens/FrogScreens/Button";
+
+export function FrogCryptoExportPCDsModal() {
+  const dispatch = useDispatch();
+  const pcds = usePCDsInFolder(FrogCryptoFolderName);
+
+  return (
+    <Container>
+      <H3>Export Your FrogPCDs</H3>
+
+      <p>
+        Each Frog is a PCD (Proof Carry Data), with attributes securely signed
+        by Zupass, making them tamper-proof. They are end-to-end encrypted,
+        meaning they cannot be recovered without your password, including by
+        Zupass.
+      </p>
+      <p>
+        By clicking Download, you will receive an unencrypted, plaintext copy of
+        all your Frogs. Although this file contains minimal sensitive
+        information, we recommend safeguarding it for privacy reasons. It can be
+        used to recover your FrogPCDs in case you forget your password or
+        encounter a glitch in the universe.
+      </p>
+
+      <ActionButton
+        ButtonComponent={BtnBase}
+        onClick={async () => {
+          try {
+            const serialized = stringify(
+              await Promise.all(pcds.map(EdDSAFrogPCDPackage.serialize))
+            );
+            const blob = new Blob([serialized], { type: "text/plaintext" });
+
+            const elem = window.document.createElement("a");
+            elem.href = window.URL.createObjectURL(blob);
+            elem.download = `frogcrypto-pcds-${new Date().toISOString()}.txt`;
+            document.body.appendChild(elem);
+            elem.click();
+            document.body.removeChild(elem);
+          } catch (e) {
+            console.error(e);
+            toast.error(
+              "There was an error saving your frogs. Maybe try again?"
+            );
+            return;
+          }
+
+          dispatch({
+            type: "set-modal",
+            modal: {
+              modalType: "none"
+            }
+          });
+        }}
+      >
+        Download
+      </ActionButton>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 16px;
+  margin: 0 16px 16px 16px;
+`;

--- a/apps/passport-client/components/modals/Modal.tsx
+++ b/apps/passport-client/components/modals/Modal.tsx
@@ -9,6 +9,7 @@ import { icons } from "../icons";
 import { AnotherDeviceChangedPasswordModal } from "./AnotherDeviceChangedPasswordModal";
 import { ChangedPasswordModal } from "./ChangedPasswordModal";
 import { ConfirmSkipSetupModal } from "./ConfirmSkipSetupModal";
+import { FrogCryptoExportPCDsModal } from "./FrogCryptoExportPCDsModal";
 import { FrogCryptoUpdateTelegramModal } from "./FrogCryptoUpdateTelegramModal";
 import { InfoModal } from "./InfoModal";
 import { InvalidUserModal } from "./InvalidUserModal";
@@ -103,6 +104,8 @@ function getModalBody(modal: AppState["modal"], isProveOrAddScreen: boolean) {
           refreshAll={modal.refreshAll}
         />
       );
+    case "frogcrypto-export-pcds":
+      return <FrogCryptoExportPCDsModal />;
     case "none":
       return null;
     default:

--- a/apps/passport-client/components/screens/FrogScreens/DexTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/DexTab.tsx
@@ -2,6 +2,7 @@ import { EdDSAFrogPCD, IFrogData, Rarity } from "@pcd/eddsa-frog-pcd";
 import { DexFrog } from "@pcd/passport-interface";
 import { Dispatch, SetStateAction, useMemo, useState } from "react";
 import styled from "styled-components";
+import { useDispatch } from "../../../src/appHooks";
 import { RippleLoader } from "../../core/RippleLoader";
 import { icons } from "../../icons";
 import { Button, ButtonGroup } from "./Button";
@@ -40,6 +41,7 @@ export function DexTab({
   possibleFrogs?: DexFrog[];
   pcds: EdDSAFrogPCD[];
 }) {
+  const dispatch = useDispatch();
   const [mode, setMode] = useState<"grid" | "list">("list");
   const groupedPCDs = useGroupedPCDs(pcds || []);
 
@@ -51,6 +53,19 @@ export function DexTab({
 
   return (
     <>
+      <Button
+        onClick={() =>
+          dispatch({
+            type: "set-modal",
+            modal: {
+              modalType: "frogcrypto-export-pcds"
+            }
+          })
+        }
+      >
+        Export FrogPCDs
+      </Button>
+
       <ButtonGroup style={{ marginLeft: "auto" }}>
         <span style={{ marginRight: "16px" }}>
           Owned: {Object.keys(groupedPCDs).length.toString().padStart(3, "0")}

--- a/apps/passport-client/src/state.ts
+++ b/apps/passport-client/src/state.ts
@@ -40,7 +40,8 @@ export interface AppState {
         modalType: "frogcrypto-update-telegram";
         revealed: boolean;
         refreshAll: () => Promise<void>;
-      };
+      }
+    | { modalType: "frogcrypto-export-pcds" };
 
   // User metadata.
   self?: User;


### PR DESCRIPTION
add button to export frogs

<img width="513" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/e266115f-cd61-47a9-a570-107224caf0a8">
