### PR TITLE
Fix warning from onClick

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/Countdown.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/Countdown.tsx
@@ -73,7 +73,7 @@ function TheEnd() {
   }, [dismiss]);
 
   return (
-    <Container visible={visible} onClick={visible && dismiss}>
+    <Container visible={visible} onClick={visible ? dismiss : undefined}>
       <img src="/images/frogs/frogelion.jpg" draggable={false} />
       <GameOver>IT IS DONE.</GameOver>
     </Container>


### PR DESCRIPTION
Fixes #1289.  CC: @saurfang 

I tested that the warning went away.  I also tested that after deleting `frogcrypto-the-end-animation-shown` variable from local storage, I saw TheEnd animation again, and clicking did properly dismiss it.
