### PR TITLE
Fix include paths for circuits

### DIFF
--- a/packages/pcd/zk-eddsa-event-ticket-pcd/circuits/index.circom
+++ b/packages/pcd/zk-eddsa-event-ticket-pcd/circuits/index.circom
@@ -1,7 +1,7 @@
 pragma circom 2.1.4;
 
-include "../../../node_modules/circomlib/circuits/poseidon.circom";
-include "../../../node_modules/circomlib/circuits/eddsaposeidon.circom";
+include "../../../../node_modules/circomlib/circuits/poseidon.circom";
+include "../../../../node_modules/circomlib/circuits/eddsaposeidon.circom";
 
 // Helper template for revealed fields. out will be set to value or to -1 if
 // not revealed.

--- a/packages/pcd/zk-eddsa-frog-pcd/circuits/index.circom
+++ b/packages/pcd/zk-eddsa-frog-pcd/circuits/index.circom
@@ -1,7 +1,7 @@
 pragma circom 2.1.4;
 
-include "../../../node_modules/circomlib/circuits/poseidon.circom";
-include "../../../node_modules/circomlib/circuits/eddsaposeidon.circom";
+include "../../../../node_modules/circomlib/circuits/poseidon.circom";
+include "../../../../node_modules/circomlib/circuits/eddsaposeidon.circom";
 
 // Claim being proved:
 // 1. The owner owns the frog: the owner's semaphore identity matches the


### PR DESCRIPTION
When re-arranging the directory structure, the include paths in our circom circuits were not updated. As a result, it was not possible to build the artifacts.

This PR updates the paths for the new directory structure.