### PR TITLE
Fail the build if installation modifies the yarn lockfile

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: dtinth/setup-github-actions-caching-for-turbo@v1
 
       - run: "yarn install"
-      - name: "Check that yarn install did not cause changes to the git workspace"
+      - name: "Check that yarn install did not cause changes to yarn.lock"
         run: "git diff --quiet -- yarn.lock"
       - run: "yarn build"
       - run: "yarn lint"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,9 @@ jobs:
       - name: Configure Turbo cache
         uses: dtinth/setup-github-actions-caching-for-turbo@v1
 
-      - run: "yarn install --frozen-lockfile"
+      - run: "yarn install"
+      - name: "Check that yarn install did not cause changes to the git workspace"
+        run: "git diff --quiet -- yarn.lock"
       - run: "yarn build"
       - run: "yarn lint"
       - run: "yarn test"

--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -101,6 +101,7 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "express": "^4.18.2",
+    "get-random-values": "3.0.0",
     "mocha": "^10.2.0",
     "ts-mocha": "^10.0.0",
     "ts-node": "^10.9.1",

--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -101,7 +101,6 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "express": "^4.18.2",
-    "get-random-values": "3.0.0",
     "mocha": "^10.2.0",
     "ts-mocha": "^10.0.0",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
Closes #1333 

Previously we used `yarn install --frozen-lockfile`, but this does not seem to produce the desired build failure in the case where a workspace's `package.json` is out of sync with the repo's `yarn.lock`.

Now we allow `yarn install` to modify `yarn.lock`, and fail the build if it has been modified (specifically, if `git` detects that any files have changed in the repo).

If you look at the commit history, you can see that the previous commit had a deliberate failure, caused by adding something to `apps/passport-client/package.json` and not committing the updated `yarn.lock`. See the failed Github action here: https://github.com/proofcarryingdata/zupass/actions/runs/7491039865