### PR TITLE
Remove buggy and unnecessary type definition

### DIFF
--- a/apps/passport-server/package.json
+++ b/apps/passport-server/package.json
@@ -84,7 +84,6 @@
     "@types/deep-equal-in-any-order": "^1.0.2",
     "@types/express": "^4.17.16",
     "@types/flat": "5",
-    "@types/generic-pool": "^3.8.1",
     "@types/lodash": "^4.14.191",
     "@types/mocha": "^10.0.1",
     "@types/mocha-steps": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4612,7 +4612,7 @@
     "@types/jsonfile" "*"
     "@types/node" "*"
 
-"@types/generic-pool@^3.1.9", "@types/generic-pool@^3.8.1":
+"@types/generic-pool@^3.1.9":
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/@types/generic-pool/-/generic-pool-3.8.1.tgz#b9b25b2ba4733057fa5df1818352d3205c48e87b"
   integrity sha512-eaMAbZS0EfKvaP5PUZ/Cdf5uJBO2t6T3RdvQTKuMqUwGhNpCnPAsKWEMyV+mCeCQG3UiHrtgdzni8X6DmhxRaQ==


### PR DESCRIPTION
Closes #1388 

As explained [here](https://stackoverflow.com/a/71599284), types packages that contain subdirectories should include an `index.d.ts` file. `@types/generic-pool` contains a subdirectory that does not include an `index.d.ts`, which causes intermittent build failures (at least on my machine). `@types/generic-pool` is deprectated, and provides types for `node-pool`, which a) has its own types now and b) isn't even being used in our repo.