### PR TITLE
Fix docs site

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "tsx scripts/watch.ts",
     "dev:apps": "turbo run dev --parallel --filter=./apps/*",
     "telegram:dev": "IS_LOCAL_HTTPS=true PASSPORT_SERVER_URL=https://dev.local:3002 PASSPORT_CLIENT_URL=https://dev.local:3000 yarn dev",
-    "docs": "typedoc",
+    "docs": "yarn build && typedoc",
     "lint": "turbo run lint --concurrency=1",
     "test": "turbo run test --concurrency=1",
     "prepublishOnly": "turbo run prepublishOnly --parallel",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "entryPoints": ["packages/*"],
+  "entryPoints": ["packages/*/*"],
   "name": "PCD SDK",
   "entryPointStrategy": "packages",
   "exclude": [


### PR DESCRIPTION
Closes #1409 

Fixes the configuration for the new package paths, and runs `yarn build` before `typedoc` to ensure that type declarations have been generated.