### PR TITLE
surface 404 error

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
@@ -148,6 +148,12 @@ const SearchButton = ({
                         "Froggy hall of fame! You've won... but your lily pad's full. No room for more buddies!"
                       );
                     }
+                    if (fetchErrorMsg?.includes("frog not found")) {
+                      subManager.resetError(id);
+                      return reject(
+                        "Alas, there is nothing but a lily pad here."
+                      );
+                    }
                   }
 
                   resolve();


### PR DESCRIPTION
Explicitly handle 404 error which will be thrown if a feed is active but configured to now return any frogs. This will allow us keeping the void "open" for folks who chased down through the zufrog riddle.

<img width="393" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/4317392/a17cc28e-c82e-4b67-aca6-3b60530f676f">
