### PR TITLE
Queue action dispatches

### DIFF
--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -58,6 +58,7 @@
     "handlebars": "^4.7.7",
     "isomorphic-timers-promises": "^1.0.1",
     "lodash": "^4.17.21",
+    "p-queue": "^8.0.1",
     "pretty-ms": "^8.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -5,6 +5,7 @@ import {
 } from "@pcd/passport-interface";
 import { isWebAssemblySupported } from "@pcd/util";
 import { Identity } from "@semaphore-protocol/identity";
+import PQueue from "p-queue";
 import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { toast } from "react-hot-toast";
@@ -82,7 +83,10 @@ class App extends React.Component<object, AppState> {
     });
   };
 
-  dispatch = (action: Action) => dispatch(action, this.state, this.update);
+  dispatchQueue = new PQueue({ concurrency: 1 });
+
+  dispatch = (action: Action) =>
+    this.dispatchQueue.add(() => dispatch(action, this.state, this.update));
   componentDidMount() {
     loadInitialState().then((s) => this.setState(s, this.startBackgroundJobs));
     setupBroadcastChannel(this.dispatch);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8345,6 +8345,11 @@ eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -12192,6 +12197,14 @@ p-queue@6, p-queue@6.6.2:
     eventemitter3 "^4.0.4"
     p-timeout "^3.2.0"
 
+p-queue@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-8.0.1.tgz#718b7f83836922ef213ddec263ff4223ce70bef8"
+  integrity sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==
+  dependencies:
+    eventemitter3 "^5.0.1"
+    p-timeout "^6.1.2"
+
 p-timeout@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-2.0.1.tgz#d8dd1979595d2dc0139e1fe46b8b646cb3cdf038"
@@ -12205,6 +12218,11 @@ p-timeout@^3.2.0:
   integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
   dependencies:
     p-finally "^1.0.0"
+
+p-timeout@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-6.1.2.tgz#22b8d8a78abf5e103030211c5fc6dee1166a6aa5"
+  integrity sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==
 
 p-try@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
An issue that came up a few times in the [account import PR](https://github.com/proofcarryingdata/zupass/pull/1347) was the risk of simultaneous "actions" updating the `AppState` in inconsistent ways - especially the possibility of either sync or feed polling changing the contents of the `pcds` `PCDCollection` while the import code is also modifying it.

This is possible because actions are async and therefore can occur concurrently. There's no good reason for this, and (for example) Redux's actions are synchronous.

This PR adds a queue around `dispatch`, so that only one action can be executing at a time.

I have tested various features such as importing, adding/removing subscriptions, and all seem to work as previously.