### PR TITLE
Disable prettier eslint error in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,8 @@
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"
     }
-  }
+  },
+  "eslint.rules.customizations": [
+    { "rule": "prettier/prettier", "severity": "off" }
+  ]
 }


### PR DESCRIPTION
We want to use the `prettier` plugin for ESLint in order to include it in the lint checks in CI. We also auto-format files with `prettier` on save in VSCode, and we also report ESLint errors in VSCode (the red squiggly underline).

However, this means that as soon as we break `prettier`'s formatting rules, VSCode flags the relevant code section as an "error". This is confusing, because when typing there are several kinds of error that one could be introducing - syntax errors, type errors, and so on, and it is not possible to distinguish these from mere formatting errors that `prettier` will resolve automatically when the file is saved. Because these formatting errors are so common during typing, they add so much noise to the typing experience that it becomes difficult to notice if or when you have introduced a more serious error.

This change causes VSCode to ignore errors from the prettier ESLint plugin. The file will still be auto-formatted on save, and ESLint will still report the error during CI or `yarn lint`.