### PR TITLE
Make eslint and tsconfig packages global dependencies for turborepo actions

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -34,6 +34,10 @@
       "cache": false
     }
   },
+  "globalDependencies": [
+    "packages/tools/eslint-config-custom/**",
+    "packages/tools/tsconfig/**"
+  ],
   "globalEnv": [
     "DATABASE_USERNAME",
     "DATABASE_PASSWORD",


### PR DESCRIPTION
We cache the `lint` job using Turborepo, which speeds up CI (a full lint takes 2 minutes). However, Turborepo can't tell that a change to the ESLint config ought to invalidate the cache, and so might fail to apply lint rules for packages that haven't changed.

This PR adds the `eslint-config-custom` package as a "[global dependency](https://turbo.build/repo/docs/reference/configuration#globaldependencies)" for Turborepo, meaning that any change to the contents of this package will invalidate the cache. I've also added the `tsconfig` package, since a similar principle seems to apply there.

Annoyingly this invalidates _all_ caches, not just specifically the lint one, but a) safety/speed trade-off seems right here, and b) we don't change either of those packages very often, so a slow CI run after changing them seems OK.