### PR TITLE
Fixed publication script to serially build packages

### DIFF
--- a/new-version.sh
+++ b/new-version.sh
@@ -1,3 +1,29 @@
+#!/bin/bash
+
+# Default to using the npm registry, use REGISTRY env var to override, for
+# example to publish to Verdaccio you might set REGISTRY=http://localhost:4873
+: "${REGISTRY:=https://registry.npmjs.org}"
+
+# Create the changeset, selecting which packages are included
 yarn changeset
+# Assign new versions to affected packages
 yarn changeset version 
-yarn changeset publish
+
+# The path to this script, i.e. the root of the repo
+full_path=$(realpath $0)
+dir_path=$(dirname $full_path)
+cyan_bold='\033[36;1m'
+
+# Loop over each package
+for dir in $dir_path/packages/*;
+do
+  # Extract the package name from the path
+  package_name=$(basename $dir)
+  echo -e "Publishing package ${cyan_bold}$package_name\033[0m"
+  # Publish the package
+  # This might fail if the current version of the package has already been
+  # published, but this is unlikely since new versions were assigned by
+  # `yarn changeset version`. Failure of a single package to publish will
+  # not prevent other packages from publishing.
+  cd $dir && yarn publish --registry=$REGISTRY --non-interactive
+done


### PR DESCRIPTION
`yarn changeset publish` tries to publish packages in parallel, but since our packages rebuild using the `prepublishOnly` hook, this causes them to all rebuild in parallel. Since some packages depend on other packages which are now only partially-built, some builds fail.

Our script now uses `yarn publish` to publish each package serially. As an added bonus, you can also change the package registry using the `REGISTRY` environment variable, making it possible to test the process first by doing:

```
yarn verdaccio
# In a separate terminal window:
REGISTRY=http://localhost:4873 ./new-version.sh
```

Omitting the `REGISTRY` environment variable will use the npm registry as the target.