### PR TITLE
Remove dynamic require

### DIFF
--- a/packages/lib/passport-crypto/src/utils.ts
+++ b/packages/lib/passport-crypto/src/utils.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "buffer";
+import nodeCrypto from "crypto";
 import sodium from "libsodium-wrappers-sumo";
 
 // This is necessary as libsodium-wrappers-sumo is a CommonJS package and
@@ -14,14 +15,16 @@ const {
 } = sodium;
 
 /**
- * Returns built in crypto if available, otherwise polyfill
+ * If in a web environment, return the global crypto object. If not, use the
+ * imported crypto library, which will either be present as a NodeJS built-in,
+ * or polyfilled by the final bundler.
  */
-export function getCrypto(): any {
+export function getCrypto(): Crypto {
   const g = globalThis as any;
   if (g.crypto) {
     return g.crypto;
   } else {
-    return require("crypto");
+    return nodeCrypto.webcrypto as Crypto;
   }
 }
 

--- a/packages/lib/util/src/CryptoHelpers.ts
+++ b/packages/lib/util/src/CryptoHelpers.ts
@@ -1,3 +1,4 @@
+import { webcrypto } from "node:crypto";
 import { isBrowser, isNode } from "./Environment";
 
 // The 'crypto' variable provides access to the functions defined
@@ -17,7 +18,7 @@ function initCryptoAPI(): Crypto {
       crypto = globalThis.crypto;
     } else if (isNode()) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { webcrypto } = require("node:crypto");
+      // const { webcrypto } = require("node:crypto");
 
       crypto = webcrypto as Crypto;
     } else {

--- a/packages/lib/util/src/CryptoHelpers.ts
+++ b/packages/lib/util/src/CryptoHelpers.ts
@@ -1,4 +1,4 @@
-import { webcrypto } from "node:crypto";
+import nodeCrypto from "crypto";
 import { isBrowser, isNode } from "./Environment";
 
 // The 'crypto' variable provides access to the functions defined
@@ -17,10 +17,7 @@ function initCryptoAPI(): Crypto {
     if (isBrowser()) {
       crypto = globalThis.crypto;
     } else if (isNode()) {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      // const { webcrypto } = require("node:crypto");
-
-      crypto = webcrypto as Crypto;
+      crypto = nodeCrypto.webcrypto as Crypto;
     } else {
       throw new Error("Crypto API is not defined");
     }

--- a/packages/tools/eslint-config-custom/index.js
+++ b/packages/tools/eslint-config-custom/index.js
@@ -42,7 +42,8 @@ module.exports = {
           }
         ]
       }
-    ]
+    ],
+    "@typescript-eslint/no-require-imports": "error"
   },
   settings: {
     "import/resolver": {


### PR DESCRIPTION
Closes #1383.

As per #1383, using `@pcd/util/getRandomValues()` from a NextJS project was causing the following error to appear in the terminal:
```
[ERROR] Error: Dynamic require of "crypto" is not supported
```

This was traced back to a dynamic require in `packages/lib/util/src/CryptoHelpers.ts`:
```typescript
      // eslint-disable-next-line @typescript-eslint/no-var-requires
      const { webcrypto } = require("node:crypto");
```

Replacing the `require` with an `import` solves the problem. This was tested by repackaging `@pcd/util` locally and testing it with the NextJS project in which the error was occurring. The version with `import` works.

I also tested this in our repo by testing some code that uses this code path - in `passport-client` the `getRandomValues()` function is called as part of encrypting the e2ee sync blob, which continues to work as expected.

A similar use of `require()` in `passport-crypto` was also changed to `import`.

## Why was this happening?

It would be nice to understand the principle behind this error. Chains of transpilation, TS -> JS and (in some cases) ESM -> CJS can be tricky to understand. A general observation I've made is that mixing ESM-style `import`s and CJS-style `require`s is a bad idea, and since TypeScript uses `import` by default, it's best to stick to using `import` exclusively. There may be some configuration of transpiler and bundler in which it's safe to mix them, but relying on this seems unwise.

I've enabled an eslint rule to prevent future use of `require()`.