### PR TITLE
 Zuzalu 2023 POAP minting

### DIFF
--- a/apps/passport-server/src/database/models.ts
+++ b/apps/passport-server/src/database/models.ts
@@ -338,4 +338,4 @@ export interface AnonMessageWithDetails extends AnonMessage {
   reactions: string[];
 }
 
-export type PoapEvent = "devconnect";
+export type PoapEvent = "devconnect" | "zuzalu23";

--- a/apps/passport-server/src/routing/routes/poapRoutes.ts
+++ b/apps/passport-server/src/routing/routes/poapRoutes.ts
@@ -22,4 +22,16 @@ export function initPoapRoutes(
 
     res.redirect(await poapService.getDevconnectPoapRedirectUrl(proof));
   });
+
+  app.get("/poap/zuzalu23/callback", async (req: Request, res: Response) => {
+    const proof = checkQueryParam(req, "proof");
+    if (!proof || typeof proof !== "string") {
+      throw new PCDHTTPError(
+        400,
+        "proof field needs to be a string and be non-empty"
+      );
+    }
+
+    res.redirect(await poapService.getZuzalu23PoapRedirectUrl(proof));
+  });
 }

--- a/apps/passport-server/src/services/poapService.ts
+++ b/apps/passport-server/src/services/poapService.ts
@@ -322,8 +322,14 @@ export class PoapService {
 
   /**
    * Helper function to handle the logic of retrieving the correct POAP mint link
-   * given the ticket ID. Returns NULL if the ticket is not associated with a link
-   * and no more unclaimed links exist.
+   * given the ticket ID.
+   *  1. If this ticket ID is already associated with a POAP mint link,
+   *     return that link.
+   *  2. If this ticket ID is not yet associated with a POAP mint link,
+   *     a new POAP mint link with the given poapEvent is associated with
+   *     the ticket ID, and that link is returned.
+   *  3. If this ticket ID is not associated with a POAP mint link and
+   *     no more unclaimed POAP mint links exist, return NULL.
    */
   public async getPoapClaimUrlByTicketId(
     ticketId: string,

--- a/apps/passport-server/src/services/poapService.ts
+++ b/apps/passport-server/src/services/poapService.ts
@@ -30,6 +30,7 @@ const DEVCONNECT_COWORK_SPACE_EVENT_ID = "a1c822c4-60bd-11ee-8732-763dbf30819c";
 // All valid Cowork products that can claim a POAP. This excludes add-on products, like the Turkish Towel.
 const DEVCONNECT_COWORK_SPACE_VALID_PRODUCT_IDS = [
   "67687bda-986f-11ee-abf3-126a2f5f3c5c",
+  "67689552-986f-11ee-abf3-126a2f5f3c5c",
   "6768a2e0-986f-11ee-abf3-126a2f5f3c5c",
   "6768af1a-986f-11ee-abf3-126a2f5f3c5c",
   "6768c81a-986f-11ee-abf3-126a2f5f3c5c",

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -2912,9 +2912,9 @@ describe("devconnect functionality", function () {
 
   step("get poap claim urls from devconnect ticket ids", async () => {
     // No POAP mint links in DB yet - all links return NULL
-    expect(await poapService.getDevconnectPoapClaimUrlByTicketId("1")).to.be
+    expect(await poapService.getPoapClaimUrlByTicketId("1", "devconnect")).to.be
       .null;
-    expect(await poapService.getDevconnectPoapClaimUrlByTicketId("2")).to.be
+    expect(await poapService.getPoapClaimUrlByTicketId("2", "devconnect")).to.be
       .null;
 
     const TEST_POAP_LINK_1 = "https://poap.xyz/mint/qwerty";
@@ -2922,22 +2922,22 @@ describe("devconnect functionality", function () {
 
     await insertNewPoapUrl(db, TEST_POAP_LINK_1, "devconnect");
 
-    expect(await poapService.getDevconnectPoapClaimUrlByTicketId("1")).to.eq(
-      TEST_POAP_LINK_1
-    );
+    expect(
+      await poapService.getPoapClaimUrlByTicketId("1", "devconnect")
+    ).to.eq(TEST_POAP_LINK_1);
     // Ran out of mint links
-    expect(await poapService.getDevconnectPoapClaimUrlByTicketId("2")).to.be
+    expect(await poapService.getPoapClaimUrlByTicketId("2", "devconnect")).to.be
       .null;
 
     await insertNewPoapUrl(db, TEST_POAP_LINK_2, "devconnect");
 
     // Still maps to existing link
-    expect(await poapService.getDevconnectPoapClaimUrlByTicketId("1")).to.eq(
-      TEST_POAP_LINK_1
-    );
-    expect(await poapService.getDevconnectPoapClaimUrlByTicketId("2")).to.eq(
-      TEST_POAP_LINK_2
-    );
+    expect(
+      await poapService.getPoapClaimUrlByTicketId("1", "devconnect")
+    ).to.eq(TEST_POAP_LINK_1);
+    expect(
+      await poapService.getPoapClaimUrlByTicketId("2", "devconnect")
+    ).to.eq(TEST_POAP_LINK_2);
   });
 
   // TODO: More tests

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -2916,11 +2916,18 @@ describe("devconnect functionality", function () {
       .null;
     expect(await poapService.getPoapClaimUrlByTicketId("2", "devconnect")).to.be
       .null;
+    expect(await poapService.getPoapClaimUrlByTicketId("3", "devconnect")).to.be
+      .null;
 
     const TEST_POAP_LINK_1 = "https://poap.xyz/mint/qwerty";
     const TEST_POAP_LINK_2 = "https://poap.xyz/mint/zxcvbn";
+    const TEST_POAP_LINK_3 = "https://poap.xyz/mint/asdfgh";
 
     await insertNewPoapUrl(db, TEST_POAP_LINK_1, "devconnect");
+    // Insert a Zuzalu 2023 POAP URL, which should never be returned
+    // by poapService.getPoapClaimUrlByTicketId() when "devconnect"
+    // is the POAP event.
+    await insertNewPoapUrl(db, TEST_POAP_LINK_2, "zuzalu23");
 
     expect(
       await poapService.getPoapClaimUrlByTicketId("1", "devconnect")
@@ -2929,7 +2936,7 @@ describe("devconnect functionality", function () {
     expect(await poapService.getPoapClaimUrlByTicketId("2", "devconnect")).to.be
       .null;
 
-    await insertNewPoapUrl(db, TEST_POAP_LINK_2, "devconnect");
+    await insertNewPoapUrl(db, TEST_POAP_LINK_3, "devconnect");
 
     // Still maps to existing link
     expect(
@@ -2937,7 +2944,10 @@ describe("devconnect functionality", function () {
     ).to.eq(TEST_POAP_LINK_1);
     expect(
       await poapService.getPoapClaimUrlByTicketId("2", "devconnect")
-    ).to.eq(TEST_POAP_LINK_2);
+    ).to.eq(TEST_POAP_LINK_3);
+    // Ran out of mint links
+    expect(await poapService.getPoapClaimUrlByTicketId("3", "devconnect")).to.be
+      .null;
   });
 
   // TODO: More tests

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -2944,7 +2944,10 @@ describe("devconnect functionality", function () {
 
       await insertNewPoapUrl(db, TEST_POAP_LINK_3, "devconnect");
 
-      // Still maps to existing link, regardless of what the poapEvent parameter is
+      // Still maps to existing link, regardless of what the poapEvent parameter is.
+      // The intended behavior is that the poapEvent parameter is only relevant when
+      // a new POAP mint link is being associated with a ticket ID. If an ticket ID
+      // is already associated with a POAP mint link, poapEvent should be irrelevant.
       expect(
         await poapService.getPoapClaimUrlByTicketId("1", "devconnect")
       ).to.eq(TEST_POAP_LINK_1);

--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -2910,45 +2910,71 @@ describe("devconnect functionality", function () {
     expect(unredactedTickets.length).to.eq(3);
   });
 
-  step("get poap claim urls from devconnect ticket ids", async () => {
-    // No POAP mint links in DB yet - all links return NULL
-    expect(await poapService.getPoapClaimUrlByTicketId("1", "devconnect")).to.be
-      .null;
-    expect(await poapService.getPoapClaimUrlByTicketId("2", "devconnect")).to.be
-      .null;
-    expect(await poapService.getPoapClaimUrlByTicketId("3", "devconnect")).to.be
-      .null;
+  step(
+    "get poap claim urls from devconnect and zuzalu ticket ids",
+    async () => {
+      // No POAP mint links in DB yet - all links return NULL
+      expect(await poapService.getPoapClaimUrlByTicketId("1", "devconnect")).to
+        .be.null;
+      expect(await poapService.getPoapClaimUrlByTicketId("2", "devconnect")).to
+        .be.null;
+      expect(await poapService.getPoapClaimUrlByTicketId("3", "devconnect")).to
+        .be.null;
+      expect(await poapService.getPoapClaimUrlByTicketId("1", "zuzalu23")).to.be
+        .null;
+      expect(await poapService.getPoapClaimUrlByTicketId("2", "zuzalu23")).to.be
+        .null;
+      expect(await poapService.getPoapClaimUrlByTicketId("3", "zuzalu23")).to.be
+        .null;
 
-    const TEST_POAP_LINK_1 = "https://poap.xyz/mint/qwerty";
-    const TEST_POAP_LINK_2 = "https://poap.xyz/mint/zxcvbn";
-    const TEST_POAP_LINK_3 = "https://poap.xyz/mint/asdfgh";
+      const TEST_POAP_LINK_1 = "https://poap.xyz/mint/qwerty";
+      const TEST_POAP_LINK_2 = "https://poap.xyz/mint/zxcvbn";
+      const TEST_POAP_LINK_3 = "https://poap.xyz/mint/asdfgh";
 
-    await insertNewPoapUrl(db, TEST_POAP_LINK_1, "devconnect");
-    // Insert a Zuzalu 2023 POAP URL, which should never be returned
-    // by poapService.getPoapClaimUrlByTicketId() when "devconnect"
-    // is the POAP event.
-    await insertNewPoapUrl(db, TEST_POAP_LINK_2, "zuzalu23");
+      await insertNewPoapUrl(db, TEST_POAP_LINK_1, "devconnect");
+      await insertNewPoapUrl(db, TEST_POAP_LINK_2, "zuzalu23");
 
-    expect(
-      await poapService.getPoapClaimUrlByTicketId("1", "devconnect")
-    ).to.eq(TEST_POAP_LINK_1);
-    // Ran out of mint links
-    expect(await poapService.getPoapClaimUrlByTicketId("2", "devconnect")).to.be
-      .null;
+      // Map ticket ID "1" to a devconnect ticket
+      expect(
+        await poapService.getPoapClaimUrlByTicketId("1", "devconnect")
+      ).to.eq(TEST_POAP_LINK_1);
+      // Ran out of mint links for Devconnect
+      expect(await poapService.getPoapClaimUrlByTicketId("2", "devconnect")).to
+        .be.null;
 
-    await insertNewPoapUrl(db, TEST_POAP_LINK_3, "devconnect");
+      await insertNewPoapUrl(db, TEST_POAP_LINK_3, "devconnect");
 
-    // Still maps to existing link
-    expect(
-      await poapService.getPoapClaimUrlByTicketId("1", "devconnect")
-    ).to.eq(TEST_POAP_LINK_1);
-    expect(
-      await poapService.getPoapClaimUrlByTicketId("2", "devconnect")
-    ).to.eq(TEST_POAP_LINK_3);
-    // Ran out of mint links
-    expect(await poapService.getPoapClaimUrlByTicketId("3", "devconnect")).to.be
-      .null;
-  });
+      // Still maps to existing link, regardless of what the poapEvent parameter is
+      expect(
+        await poapService.getPoapClaimUrlByTicketId("1", "devconnect")
+      ).to.eq(TEST_POAP_LINK_1);
+      expect(
+        await poapService.getPoapClaimUrlByTicketId("1", "zuzalu23")
+      ).to.eq(TEST_POAP_LINK_1);
+      // Map ticket ID "2" to a devconnect ticket
+      expect(
+        await poapService.getPoapClaimUrlByTicketId("2", "devconnect")
+      ).to.eq(TEST_POAP_LINK_3);
+      expect(
+        await poapService.getPoapClaimUrlByTicketId("2", "zuzalu23")
+      ).to.eq(TEST_POAP_LINK_3);
+      // Ran out of mint links for Devconnect
+      expect(await poapService.getPoapClaimUrlByTicketId("3", "devconnect")).to
+        .be.null;
+
+      // Map ticket ID "3" to a zuzalu 2023 ticket
+      expect(
+        await poapService.getPoapClaimUrlByTicketId("3", "zuzalu23")
+      ).to.be.eq(TEST_POAP_LINK_2);
+      // Still maps to existing link, regardless of what the poapEvent parameter is
+      expect(
+        await poapService.getPoapClaimUrlByTicketId("3", "zuzalu23")
+      ).to.be.eq(TEST_POAP_LINK_2);
+      expect(
+        await poapService.getPoapClaimUrlByTicketId("3", "devconnect")
+      ).to.be.eq(TEST_POAP_LINK_2);
+    }
+  );
 
   // TODO: More tests
   // 1. Test that item_name in ItemInfo and event_name EventInfo always syncs with Pretix.


### PR DESCRIPTION
Steps to test this locally:
1. Ensure that your local db table `zuzalu_pretix_tickets` matches that of prod (I just manually copy-pasted from prod db to local).
2. If you have an email associated with a Zuzalu 2023, sign into Zupass (http://localhost:3000) locally with that email. If you do not, you may log in with a known Zuzalu email like `richard@pcd.team`. Once logged in, check that you have a Zuzalu '23 ticket.
3. Add a row to the table `poap_claim_links`, making sure to put down the test POAP link (message me if you need one) as the `claim_url`, "zuzalu23" as the `poap_event`, and NULL as the `hashed_ticket_id`.
4. Navigate to the [Zupass POAP link](http://localhost:3000/#/prove?request=%7B%22type%22%3A%22Get%22%2C%22returnUrl%22%3A%22http%3A%2F%2Flocalhost%3A3002%2Fpoap%2Fzuzalu23%2Fcallback%22%2C%22args%22%3A%7B%22ticket%22%3A%7B%22argumentType%22%3A%22PCD%22%2C%22pcdType%22%3A%22eddsa-ticket-pcd%22%2C%22userProvided%22%3Atrue%2C%22displayName%22%3A%22Your%20Ticket%22%2C%22description%22%3A%22%22%2C%22validatorParams%22%3A%7B%22eventIds%22%3A%5B%225de90d09-22db-40ca-b3ae-d934573def8b%22%5D%2C%22productIds%22%3A%5B%5D%2C%22notFoundMessage%22%3A%22You%20do%20not%20have%20a%20valid%20Zuzalu%202023%20ticket%20on%20this%20account.%20Please%20ensure%20that%20you%20are%20logged%20into%20the%20correct%20Zupass%20account%20that%20corresponds%20to%20the%20email%20on%20your%20Zuzalu%20ticket.%20You%20may%20email%20support%40zupass.org%20if%20you%20continue%20having%20issues.%22%7D%2C%22hideIcon%22%3Atrue%7D%2C%22identity%22%3A%7B%22argumentType%22%3A%22PCD%22%2C%22pcdType%22%3A%22semaphore-identity-pcd%22%2C%22userProvided%22%3Atrue%7D%2C%22fieldsToReveal%22%3A%7B%22argumentType%22%3A%22ToggleList%22%2C%22value%22%3A%7B%22revealTicketId%22%3Atrue%7D%2C%22userProvided%22%3Afalse%2C%22hideIcon%22%3Atrue%7D%2C%22externalNullifier%22%3A%7B%22argumentType%22%3A%22BigInt%22%2C%22userProvided%22%3Afalse%7D%2C%22validEventIds%22%3A%7B%22argumentType%22%3A%22StringArray%22%2C%22value%22%3A%5B%225de90d09-22db-40ca-b3ae-d934573def8b%22%5D%2C%22userProvided%22%3Afalse%7D%2C%22watermark%22%3A%7B%22argumentType%22%3A%22BigInt%22%2C%22value%22%3A%220%22%2C%22userProvided%22%3Afalse%7D%7D%2C%22pcdType%22%3A%22zk-eddsa-event-ticket-pcd%22%2C%22options%22%3A%7B%22genericProveScreen%22%3Atrue%2C%22title%22%3A%22%22%2C%22description%22%3A%22Zuzalu%20requests%20a%20zero-knowledge%20proof%20of%20your%20ticket%20to%20access%20your%20unique%20POAP%20mint%20link.%22%7D%7D) and follow the steps to claim the test POAP link.

If all goes well, it should look something like this:

https://github.com/proofcarryingdata/zupass/assets/36896271/af5d6cb1-ccc4-4cc6-abf2-e88454c52ac6
