### PR TITLE
Prevent import of internal files from other `@pcd` packages

### DIFF
--- a/packages/pcd/webauthn-pcd/package.json
+++ b/packages/pcd/webauthn-pcd/package.json
@@ -10,6 +10,11 @@
     "build": "tsc --noEmit",
     "clean": "rm -rf dist node_modules"
   },
+  "files": [
+    "dist",
+    "./README.md",
+    "./LICENSE"
+  ],
   "dependencies": {
     "@pcd/passport-crypto": "0.10.0",
     "@pcd/pcd-types": "0.10.0",

--- a/packages/pcd/webauthn-pcd/test/WebAuthnPCD.spec.ts
+++ b/packages/pcd/webauthn-pcd/test/WebAuthnPCD.spec.ts
@@ -1,4 +1,4 @@
-import { VerifyAuthenticationResponseOpts } from "@simplewebauthn/server/./dist";
+import { VerifyAuthenticationResponseOpts } from "@simplewebauthn/server";
 import assert from "assert";
 import { WebAuthnPCDArgs, WebAuthnPCDPackage } from "../src/WebAuthnPCD";
 

--- a/packages/tools/eslint-config-custom/index.js
+++ b/packages/tools/eslint-config-custom/index.js
@@ -30,7 +30,19 @@ module.exports = {
     "react/no-unescaped-entities": "off",
     "import/no-named-as-default-member": "off",
     "import/no-extraneous-dependencies": "error",
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: ["@pcd/*/**"],
+            message:
+              "Internal files from other packages should not be imported. Within-package imports should use relative file paths."
+          }
+        ]
+      }
+    ]
   },
   settings: {
     "import/resolver": {

--- a/packages/ui/webauthn-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/webauthn-pcd-ui/src/CardBody.tsx
@@ -6,7 +6,7 @@ import {
   styled
 } from "@pcd/passport-ui";
 import { PCDUI } from "@pcd/pcd-types";
-import { WebAuthnPCD } from "@pcd/webauthn-pcd/src/WebAuthnPCD";
+import { WebAuthnPCD } from "@pcd/webauthn-pcd";
 
 export const WebAuthnPCDUI: PCDUI<WebAuthnPCD> = {
   renderCardBody: WebAuthnCardBody


### PR DESCRIPTION
Closes #1401 

This prevents imports of the type `import { foo } from "@pcd/package/sub/file/path"`. If `foo` is meant to be available then it will be exported by the top-level `@pcd/package`, otherwise it is intended only for internal use within that package.

This rule only affects imports from `@pcd/*` packages. Other packages may have different structures that intentionally support importing sub-package files. This is sometimes considered to be a good design pattern as it can allow for more efficient elimination of un-needed code from a package, if only a specific part of the package is required.