### PR TITLE
Increment sync API version

### DIFF
--- a/apps/passport-server/src/routing/routes/e2eeRoutes.ts
+++ b/apps/passport-server/src/routing/routes/e2eeRoutes.ts
@@ -20,7 +20,7 @@ export function initE2EERoutes(
    * storage, storing the new encrypted storage, and updating the user's
    * salt so they can re-derive their key.
    */
-  app.post("/sync/v2/changeBlobKey", async (req: Request, res: Response) => {
+  app.post("/sync/v3/changeBlobKey", async (req: Request, res: Response) => {
     const request = req.body as ChangeBlobKeyRequest;
     await e2eeService.handleChangeBlobKey(request, res);
   });
@@ -35,7 +35,7 @@ export function initE2EERoutes(
    *
    * @todo - restrict the calling of this api somehow? at least a rate limit.
    */
-  app.get("/sync/v2/load/", async (req: Request, res: Response) => {
+  app.get("/sync/v3/load/", async (req: Request, res: Response) => {
     await e2eeService.handleLoad(
       checkQueryParam(req, "blobKey"),
       checkOptionalQueryParam(req, "knownRevision"),
@@ -55,7 +55,7 @@ export function initE2EERoutes(
    * @todo - restrict + rate limit this?
    * @todo - size limits?
    */
-  app.post("/sync/v2/save", async (req: Request, res: Response) => {
+  app.post("/sync/v3/save", async (req: Request, res: Response) => {
     const request = req.body as UploadEncryptedStorageRequest;
     await e2eeService.handleSave(request, res);
   });

--- a/packages/lib/passport-interface/src/api/requestChangeBlobKey.ts
+++ b/packages/lib/passport-interface/src/api/requestChangeBlobKey.ts
@@ -26,7 +26,7 @@ export async function requestChangeBlobKey(
   knownRevision?: string
 ): Promise<ChangeBlobKeyResult> {
   return httpPost<ChangeBlobKeyResult>(
-    urlJoin(zupassServerUrl, `/sync/v2/changeBlobKey`),
+    urlJoin(zupassServerUrl, `/sync/v3/changeBlobKey`),
     {
       onValue: async (resText: string) => ({
         value: JSON.parse(resText) as ChangeBlobKeyResponseValue,

--- a/packages/lib/passport-interface/src/api/requestEncryptedStorage.ts
+++ b/packages/lib/passport-interface/src/api/requestEncryptedStorage.ts
@@ -19,7 +19,7 @@ export async function requestEncryptedStorage(
   knownRevision?: string
 ): Promise<EncryptedStorageResult> {
   return httpGet<EncryptedStorageResult>(
-    urlJoin(zupassServerUrl, "/sync/v2/load"),
+    urlJoin(zupassServerUrl, "/sync/v3/load"),
     {
       onValue: async (resText) => ({
         value: JSON.parse(resText) as DownloadEncryptedStorageResponseValue,

--- a/packages/lib/passport-interface/src/api/requestUploadEncryptedStorage.ts
+++ b/packages/lib/passport-interface/src/api/requestUploadEncryptedStorage.ts
@@ -20,7 +20,7 @@ export async function requestUploadEncryptedStorage(
   knownRevision?: string
 ): Promise<UploadEncryptedStorageResult> {
   return httpPost<UploadEncryptedStorageResult>(
-    urlJoin(zupassServerUrl, `/sync/v2/save`),
+    urlJoin(zupassServerUrl, `/sync/v3/save`),
     {
       onValue: async (resText: string) => ({
         value: JSON.parse(resText) as UploadEncryptedStorageResponseValue,


### PR DESCRIPTION
Closes #1343

This is a quck-and-dirty way to ensure that older clients which don't yet have our sync fixes won't be able to upload or download, and thus won't be able to lose more PCDs in conflicts.

Someday we might want to have an explicit updating scheme which prompts the user to reload the page, but this seems to work okay for now.
