### PR TITLE
Use `tsc` to generate type declarations and declaration maps

### DIFF
--- a/packages/eddsa-frog-pcd/package.json
+++ b/packages/eddsa-frog-pcd/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/eddsa-pcd/package.json
+++ b/packages/eddsa-pcd/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/eddsa-ticket-pcd/package.json
+++ b/packages/eddsa-ticket-pcd/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/email-pcd/package.json
+++ b/packages/email-pcd/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -4,12 +4,12 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/index.js",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/types/src/index.d.ts"
     }
   },
   "files": [
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/ethereum-group-pcd/package.json
+++ b/packages/ethereum-group-pcd/package.json
@@ -4,20 +4,20 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/node/index.js",
   "module": "./dist/node/index.mjs",
-  "types": "./dist/node/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
       "browser": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       },
       "node": {
-        "types": "./dist/node/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/node/index.mjs",
         "require": "./dist/node/index.js"
       },
       "default": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       }
     }
@@ -30,8 +30,14 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format cjs,esm --dts --clean && tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:browser\" \"yarn build:node\" \"yarn build:types\"",
+    "build:browser": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format esm --clean",
+    "build:node": "tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\" \"yarn dev:types\"",
+    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --watch",
+    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/ethereum-ownership-pcd/package.json
+++ b/packages/ethereum-ownership-pcd/package.json
@@ -4,20 +4,20 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/node/index.js",
   "module": "./dist/node/index.mjs",
-  "types": "./dist/node/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
       "browser": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       },
       "node": {
-        "types": "./dist/node/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/node/index.mjs",
         "require": "./dist/node/index.js"
       },
       "default": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       }
     }
@@ -30,8 +30,14 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format cjs,esm --dts --clean && tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:browser\" \"yarn build:node\" \"yarn build:types\"",
+    "build:browser": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format esm --clean",
+    "build:node": "tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\" \"yarn dev:types\"",
+    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --watch",
+    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/halo-nonce-pcd/package.json
+++ b/packages/halo-nonce-pcd/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/input-test-pcd/package.json
+++ b/packages/input-test-pcd/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/passport-crypto/package.json
+++ b/packages/passport-crypto/package.json
@@ -4,20 +4,20 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/node/index.js",
   "module": "./dist/browser/index.mjs",
-  "types": "./dist/node/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
       "browser": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       },
       "node": {
-        "types": "./dist/node/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/node/index.mjs",
         "require": "./dist/node/index.js"
       },
       "default": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       }
     }
@@ -30,10 +30,14 @@
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",
-    "build": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format esm --dts --clean && tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --dts --clean",
-    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\"",
-    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --dts --watch",
-    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:browser\" \"yarn build:node\" \"yarn build:types\"",
+    "build:browser": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format esm --clean",
+    "build:node": "tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\" \"yarn dev:types\"",
+    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --watch",
+    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "clean": "rm -rf dist node_modules"

--- a/packages/passport-interface/package.json
+++ b/packages/passport-interface/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/passport-ui/package.json
+++ b/packages/passport-ui/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/pcd-collection/package.json
+++ b/packages/pcd-collection/package.json
@@ -4,10 +4,10 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/pcd-types/package.json
+++ b/packages/pcd-types/package.json
@@ -4,10 +4,10 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types/src",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "clean": "rm -rf dist node_modules"

--- a/packages/rsa-image-pcd/package.json
+++ b/packages/rsa-image-pcd/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/rsa-pcd/package.json
+++ b/packages/rsa-pcd/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/rsa-ticket-pcd/package.json
+++ b/packages/rsa-ticket-pcd/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/semaphore-group-pcd/package.json
+++ b/packages/semaphore-group-pcd/package.json
@@ -4,20 +4,20 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/node/index.js",
   "module": "./dist/browser/index.mjs",
-  "types": "./dist/node/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
       "browser": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       },
       "node": {
-        "types": "./dist/node/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/node/index.mjs",
         "require": "./dist/node/index.js"
       },
       "default": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       }
     }
@@ -30,10 +30,14 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format esm --dts --clean && tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --dts --clean",
-    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\"",
-    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format cjs,esm --dts --watch",
-    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:browser\" \"yarn build:node\" \"yarn build:types\"",
+    "build:browser": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format esm --clean",
+    "build:node": "tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\" \"yarn dev:types\"",
+    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --watch",
+    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/semaphore-identity-pcd/package.json
+++ b/packages/semaphore-identity-pcd/package.json
@@ -4,20 +4,20 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/node/index.js",
   "module": "./dist/node/index.mjs",
-  "types": "./dist/node/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
       "browser": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       },
       "node": {
-        "types": "./dist/node/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/node/index.mjs",
         "require": "./dist/node/index.js"
       },
       "default": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       }
     }
@@ -29,10 +29,14 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format cjs,esm --dts --clean && tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --dts --clean",
-    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\"",
-    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format cjs,esm --dts --watch",
-    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:browser\" \"yarn build:node\" \"yarn build:types\"",
+    "build:browser": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format esm --clean",
+    "build:node": "tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\" \"yarn dev:types\"",
+    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --watch",
+    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/semaphore-identity-pcd/src/CardBody.tsx
+++ b/packages/semaphore-identity-pcd/src/CardBody.tsx
@@ -1,5 +1,5 @@
 import { FieldLabel, HiddenText, Separator, styled } from "@pcd/passport-ui";
-import { SemaphoreIdentityPCD } from "@pcd/semaphore-identity-pcd";
+import { SemaphoreIdentityPCD } from "./SemaphoreIdentityPCD";
 
 export function SemaphoreIdentityCardBody({
   pcd

--- a/packages/semaphore-signature-pcd/package.json
+++ b/packages/semaphore-signature-pcd/package.json
@@ -4,20 +4,20 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/node/index.js",
   "module": "./dist/node/index.mjs",
-  "types": "./dist/node/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
       "browser": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       },
       "node": {
-        "types": "./dist/node/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/node/index.mjs",
         "require": "./dist/node/index.js"
       },
       "default": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       }
     }
@@ -30,10 +30,14 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format cjs,esm --dts --clean && tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --dts --clean",
-    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\"",
-    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format cjs,esm --dts --watch",
-    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:browser\" \"yarn build:node\" \"yarn build:types\"",
+    "build:browser": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format esm --clean",
+    "build:node": "tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\" \"yarn dev:types\"",
+    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --watch",
+    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -4,10 +4,10 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
@@ -19,8 +19,12 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --watch",
+    "build": "concurrently \"yarn build:ts\" \"yarn build:types\"",
+    "build:ts": "tsup src/index.ts --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:ts\" \"yarn dev:types\"",
+    "dev:ts": "tsup src/index.ts --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/zk-eddsa-event-ticket-pcd/package.json
+++ b/packages/zk-eddsa-event-ticket-pcd/package.json
@@ -4,20 +4,20 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/node/index.js",
   "module": "./dist/node/index.mjs",
-  "types": "./dist/node/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
       "browser": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       },
       "node": {
-        "types": "./dist/node/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/node/index.mjs",
         "require": "./dist/node/index.js"
       },
       "default": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       }
     }
@@ -30,10 +30,14 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format cjs,esm --dts --clean && tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --dts --clean",
-    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\"",
-    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --dts --watch",
-    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:browser\" \"yarn build:node\" \"yarn build:types\"",
+    "build:browser": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format esm --clean",
+    "build:node": "tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\" \"yarn dev:types\"",
+    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --watch",
+    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "prepublishOnly": "yarn build",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",

--- a/packages/zk-eddsa-frog-pcd/package.json
+++ b/packages/zk-eddsa-frog-pcd/package.json
@@ -4,20 +4,20 @@
   "license": "GPL-3.0-or-later",
   "main": "./dist/node/index.js",
   "module": "./dist/node/index.mjs",
-  "types": "./dist/node/index.d.ts",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
       "browser": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       },
       "node": {
-        "types": "./dist/node/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/node/index.mjs",
         "require": "./dist/node/index.js"
       },
       "default": {
-        "types": "./dist/browser/index.d.ts",
+        "types": "./dist/types/src/index.d.ts",
         "import": "./dist/browser/index.mjs"
       }
     }
@@ -30,10 +30,14 @@
   ],
   "scripts": {
     "lint": "eslint \"**/*.ts{,x}\"",
-    "build": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format cjs,esm --dts --clean && tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --dts --clean",
-    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\"",
-    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --dts --watch",
-    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --dts --watch",
+    "build": "concurrently \"yarn build:browser\" \"yarn build:node\" \"yarn build:types\"",
+    "build:browser": "tsup src/index.ts --platform=browser --out-dir=./dist/browser --format esm --clean",
+    "build:node": "tsup src/index.ts --platform=node --out-dir=./dist/node --format cjs,esm --clean",
+    "build:types": "rm -rf dist/types && tsc --emitDeclarationOnly --outDir dist/types",
+    "dev": "concurrently \"yarn dev:browser\" \"yarn dev:node\" \"yarn dev:types\"",
+    "dev:browser": "tsup --platform=browser src/index.ts --out-dir ./dist/browser --format esm --watch",
+    "dev:node": "tsup --platform=node src/index.ts --out-dir ./dist/node --format cjs,esm --watch",
+    "dev:types": "tsc --emitDeclarationOnly --outDir dist/types --watch",
     "typecheck": "yarn tsc --noEmit",
     "test": "ts-mocha --config ../../.mocharc.js --exit test/**/*.spec.ts",
     "prepublishOnly": "yarn build",


### PR DESCRIPTION
Since `tsup` [does not support declaration maps](https://github.com/egoist/tsup/issues/564) we have to use `tsc` for this.

I've refactored the build commands a bit so that it's a bit easier to see what is going on. Most packages now have two `build` commands, `build:ts` and `build:types`. The first uses `tsup` to build the TypeScript and bundle the resulting JS, and the second creates type declarations and declaration maps. Some packages with separate node and browser builds have three: instead of `build:ts` they have `build:browser` and `build:node`, with `build:types` remaining the same.

I have also created `dev:*` equivalents of these build commands.