### PR TITLE
Robust lookup for semaphore identity PCD

### DIFF
--- a/apps/passport-client/components/shared/PCDCardList.tsx
+++ b/apps/passport-client/components/shared/PCDCardList.tsx
@@ -1,9 +1,8 @@
 import { PCD } from "@pcd/pcd-types";
-import { SemaphoreIdentityPCDTypeName } from "@pcd/semaphore-identity-pcd";
 import _ from "lodash";
 import { useCallback, useMemo, useState } from "react";
 import styled from "styled-components";
-import { usePCDCollection } from "../../src/appHooks";
+import { usePCDCollection, useUserIdentityPCD } from "../../src/appHooks";
 import { PCDCard } from "./PCDCard";
 
 type Sortable<T = unknown> = {
@@ -44,13 +43,9 @@ export function PCDCardList({
    */
   allExpanded?: boolean;
 }) {
-  const mainPCDId = useMemo(() => {
-    if (pcds[0]?.type === SemaphoreIdentityPCDTypeName) {
-      return pcds[0]?.id;
-    }
-  }, [pcds]);
-
   const pcdCollection = usePCDCollection();
+  const userIdentityPCD = useUserIdentityPCD();
+  const userIdentityPCDId = userIdentityPCD?.id;
   const sortablePCDs = useMemo<Sortable<PCD>[]>(
     () =>
       pcds.map((pcd, i) => ({
@@ -123,7 +118,7 @@ export function PCDCardList({
         <PCDCard
           key={pcd.id}
           pcd={pcd}
-          isMainIdentity={pcd.id === mainPCDId}
+          isMainIdentity={pcd.id === userIdentityPCDId}
           onClick={allExpanded ? undefined : onClick}
           expanded={allExpanded || pcd.id === selectedPCD?.id}
         />

--- a/apps/passport-client/components/shared/cards/DevconnectTicket.tsx
+++ b/apps/passport-client/components/shared/cards/DevconnectTicket.tsx
@@ -13,7 +13,7 @@ import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import { ZKEdDSAEventTicketPCDPackage } from "@pcd/zk-eddsa-event-ticket-pcd";
 import { useCallback, useState } from "react";
 import styled from "styled-components";
-import { usePCDCollection } from "../../../src/appHooks";
+import { useUserIdentityPCD } from "../../../src/appHooks";
 import { RedactedText } from "../../core/RedactedText";
 import { ToggleSwitch } from "../../core/Toggle";
 import { icons } from "../../icons";
@@ -40,14 +40,13 @@ function makeTicketIdPCDVerifyLink(pcdStr: string): string {
  * other's ZK QR codes.
  */
 function TicketQR({ pcd, zk }: { pcd: EdDSATicketPCD; zk: boolean }) {
-  const pcds = usePCDCollection();
+  const identityPCD = useUserIdentityPCD();
 
   const generate = useCallback(async () => {
     if (zk) {
       const serializedTicketPCD = await EdDSATicketPCDPackage.serialize(pcd);
-      const serializedIdentityPCD = await SemaphoreIdentityPCDPackage.serialize(
-        pcds.getPCDsByType(SemaphoreIdentityPCDPackage.name)[0]
-      );
+      const serializedIdentityPCD =
+        await SemaphoreIdentityPCDPackage.serialize(identityPCD);
       const zkPCD = await ZKEdDSAEventTicketPCDPackage.prove({
         ticket: {
           value: serializedTicketPCD,
@@ -90,7 +89,7 @@ function TicketQR({ pcd, zk }: { pcd: EdDSATicketPCD; zk: boolean }) {
       const verificationLink = makeTicketIdVerifyLink(ticketId);
       return verificationLink;
     }
-  }, [pcd, pcds, zk]);
+  }, [pcd, identityPCD, zk]);
 
   if (zk) {
     return (

--- a/apps/passport-client/components/shared/cards/ZKTicket.tsx
+++ b/apps/passport-client/components/shared/cards/ZKTicket.tsx
@@ -15,7 +15,7 @@ import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import { ZKEdDSAEventTicketPCDPackage } from "@pcd/zk-eddsa-event-ticket-pcd";
 import { useCallback, useState } from "react";
 import styled from "styled-components";
-import { usePCDCollection } from "../../../src/appHooks";
+import { useUserIdentityPCD } from "../../../src/appHooks";
 import { makeEncodedVerifyLink } from "../../../src/qr";
 import { TextCenter } from "../../core";
 import { RedactedText } from "../../core/RedactedText";
@@ -38,13 +38,13 @@ function makeTicketIdVerifyLink(ticketId: string): string {
  * ZKEdDSAEventTicketPCD.
  */
 function TicketQR({ pcd, zk }: { pcd: EdDSATicketPCD; zk: boolean }) {
-  const pcds = usePCDCollection();
+  const identityPCD = useUserIdentityPCD();
+
   const generate = useCallback(async () => {
     if (zk) {
       const serializedTicketPCD = await EdDSATicketPCDPackage.serialize(pcd);
-      const serializedIdentityPCD = await SemaphoreIdentityPCDPackage.serialize(
-        pcds.getPCDsByType(SemaphoreIdentityPCDPackage.name)[0]
-      );
+      const serializedIdentityPCD =
+        await SemaphoreIdentityPCDPackage.serialize(identityPCD);
       const zkPCD = await ZKEdDSAEventTicketPCDPackage.prove({
         ticket: {
           value: serializedTicketPCD,
@@ -86,7 +86,7 @@ function TicketQR({ pcd, zk }: { pcd: EdDSATicketPCD; zk: boolean }) {
       const verificationLink = makeTicketIdVerifyLink(ticketId);
       return verificationLink;
     }
-  }, [pcd, pcds, zk]);
+  }, [pcd, identityPCD, zk]);
 
   if (zk) {
     return (

--- a/apps/passport-client/src/pcdRenderers.ts
+++ b/apps/passport-client/src/pcdRenderers.ts
@@ -18,6 +18,8 @@ import { RSATicketPCDTypeName } from "@pcd/rsa-ticket-pcd";
 import { RSATicketPCDUI } from "@pcd/rsa-ticket-pcd-ui";
 import { SemaphoreGroupPCDTypeName } from "@pcd/semaphore-group-pcd";
 import { SemaphoreGroupPCDUI } from "@pcd/semaphore-group-pcd-ui";
+import { SemaphoreIdentityPCDTypeName } from "@pcd/semaphore-identity-pcd";
+import { SemaphoreIdentityPCDUI } from "@pcd/semaphore-identity-pcd-ui";
 import { SemaphoreSignaturePCDTypeName } from "@pcd/semaphore-signature-pcd";
 import { SemaphoreSignaturePCDUI } from "@pcd/semaphore-signature-pcd-ui";
 import { ZKEdDSAEventTicketPCDTypeName } from "@pcd/zk-eddsa-event-ticket-pcd";
@@ -34,6 +36,7 @@ const renderablePCDs = [
   RSATicketPCDTypeName,
   RSATicketPCDTypeName,
   SemaphoreGroupPCDTypeName,
+  SemaphoreIdentityPCDTypeName,
   SemaphoreSignaturePCDTypeName,
   ZKEdDSAEventTicketPCDTypeName,
   RSAImagePCDTypeName
@@ -51,6 +54,7 @@ export const pcdRenderers: { [key in RenderablePCDType]: PCDUI } = {
   [RSAPCDTypeName]: RSAPCDUI,
   [RSATicketPCDTypeName]: RSATicketPCDUI,
   [SemaphoreGroupPCDTypeName]: SemaphoreGroupPCDUI,
+  [SemaphoreIdentityPCDTypeName]: SemaphoreIdentityPCDUI,
   [SemaphoreSignaturePCDTypeName]: SemaphoreSignaturePCDUI,
   [ZKEdDSAEventTicketPCDTypeName]: ZKEdDSAEventTicketPCDUI,
   [RSAImagePCDTypeName]: RSAImagePCDUI

--- a/apps/passport-client/src/user.ts
+++ b/apps/passport-client/src/user.ts
@@ -1,4 +1,9 @@
 import { requestLogToServer, requestUser, User } from "@pcd/passport-interface";
+import { PCDCollection } from "@pcd/pcd-collection";
+import {
+  SemaphoreIdentityPCD,
+  SemaphoreIdentityPCDTypeName
+} from "@pcd/semaphore-identity-pcd";
 import { appConfig } from "./appConfig";
 import { Dispatcher } from "./dispatch";
 
@@ -35,4 +40,26 @@ export async function pollUser(self: User, dispatch: Dispatcher) {
 // Function that checks whether the user has set a password for their account
 export function hasSetupPassword(user: User) {
   return user != null && user.salt != null;
+}
+
+export function findUserIdentityPCD(
+  pcds: PCDCollection,
+  user: User
+): SemaphoreIdentityPCD | undefined {
+  return findIdentityPCD(pcds, user.commitment);
+}
+
+export function findIdentityPCD(
+  pcds: PCDCollection,
+  identityCommitment: string
+): SemaphoreIdentityPCD | undefined {
+  for (const pcd of pcds.getPCDsByType(SemaphoreIdentityPCDTypeName)) {
+    if (
+      (pcd as SemaphoreIdentityPCD).claim.identity.commitment.toString() ===
+      identityCommitment
+    ) {
+      return pcd;
+    }
+  }
+  return undefined;
 }

--- a/apps/passport-client/test/stateValidation.spec.ts
+++ b/apps/passport-client/test/stateValidation.spec.ts
@@ -95,6 +95,20 @@ describe("validateAppState", async function () {
       ...TAG
     } satisfies ErrorReport);
 
+    const pcds = new PCDCollection(pcdPackages);
+    pcds.add(
+      await SemaphoreIdentityPCDPackage.prove({
+        identity: identity1
+      })
+    );
+    expect(
+      validateRunningAppState(TAG_STR, undefined, undefined, pcds, true)
+    ).to.deep.eq({
+      errors: [],
+      userUUID: undefined,
+      ...TAG
+    } satisfies ErrorReport);
+
     expect(
       validateRunningAppState(TAG_STR, undefined, undefined, undefined, true)
     ).to.deep.eq({
@@ -115,7 +129,37 @@ describe("validateAppState", async function () {
       terms_agreed: 1,
       uuid: uuid()
     };
-    const pcds = new PCDCollection(pcdPackages);
+    let pcds = new PCDCollection(pcdPackages);
+    pcds.add(
+      await SemaphoreIdentityPCDPackage.prove({
+        identity: identity1
+      })
+    );
+    expect(validateRunningAppState(TAG_STR, self, identity1, pcds)).to.deep.eq({
+      userUUID: self.uuid,
+      errors: [],
+      ...TAG
+    } satisfies ErrorReport);
+
+    // Extra identity PCD comes second and is ignored.
+    pcds.add(
+      await SemaphoreIdentityPCDPackage.prove({
+        identity: identity2
+      })
+    );
+    expect(validateRunningAppState(TAG_STR, self, identity1, pcds)).to.deep.eq({
+      userUUID: self.uuid,
+      errors: [],
+      ...TAG
+    } satisfies ErrorReport);
+
+    // Extra identity PCD comes first and is ignored.
+    pcds = new PCDCollection(pcdPackages);
+    pcds.add(
+      await SemaphoreIdentityPCDPackage.prove({
+        identity: identity2
+      })
+    );
     pcds.add(
       await SemaphoreIdentityPCDPackage.prove({
         identity: identity1


### PR DESCRIPTION
Replace all the places where semaphore identity PCD is looked up to no longer assume it's the first one.  Instead, `self.commitment` is used to find a matching PCD.  This removes some flaky assumptions, and sets us up for supporting multiple Semaphore identities in future.  The state validator also gets an update so it can use this lookup method normally, but also have a fallback so it report correctly when the User or Identity are missing.

Along the way, I ran into a case which made me finally understand Ivan's suggestion about using Wrapper<T> in React hooks.  I'm interested to know if the pattern I captured in `usePCDCollectionWithWrapper()` seems correct and clear.  It seemed to work in my limited test case.
