### PR TITLE
Basic account export

### DIFF
--- a/apps/passport-client/components/modals/SettingsModal.tsx
+++ b/apps/passport-client/components/modals/SettingsModal.tsx
@@ -23,6 +23,10 @@ export function SettingsModal({
     }
   }, [dispatch]);
 
+  const exportData = useCallback(() => {
+    dispatch({ type: "export-data" });
+  }, [dispatch]);
+
   return (
     <>
       <TextCenter>
@@ -49,6 +53,8 @@ export function SettingsModal({
             <Spacer h={16} />
           </>
         )}
+        <Button onClick={exportData}>Export Account Data</Button>
+        <Spacer h={16} />
         <Button onClick={clearZupass} style="danger">
           Log Out
         </Button>


### PR DESCRIPTION
This allows the user to export the same data that is used for e2ee sync as a JSON file. This includes their Semaphore identity along with all other PCDs, their subscriptions, and their user profile (uuid, email, salt, privacy policy status).

<img width="447" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/0e63dd72-8e34-48f9-a15e-5ee868530661">

The more complex part is figuring out how to import this data, but this at least allows people to export their data in the meantime.