### PR TITLE
Implement merge for sync

### DIFF
--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -25,6 +25,7 @@ import {
   useUserForcedToLogout
 } from "../../src/appHooks";
 import { isDefaultSubscription } from "../../src/defaultSubscriptions";
+import { saveSubscriptions } from "../../src/localstorage";
 import {
   clearAllPendingRequests,
   pendingAddSubscriptionRequestKey,
@@ -89,6 +90,7 @@ export function AddSubscriptionScreen() {
         setFetchedProviderName(response.providerName);
         if (!subs.getProvider(response.providerUrl)) {
           subs.addProvider(response.providerUrl, response.providerName);
+          saveSubscriptions(subs);
         }
       })
       .catch((e) => {

--- a/apps/passport-client/components/screens/FrogScreens/useFrogFeed.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/useFrogFeed.tsx
@@ -11,6 +11,7 @@ import urljoin from "url-join";
 import { validate } from "uuid";
 import { appConfig } from "../../../src/appConfig";
 import { useDispatch, useSubscriptions } from "../../../src/appHooks";
+import { saveSubscriptions } from "../../../src/localstorage";
 
 export const DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL = `${appConfig.frogCryptoServer}/frogcrypto/feeds`;
 
@@ -30,6 +31,7 @@ export function useInitializeFrogSubscriptions(): (
         DEFAULT_FROG_SUBSCRIPTION_PROVIDER_URL,
         FrogCryptoFolderName
       );
+      saveSubscriptions(subs); // If the subscription was new, make sure it's saved.
 
       function parseAndAddFeed(feed: Feed, deeplink: boolean): boolean {
         // skip any feeds that are already subscribed to.

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -62,7 +62,6 @@ import {
   saveCheckedInOfflineTickets,
   saveIdentity,
   saveOfflineTickets,
-  saveSubscriptions,
   saveUsingLaserScanner
 } from "../src/localstorage";
 import { registerServiceWorker } from "../src/registerServiceWorker";
@@ -409,8 +408,6 @@ async function loadInitialState(): Promise<AppState> {
   const offlineTickets = loadOfflineTickets();
   const checkedInOfflineDevconnectTickets =
     loadCheckedInOfflineDevconnectTickets();
-
-  subscriptions.updatedEmitter.listen(() => saveSubscriptions(subscriptions));
 
   let modal = { modalType: "none" } as AppState["modal"];
 

--- a/apps/passport-client/src/useSyncE2EEStorage.tsx
+++ b/apps/passport-client/src/useSyncE2EEStorage.tsx
@@ -31,14 +31,6 @@ import {
 import { getPackages } from "./pcdPackages";
 import { useOnStateChange } from "./subscribe";
 
-// Temporary feature flag to allow the sync-merge code to be on the main branch
-// before it's fully complete.  When this is set to false, the behavior should
-// remain as it was before sync-merge was implemented at all.  Uploads will
-// always overwrite existing contents, and downloads will always take new
-// contents without merging.
-// TODO(artwyman): Remove this when #1342 is complete.
-const ENABLE_SYNC_MERGE = true;
-
 export type UpdateBlobKeyStorageInfo = {
   revision: string;
   storageHash: string;
@@ -79,7 +71,7 @@ export async function updateBlobKeyForEncryptedStorage(
     newUser.uuid,
     newSalt,
     encryptedStorage,
-    ENABLE_SYNC_MERGE ? knownServerStorageRevision : undefined
+    knownServerStorageRevision
   );
   if (changeResult.success) {
     console.log(
@@ -154,7 +146,7 @@ export async function uploadSerializedStorage(
     appConfig.zupassServer,
     blobKey,
     encryptedStorage,
-    ENABLE_SYNC_MERGE ? knownRevision : undefined
+    knownRevision
   );
 
   if (uploadResult.success) {
@@ -342,11 +334,7 @@ export async function downloadAndMergeStorage(
   // Check if local app state has changes since the last server revision, in
   // which case a merge is necessary.  Otherwise we keep the downloaded state.
   let [newPCDs, newSubscriptions] = [dlPCDs, dlSubscriptions];
-  if (
-    ENABLE_SYNC_MERGE &&
-    knownServerRevision !== undefined &&
-    knownServerHash !== undefined
-  ) {
+  if (knownServerRevision !== undefined && knownServerHash !== undefined) {
     const appStorage = await serializeStorage(
       appSelf,
       appPCDs,

--- a/packages/lib/passport-interface/test/SubscriptionManager.spec.ts
+++ b/packages/lib/passport-interface/test/SubscriptionManager.spec.ts
@@ -75,6 +75,8 @@ describe("Subscription Manager", async function () {
         feed
       );
       expect(subs1).to.have.length(1);
+      expect(subs1[0].providerUrl).to.eq("https://" + provider);
+      expect(subs1[0].feed.id).to.eq(feed);
     }
   }
 
@@ -217,7 +219,7 @@ describe("Subscription Manager", async function () {
       }
     };
 
-    const sub = await manager.subscribe(providerUrl, feed, undefined);
+    const sub = await manager.subscribe(providerUrl, feed);
 
     const action = {
       type: PCDActionType.ReplaceInFolder,
@@ -258,6 +260,8 @@ describe("Subscription Manager", async function () {
   });
 
   it("merging unique data should work", async function () {
+    // There are some collisions on provider ID, but all (provider, feed) pairs
+    // are unique, so we expect all of them to be maintained in a merge.
     const entries1 = [
       { provider: "1", feed: "1A" },
       { provider: "1", feed: "1B" },
@@ -277,7 +281,7 @@ describe("Subscription Manager", async function () {
       newProviders: 2,
       newSubscriptions: 4
     });
-    expect(mgr1.getActiveSubscriptions()).to.have.length(7);
+    expect(mgr1.getActiveSubscriptions()).to.have.length(allSubs.length);
     expectAllTestSubs(mgr1, allSubs);
 
     expect(mgr2.merge(mgr1)).to.deep.eq({

--- a/packages/lib/passport-interface/test/SubscriptionManager.spec.ts
+++ b/packages/lib/passport-interface/test/SubscriptionManager.spec.ts
@@ -1,8 +1,9 @@
 import { EmailPCDPackage } from "@pcd/email-pcd";
-import { PCDCollection } from "@pcd/pcd-collection";
+import { PCDActionType, PCDCollection } from "@pcd/pcd-collection";
 import { ArgumentTypeName } from "@pcd/pcd-types";
+import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import { Identity } from "@semaphore-protocol/identity";
-import { expect } from "chai";
+import { assert, expect } from "chai";
 import MockDate from "mockdate";
 import {
   CredentialManager,
@@ -32,6 +33,67 @@ describe("Subscription Manager", async function () {
   this.afterEach(() => {
     MockDate.reset();
   });
+
+  function setupTestManager(
+    subs: { provider: string; feed: string }[]
+  ): FeedSubscriptionManager {
+    const manager = new FeedSubscriptionManager(new MockFeedApi());
+    for (const sub of subs) {
+      const providerUrl = "https://" + sub.provider;
+      manager.getOrAddProvider(providerUrl, sub.provider);
+      manager.subscribe(providerUrl, {
+        description: "description of " + sub.feed,
+        id: sub.feed,
+        name: "name of " + sub.feed,
+        permissions: [],
+        inputPCDType: undefined,
+        partialArgs: undefined,
+        credentialRequest: {
+          signatureType: "sempahore-signature-pcd"
+        }
+      });
+    }
+
+    expect(manager.getActiveSubscriptions()).to.have.length(subs.length);
+    for (const sub of subs) {
+      const providerUrl = "https://" + sub.provider;
+      expect(manager.hasProvider(providerUrl)).to.be.true;
+      expect(
+        manager.getSubscriptionsByProviderAndFeedId(providerUrl, sub.feed)
+      ).to.have.length(1);
+    }
+    return manager;
+  }
+
+  function expectAllTestSubs(
+    mgr: FeedSubscriptionManager,
+    subs: { provider: string; feed: string }[]
+  ): void {
+    for (const { provider, feed } of subs) {
+      const subs1 = mgr.getSubscriptionsByProviderAndFeedId(
+        "https://" + provider,
+        feed
+      );
+      expect(subs1).to.have.length(1);
+    }
+  }
+
+  function expectSameSubs(
+    mgr1: FeedSubscriptionManager,
+    mgr2: FeedSubscriptionManager
+  ): void {
+    expect(mgr1.getActiveSubscriptions().length).to.eq(
+      mgr2.getActiveSubscriptions().length
+    );
+    for (const sub1 of mgr1.getActiveSubscriptions()) {
+      const subs2 = mgr2.getSubscriptionsByProviderAndFeedId(
+        sub1.providerUrl,
+        sub1.feed.id
+      );
+      expect(subs2).to.have.length(1);
+      expect(subs2[0]).to.deep.eq(sub1);
+    }
+  }
 
   it("keeping track of providers should work", async function () {
     const manager = new FeedSubscriptionManager(mockFeedApi);
@@ -135,6 +197,146 @@ describe("Subscription Manager", async function () {
       expect(l.providerUrl).to.eq(r.providerUrl);
       expect(l.subscribedTimestamp).to.eq(r.subscribedTimestamp);
     }
+  });
+
+  it("cloning should work", async function () {
+    const manager = new FeedSubscriptionManager(mockFeedApi);
+
+    const providerUrl = "test url";
+    manager.addProvider(providerUrl, PROVIDER_NAME);
+
+    const feed: Feed = {
+      description: "description",
+      id: "1",
+      name: "test feed",
+      permissions: [],
+      inputPCDType: undefined,
+      partialArgs: undefined,
+      credentialRequest: {
+        signatureType: "sempahore-signature-pcd"
+      }
+    };
+
+    const sub = await manager.subscribe(providerUrl, feed, undefined);
+
+    const action = {
+      type: PCDActionType.ReplaceInFolder,
+      folder: "TEST",
+      pcds: [
+        await SemaphoreIdentityPCDPackage.serialize(
+          await SemaphoreIdentityPCDPackage.prove({
+            identity: new Identity()
+          })
+        )
+      ]
+    };
+
+    manager.setError("1", {
+      type: SubscriptionErrorType.PermissionError,
+      actions: [action]
+    });
+
+    const cleanupListener = manager.updatedEmitter.listen(() => {
+      assert.fail("Listener should never be called.");
+    });
+
+    expect(manager.getProviders()).to.have.length(1);
+    expect(manager.getActiveSubscriptions()).to.have.length(1);
+    expect(manager.getSubscription(sub.id)).to.not.be.undefined;
+
+    const clone = manager.clone();
+
+    expect(clone.getProviders()).to.deep.eq(manager.getProviders());
+    expect(clone.getSubscriptionsByProvider()).to.deep.eq(
+      manager.getSubscriptionsByProvider()
+    );
+    expectSameSubs(manager, clone);
+    expect(clone.getAllErrors()).to.deep.eq(manager.getAllErrors());
+
+    clone.unsubscribe(sub.id); // Would trigger listener if it were on the clone.
+    cleanupListener();
+  });
+
+  it("merging unique data should work", async function () {
+    const entries1 = [
+      { provider: "1", feed: "1A" },
+      { provider: "1", feed: "1B" },
+      { provider: "2", feed: "2A" }
+    ];
+    const mgr1 = setupTestManager(entries1);
+    const entries2 = [
+      { provider: "1", feed: "1C" },
+      { provider: "B", feed: "B1" },
+      { provider: "C", feed: "C1" },
+      { provider: "C", feed: "2A" }
+    ];
+    const mgr2 = setupTestManager(entries2);
+    const allSubs = [...entries1, ...entries2];
+
+    expect(mgr1.merge(mgr2)).to.deep.eq({
+      newProviders: 2,
+      newSubscriptions: 4
+    });
+    expect(mgr1.getActiveSubscriptions()).to.have.length(7);
+    expectAllTestSubs(mgr1, allSubs);
+
+    expect(mgr2.merge(mgr1)).to.deep.eq({
+      newProviders: 1,
+      newSubscriptions: 3
+    });
+    expect(mgr2.getActiveSubscriptions()).to.have.length(7);
+    expectAllTestSubs(mgr2, allSubs);
+
+    expectSameSubs(mgr1, mgr2);
+  });
+
+  it("merging should ignore duplicates", async function () {
+    const mgr = setupTestManager([
+      { provider: "1", feed: "1A" },
+      { provider: "1", feed: "1B" },
+      { provider: "2", feed: "2A" }
+    ]);
+    expect(mgr.getActiveSubscriptions()).to.have.length(3);
+
+    // Self-merge should be a nop.
+    expect(mgr.merge(mgr)).to.deep.eq({ newProviders: 0, newSubscriptions: 0 });
+    expect(mgr.getActiveSubscriptions()).to.have.length(3);
+
+    // Merge wth a clone should also be a nop.
+    expect(mgr.merge(mgr.clone())).to.deep.eq({
+      newProviders: 0,
+      newSubscriptions: 0
+    });
+    expect(mgr.getActiveSubscriptions()).to.have.length(3);
+
+    // Ignore duplicate feeds under the same provider.
+    expect(
+      mgr.merge(setupTestManager([{ provider: "1", feed: "1A" }]))
+    ).to.deep.eq({
+      newProviders: 0,
+      newSubscriptions: 0
+    });
+    expect(mgr.getActiveSubscriptions()).to.have.length(3);
+
+    // Allow duplicate feeds under a different provider.
+    expect(
+      mgr.merge(setupTestManager([{ provider: "3", feed: "1A" }]))
+    ).to.deep.eq({
+      newProviders: 1,
+      newSubscriptions: 1
+    });
+    expect(mgr.getActiveSubscriptions()).to.have.length(4);
+
+    // Ignore a duplicate subscription ID regardless of provider and feed.
+    // Also ensuring that no provider is added if no subscription is added.
+    const mgrWithDupId = setupTestManager([{ provider: "4", feed: "4A" }]);
+    mgrWithDupId.getActiveSubscriptions()[0].id =
+      mgr.getActiveSubscriptions()[0].id;
+    expect(mgr.merge(mgrWithDupId)).to.deep.eq({
+      newProviders: 0,
+      newSubscriptions: 0
+    });
+    expect(mgr.getActiveSubscriptions()).to.have.length(4);
   });
 
   it("listing feeds over network should work", async () => {


### PR DESCRIPTION
[Updated after force push] Adds merge functionality to sync, filling in the stub added in a previous diff.  Major pieces included:

- The E2EESync implementation uses the underlying merge of PCDs and subscriptions, and adds some stats accounting I hope to be useful for logging.
- There are TODOs for some pieces I think might want to be better, including explaining the goals and assumptions of the merge algorithm.
- The FeedsSubscritpionManager merge is implemented and tested as per the previous revision of this PR.
- The app-level changes around subscriptions motivated by my wanting to make sure it's okay to replace the FeedsSubscriptionManager with a new one at merge time.  Different parts of the app have different assumptions about this.  I've done my best to make it consistent.

This deserves more testing, but I did some manual testing creating conflicts with both PCDs and subscriptions, and I saw the expected results in both data and stats.  Those expectations are met both in the positive (no objects are ever lost) and the negative (removed objects come back if involved in a merge.

Fixes #641
Closes #1342
