### PR TITLE
Flag feeds which return a `410` error as 'ended'

### DIFF
--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -358,8 +358,19 @@ function AlreadySubscribed({
 
   return (
     <div>
-      <div>This feed has the following permissions:</div>
-      <PermissionsView permissions={existingSubscription.feed.permissions} />
+      {existingSubscription.ended && (
+        <div>
+          <strong>This feed is no longer active.</strong>
+        </div>
+      )}
+      {!existingSubscription.ended && (
+        <>
+          <div>This feed has the following permissions:</div>
+          <PermissionsView
+            permissions={existingSubscription.feed.permissions}
+          />
+        </>
+      )}
       <Spacer h={16} />
       You subscribed to this feed on{" "}
       {new Date(existingSubscription.subscribedTimestamp).toLocaleDateString(

--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -361,6 +361,12 @@ function AlreadySubscribed({
       {existingSubscription.ended && (
         <div>
           <strong>This feed is no longer active.</strong>
+          {existingSubscription.ended_message && (
+            <>
+              <Spacer h={8} />
+              <p>{existingSubscription.ended_message}</p>
+            </>
+          )}
         </div>
       )}
       {!existingSubscription.ended && (

--- a/apps/passport-client/components/screens/SubscriptionsScreen.tsx
+++ b/apps/passport-client/components/screens/SubscriptionsScreen.tsx
@@ -108,7 +108,7 @@ function SingleProvider({
             providerName={providerName}
             info={s.feed}
             subscriptions={subscriptions}
-            showErrors={true}
+            showErrors={!s.ended}
           />
         </React.Fragment>
       ))}

--- a/apps/passport-client/src/defaultSubscriptions.ts
+++ b/apps/passport-client/src/defaultSubscriptions.ts
@@ -1,7 +1,6 @@
 import {
   FeedSubscriptionManager,
   Subscription,
-  ZupassFeedIds,
   zupassDefaultSubscriptions
 } from "@pcd/passport-interface";
 import { appConfig } from "../src/appConfig";
@@ -9,14 +8,7 @@ import { appConfig } from "../src/appConfig";
 const DEFAULT_FEED_URL = `${appConfig.zupassServer}/feeds`;
 const DEFAULT_FEED_PROVIDER_NAME = "Zupass";
 
-const DEFAULT_FEEDS = new Set(
-  [
-    ZupassFeedIds.Devconnect,
-    ZupassFeedIds.Email,
-    ZupassFeedIds.Zuzalu_23,
-    ZupassFeedIds.Zuconnect_23
-  ].map((s) => s.toString())
-);
+const DEFAULT_FEEDS = new Set(Object.keys(zupassDefaultSubscriptions));
 
 export function isDefaultSubscription(sub: Subscription): boolean {
   return sub.providerUrl === DEFAULT_FEED_URL && DEFAULT_FEEDS.has(sub.feed.id);

--- a/apps/passport-client/src/defaultSubscriptions.ts
+++ b/apps/passport-client/src/defaultSubscriptions.ts
@@ -2,7 +2,6 @@ import {
   FeedSubscriptionManager,
   Subscription,
   ZupassFeedIds,
-  zupassAutoUnsubscribeFeedIds,
   zupassDefaultSubscriptions
 } from "@pcd/passport-interface";
 import { appConfig } from "../src/appConfig";
@@ -37,27 +36,5 @@ export async function addDefaultSubscriptions(
       // Replace the existing subscription if it already exists
       true
     );
-  }
-}
-
-/**
- * Unsubscribes from any feeds in `zupassAutoUnsubscribeFeedIds`.
- * For the sake of simpler user experience, we opted users in to subscribing
- * to feeds like Devconnect tickets. Now that these feeds are being deprecated,
- * we should automatically unsubscribe users from them.
- */
-export function removeAutoUnsubscribedSubscriptions(
-  subscriptions: FeedSubscriptionManager
-) {
-  for (const id of zupassAutoUnsubscribeFeedIds) {
-    // In practice this returns an array of length 0 or length 1
-    const matchingSubs = subscriptions.getSubscriptionsByProviderAndFeedId(
-      DEFAULT_FEED_URL,
-      id
-    );
-    // If the array had a subscription, unsubscribe
-    for (const sub of matchingSubs) {
-      subscriptions.unsubscribe(sub.id);
-    }
   }
 }

--- a/apps/passport-client/src/defaultSubscriptions.ts
+++ b/apps/passport-client/src/defaultSubscriptions.ts
@@ -2,6 +2,7 @@ import {
   FeedSubscriptionManager,
   Subscription,
   ZupassFeedIds,
+  zupassAutoUnsubscribeFeedIds,
   zupassDefaultSubscriptions
 } from "@pcd/passport-interface";
 import { appConfig } from "../src/appConfig";
@@ -36,5 +37,27 @@ export async function addDefaultSubscriptions(
       // Replace the existing subscription if it already exists
       true
     );
+  }
+}
+
+/**
+ * Unsubscribes from any feeds in `zupassAutoUnsubscribeFeedIds`.
+ * For the sake of simpler user experience, we opted users in to subscribing
+ * to feeds like Devconnect tickets. Now that these feeds are being deprecated,
+ * we should automatically unsubscribe users from them.
+ */
+export function removeAutoUnsubscribedSubscriptions(
+  subscriptions: FeedSubscriptionManager
+) {
+  for (const id of zupassAutoUnsubscribeFeedIds) {
+    // In practice this returns an array of length 0 or length 1
+    const matchingSubs = subscriptions.getSubscriptionsByProviderAndFeedId(
+      DEFAULT_FEED_URL,
+      id
+    );
+    // If the array had a subscription, unsubscribe
+    for (const sub of matchingSubs) {
+      subscriptions.unsubscribe(sub.id);
+    }
   }
 }

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -31,10 +31,7 @@ import {
   notifyLogoutToOtherTabs,
   notifyPasswordChangeToOtherTabs
 } from "./broadcastChannel";
-import {
-  addDefaultSubscriptions,
-  removeAutoUnsubscribedSubscriptions
-} from "./defaultSubscriptions";
+import { addDefaultSubscriptions } from "./defaultSubscriptions";
 import {
   loadEncryptionKey,
   loadPrivacyNoticeAgreed,
@@ -786,7 +783,6 @@ async function doSync(
     try {
       console.log("[SYNC] loading issued pcds");
       addDefaultSubscriptions(state.subscriptions);
-      removeAutoUnsubscribedSubscriptions(state.subscriptions);
       console.log(
         "[SYNC] active subscriptions",
         state.subscriptions.getActiveSubscriptions()

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -31,7 +31,10 @@ import {
   notifyLogoutToOtherTabs,
   notifyPasswordChangeToOtherTabs
 } from "./broadcastChannel";
-import { addDefaultSubscriptions } from "./defaultSubscriptions";
+import {
+  addDefaultSubscriptions,
+  removeAutoUnsubscribedSubscriptions
+} from "./defaultSubscriptions";
 import {
   loadEncryptionKey,
   loadPrivacyNoticeAgreed,
@@ -783,6 +786,7 @@ async function doSync(
     try {
       console.log("[SYNC] loading issued pcds");
       addDefaultSubscriptions(state.subscriptions);
+      removeAutoUnsubscribedSubscriptions(state.subscriptions);
       console.log(
         "[SYNC] active subscriptions",
         state.subscriptions.getActiveSubscriptions()

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -219,41 +219,7 @@ export class IssuanceService {
 
             return { actions };
           },
-          feed: {
-            id: ZupassFeedIds.Devconnect,
-            name: "Devconnect Tickets",
-            description: "Get your Devconnect tickets here!",
-            partialArgs: undefined,
-            credentialRequest: {
-              signatureType: "sempahore-signature-pcd"
-            },
-            permissions: [
-              {
-                folder: "Devconnect",
-                type: PCDPermissionType.AppendToFolder
-              },
-              {
-                folder: "Devconnect",
-                type: PCDPermissionType.ReplaceInFolder
-              },
-              {
-                folder: "Devconnect",
-                type: PCDPermissionType.DeleteFolder
-              },
-              {
-                folder: "SBC SRW",
-                type: PCDPermissionType.AppendToFolder
-              },
-              {
-                folder: "SBC SRW",
-                type: PCDPermissionType.ReplaceInFolder
-              },
-              {
-                folder: "SBC SRW",
-                type: PCDPermissionType.DeleteFolder
-              }
-            ]
-          }
+          feed: zupassDefaultSubscriptions[ZupassFeedIds.Devconnect]
         },
         {
           handleRequest: async (

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -694,7 +694,7 @@ export class IssuanceService {
             await upsertUser(this.context.dbPool, commitmentRow);
           } else {
             throw new PCDHTTPError(
-              401,
+              410,
               `Issuance of Devconnect tickets was turned off on ${this.getTicketIssuanceCutoffDate()?.toDateString()}.` +
                 ` Contact support@0xparc.org if you've lost access to your tickets.`
             );

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -219,7 +219,41 @@ export class IssuanceService {
 
             return { actions };
           },
-          feed: zupassDefaultSubscriptions[ZupassFeedIds.Devconnect]
+          feed: {
+            id: ZupassFeedIds.Devconnect,
+            name: "Devconnect Tickets",
+            description: "Get your Devconnect tickets here!",
+            partialArgs: undefined,
+            credentialRequest: {
+              signatureType: "sempahore-signature-pcd"
+            },
+            permissions: [
+              {
+                folder: "Devconnect",
+                type: PCDPermissionType.AppendToFolder
+              },
+              {
+                folder: "Devconnect",
+                type: PCDPermissionType.ReplaceInFolder
+              },
+              {
+                folder: "Devconnect",
+                type: PCDPermissionType.DeleteFolder
+              },
+              {
+                folder: "SBC SRW",
+                type: PCDPermissionType.AppendToFolder
+              },
+              {
+                folder: "SBC SRW",
+                type: PCDPermissionType.ReplaceInFolder
+              },
+              {
+                folder: "SBC SRW",
+                type: PCDPermissionType.DeleteFolder
+              }
+            ]
+          }
         },
         {
           handleRequest: async (

--- a/packages/lib/passport-interface/src/SubscriptionManager.ts
+++ b/packages/lib/passport-interface/src/SubscriptionManager.ts
@@ -239,6 +239,11 @@ export class FeedSubscriptionManager {
       });
 
       if (!result.success) {
+        if (result.code === 410) {
+          this.unsubscribe(subscription.id);
+          return responses;
+        }
+
         throw new Error(result.error);
       }
 
@@ -251,6 +256,7 @@ export class FeedSubscriptionManager {
         subscription
       });
     } catch (e) {
+      console.log(e);
       this.setError(subscription.id, {
         type: SubscriptionErrorType.FetchError,
         e: e instanceof Error ? e : undefined

--- a/packages/lib/passport-interface/src/SubscriptionManager.ts
+++ b/packages/lib/passport-interface/src/SubscriptionManager.ts
@@ -244,7 +244,7 @@ export class FeedSubscriptionManager {
 
       if (!result.success) {
         if (result.code === 410) {
-          this.flagSubscriptionAsEnded(subscription.id);
+          this.flagSubscriptionAsEnded(subscription.id, result.error);
           return responses;
         }
 
@@ -428,12 +428,16 @@ export class FeedSubscriptionManager {
     this.updatedEmitter.emit();
   }
 
-  public flagSubscriptionAsEnded(subscriptionId: string): void {
+  public flagSubscriptionAsEnded(
+    subscriptionId: string,
+    message: string
+  ): void {
     const sub = this.getSubscription(subscriptionId);
     if (!sub) {
       throw new Error(`no subscription found matching ${subscriptionId}`);
     }
     sub.ended = true;
+    sub.ended_message = message;
     this.updatedEmitter.emit();
   }
 
@@ -652,4 +656,6 @@ export interface Subscription {
   subscribedTimestamp: number;
   // Whether the subscription is to a feed which has ceased issuance
   ended: boolean;
+  // Final message indicating what to do if the feed has ended
+  ended_message?: string;
 }

--- a/packages/lib/passport-interface/src/ZupassDefaultSubscriptions.ts
+++ b/packages/lib/passport-interface/src/ZupassDefaultSubscriptions.ts
@@ -1,10 +1,11 @@
 import { PCDPermissionType } from "@pcd/pcd-collection";
 import { Feed, ZupassFeedIds } from "./SubscriptionManager";
 
-export const zupassAutoUnsubscribeFeedIds = [ZupassFeedIds.Devconnect];
-
 export const zupassDefaultSubscriptions: Record<
-  ZupassFeedIds.Email | ZupassFeedIds.Zuzalu_23 | ZupassFeedIds.Zuconnect_23,
+  | ZupassFeedIds.Devconnect
+  | ZupassFeedIds.Email
+  | ZupassFeedIds.Zuzalu_23
+  | ZupassFeedIds.Zuconnect_23,
   Feed
 > = {
   [ZupassFeedIds.Zuzalu_23]: {
@@ -23,6 +24,41 @@ export const zupassDefaultSubscriptions: Record<
       {
         folder: "Zuzalu '23",
         type: PCDPermissionType.ReplaceInFolder
+      }
+    ]
+  },
+  [ZupassFeedIds.Devconnect]: {
+    id: ZupassFeedIds.Devconnect,
+    name: "Devconnect Tickets",
+    description: "Get your Devconnect tickets here!",
+    partialArgs: undefined,
+    credentialRequest: {
+      signatureType: "sempahore-signature-pcd"
+    },
+    permissions: [
+      {
+        folder: "Devconnect",
+        type: PCDPermissionType.AppendToFolder
+      },
+      {
+        folder: "Devconnect",
+        type: PCDPermissionType.ReplaceInFolder
+      },
+      {
+        folder: "Devconnect",
+        type: PCDPermissionType.DeleteFolder
+      },
+      {
+        folder: "SBC SRW",
+        type: PCDPermissionType.AppendToFolder
+      },
+      {
+        folder: "SBC SRW",
+        type: PCDPermissionType.ReplaceInFolder
+      },
+      {
+        folder: "SBC SRW",
+        type: PCDPermissionType.DeleteFolder
       }
     ]
   },

--- a/packages/lib/passport-interface/src/ZupassDefaultSubscriptions.ts
+++ b/packages/lib/passport-interface/src/ZupassDefaultSubscriptions.ts
@@ -1,11 +1,10 @@
 import { PCDPermissionType } from "@pcd/pcd-collection";
 import { Feed, ZupassFeedIds } from "./SubscriptionManager";
 
+export const zupassAutoUnsubscribeFeedIds = [ZupassFeedIds.Devconnect];
+
 export const zupassDefaultSubscriptions: Record<
-  | ZupassFeedIds.Devconnect
-  | ZupassFeedIds.Email
-  | ZupassFeedIds.Zuzalu_23
-  | ZupassFeedIds.Zuconnect_23,
+  ZupassFeedIds.Email | ZupassFeedIds.Zuzalu_23 | ZupassFeedIds.Zuconnect_23,
   Feed
 > = {
   [ZupassFeedIds.Zuzalu_23]: {
@@ -24,41 +23,6 @@ export const zupassDefaultSubscriptions: Record<
       {
         folder: "Zuzalu '23",
         type: PCDPermissionType.ReplaceInFolder
-      }
-    ]
-  },
-  [ZupassFeedIds.Devconnect]: {
-    id: ZupassFeedIds.Devconnect,
-    name: "Devconnect Tickets",
-    description: "Get your Devconnect tickets here!",
-    partialArgs: undefined,
-    credentialRequest: {
-      signatureType: "sempahore-signature-pcd"
-    },
-    permissions: [
-      {
-        folder: "Devconnect",
-        type: PCDPermissionType.AppendToFolder
-      },
-      {
-        folder: "Devconnect",
-        type: PCDPermissionType.ReplaceInFolder
-      },
-      {
-        folder: "Devconnect",
-        type: PCDPermissionType.DeleteFolder
-      },
-      {
-        folder: "SBC SRW",
-        type: PCDPermissionType.AppendToFolder
-      },
-      {
-        folder: "SBC SRW",
-        type: PCDPermissionType.ReplaceInFolder
-      },
-      {
-        folder: "SBC SRW",
-        type: PCDPermissionType.DeleteFolder
       }
     ]
   },

--- a/packages/lib/passport-interface/src/ZupassDefaultSubscriptions.ts
+++ b/packages/lib/passport-interface/src/ZupassDefaultSubscriptions.ts
@@ -2,10 +2,7 @@ import { PCDPermissionType } from "@pcd/pcd-collection";
 import { Feed, ZupassFeedIds } from "./SubscriptionManager";
 
 export const zupassDefaultSubscriptions: Record<
-  | ZupassFeedIds.Devconnect
-  | ZupassFeedIds.Email
-  | ZupassFeedIds.Zuzalu_23
-  | ZupassFeedIds.Zuconnect_23,
+  ZupassFeedIds.Email | ZupassFeedIds.Zuzalu_23 | ZupassFeedIds.Zuconnect_23,
   Feed
 > = {
   [ZupassFeedIds.Zuzalu_23]: {
@@ -24,41 +21,6 @@ export const zupassDefaultSubscriptions: Record<
       {
         folder: "Zuzalu '23",
         type: PCDPermissionType.ReplaceInFolder
-      }
-    ]
-  },
-  [ZupassFeedIds.Devconnect]: {
-    id: ZupassFeedIds.Devconnect,
-    name: "Devconnect Tickets",
-    description: "Get your Devconnect tickets here!",
-    partialArgs: undefined,
-    credentialRequest: {
-      signatureType: "sempahore-signature-pcd"
-    },
-    permissions: [
-      {
-        folder: "Devconnect",
-        type: PCDPermissionType.AppendToFolder
-      },
-      {
-        folder: "Devconnect",
-        type: PCDPermissionType.ReplaceInFolder
-      },
-      {
-        folder: "Devconnect",
-        type: PCDPermissionType.DeleteFolder
-      },
-      {
-        folder: "SBC SRW",
-        type: PCDPermissionType.AppendToFolder
-      },
-      {
-        folder: "SBC SRW",
-        type: PCDPermissionType.ReplaceInFolder
-      },
-      {
-        folder: "SBC SRW",
-        type: PCDPermissionType.DeleteFolder
       }
     ]
   },

--- a/packages/lib/passport-interface/src/api/apiResult.ts
+++ b/packages/lib/passport-interface/src/api/apiResult.ts
@@ -10,7 +10,7 @@ export type APIResult<TResult = unknown, TError = string> =
       error?: never;
       success: true;
     }
-  | { value?: never; error: TError; success: false };
+  | { value?: never; error: TError; success: false; code?: number };
 
 /**
  * Given the string result an HTTP endpoint responds with, return

--- a/packages/lib/passport-interface/src/api/makeRequest.ts
+++ b/packages/lib/passport-interface/src/api/makeRequest.ts
@@ -43,7 +43,11 @@ export async function httpGetSimple<TResult>(
     url,
     {
       onValue,
-      onError: async (resText) => ({ error: resText, success: false })
+      onError: async (resText, code) => ({
+        error: resText,
+        success: false,
+        code
+      })
     },
     query
   );
@@ -61,7 +65,11 @@ export async function httpPostSimple<TResult>(
     url,
     {
       onValue,
-      onError: async (resText) => ({ error: resText, success: false })
+      onError: async (resText, code) => ({
+        error: resText,
+        success: false,
+        code
+      })
     },
     postBody
   );

--- a/packages/lib/passport-interface/test/MockFeedApi.ts
+++ b/packages/lib/passport-interface/test/MockFeedApi.ts
@@ -196,7 +196,11 @@ export class MockFeedApi implements IFeedApi {
         success: true
       };
     } catch (e) {
-      return { error: getErrorMessage(e), success: false, code: e.code };
+      return {
+        error: getErrorMessage(e),
+        success: false,
+        code: (e as MockFeedError).code
+      };
     }
   }
 

--- a/packages/lib/passport-interface/test/MockFeedApi.ts
+++ b/packages/lib/passport-interface/test/MockFeedApi.ts
@@ -16,10 +16,20 @@ import {
   verifyFeedCredential
 } from "../src/FeedCredential";
 
+class MockFeedError extends Error {
+  public code: number;
+  public constructor(message: string, code: number) {
+    super(message);
+    this.code = code;
+  }
+}
+
 export class MockFeedApi implements IFeedApi {
   private feedHosts: Map<string, FeedHost>;
 
   public receivedPayload: FeedCredentialPayload | undefined;
+
+  public issuanceDisabled = false;
 
   public constructor(date?: Date) {
     this.feedHosts = new Map<string, FeedHost>([
@@ -49,6 +59,9 @@ export class MockFeedApi implements IFeedApi {
               handleRequest: async (req: PollFeedRequest) => {
                 if (date) {
                   MockDate.set(date);
+                }
+                if (this.issuanceDisabled) {
+                  throw new MockFeedError("Issuance disabled", 410);
                 }
                 const { payload } = await verifyFeedCredential(
                   req.pcd as SerializedPCD
@@ -93,6 +106,9 @@ export class MockFeedApi implements IFeedApi {
                 if (date) {
                   MockDate.set(date);
                 }
+                if (this.issuanceDisabled) {
+                  throw new MockFeedError("Issuance disabled", 410);
+                }
                 const { payload } = await verifyFeedCredential(
                   req.pcd as SerializedPCD
                 );
@@ -133,7 +149,9 @@ export class MockFeedApi implements IFeedApi {
                 if (date) {
                   MockDate.set(date);
                 }
-
+                if (this.issuanceDisabled) {
+                  throw new MockFeedError("Issuance disabled", 410);
+                }
                 const { payload } = await verifyFeedCredential(
                   req.pcd as SerializedPCD
                 );
@@ -178,7 +196,7 @@ export class MockFeedApi implements IFeedApi {
         success: true
       };
     } catch (e) {
-      return { error: getErrorMessage(e), success: false };
+      return { error: getErrorMessage(e), success: false, code: e.code };
     }
   }
 

--- a/packages/lib/passport-interface/test/SubscriptionManager.spec.ts
+++ b/packages/lib/passport-interface/test/SubscriptionManager.spec.ts
@@ -488,7 +488,7 @@ describe("Subscription Manager", async function () {
     expect(mockFeedApi.receivedPayload?.timestamp).to.eq(thirdDate.getTime());
   });
 
-  it("feeds returning a 410 error should automatically be unsubscribed from", async () => {
+  it("feeds returning a 410 error should be flagged as 'ended'", async () => {
     // First verify that we have a working subscription
     const manager = new FeedSubscriptionManager(mockFeedApi);
     const firstProviderUrl = mockFeedApi.getProviderUrls()[0];
@@ -504,7 +504,7 @@ describe("Subscription Manager", async function () {
       credentialCache
     );
 
-    await manager.subscribe(firstProviderUrl, firstFeed);
+    const sub = await manager.subscribe(firstProviderUrl, firstFeed);
     const actions = await manager.pollSubscriptions(credentialManager);
     expect(actions.length).to.eq(1);
 
@@ -512,8 +512,8 @@ describe("Subscription Manager", async function () {
     mockFeedApi.issuanceDisabled = true;
 
     await manager.pollSubscriptions(credentialManager);
-    // Our feed returned a 410 error, so we should have unsubscribed
-    expect(manager.getActiveSubscriptions().length).to.eq(0);
+    // Our feed returned a 410 error, so it should be marked as 'ended'
+    expect(manager.getSubscription(sub.id)?.ended).to.eq(true);
 
     mockFeedApi.issuanceDisabled = false;
   });

--- a/packages/lib/passport-interface/test/SubscriptionManager.spec.ts
+++ b/packages/lib/passport-interface/test/SubscriptionManager.spec.ts
@@ -487,4 +487,34 @@ describe("Subscription Manager", async function () {
     // But now it should have happened, as the original credential expired
     expect(mockFeedApi.receivedPayload?.timestamp).to.eq(thirdDate.getTime());
   });
+
+  it("feeds returning a 410 error should automatically be unsubscribed from", async () => {
+    // First verify that we have a working subscription
+    const manager = new FeedSubscriptionManager(mockFeedApi);
+    const firstProviderUrl = mockFeedApi.getProviderUrls()[0];
+    manager.addProvider(firstProviderUrl, "Mock Provider");
+    const feeds = (await manager.listFeeds(firstProviderUrl)).feeds;
+    const firstFeed = feeds[0];
+
+    const collection = new PCDCollection([]);
+    const credentialCache = await createCredentialCache();
+    const credentialManager = new CredentialManager(
+      identity,
+      collection,
+      credentialCache
+    );
+
+    await manager.subscribe(firstProviderUrl, firstFeed);
+    const actions = await manager.pollSubscriptions(credentialManager);
+    expect(actions.length).to.eq(1);
+
+    // Now disable issuance
+    mockFeedApi.issuanceDisabled = true;
+
+    await manager.pollSubscriptions(credentialManager);
+    // Our feed returned a 410 error, so we should have unsubscribed
+    expect(manager.getActiveSubscriptions().length).to.eq(0);
+
+    mockFeedApi.issuanceDisabled = false;
+  });
 });


### PR DESCRIPTION
Closes #1412

This PR does two things:

1) Remove Devconnect from "default subscriptions". This will prevent the Devconnect subscription from being automatically re-added if removed.

2) Automatically flag any feed which returns a `410 Gone` HTTP status code as 'ended', and change the Devconnect feed to return a 410 when issuance is disabled and the user has used up their final reissuance.

My original idea had been to add an "auto-unusubscribe" list, opposite in purpose to "default subscriptions", where we would automatically delete any subscription in a list of feed IDs. However, this might result in the Devconnect subscription being removed before the user's final reissuance.

Secondly I considered automatically unsubscribing from any feed which returns a `410 Gone` error code. This solved the problem of the [unresolvable subscription error](https://github.com/proofcarryingdata/zupass/issues/1412). However, it would lead to the feed silently disappearing from the user's subscriptions, which might be confusing for the user.

Instead, subscriptions which receive a 410 response are retained, but flagged as "ended" and no longer polled. The user can still see the subscription, but cannot poll it. They can still choose to unsubscribe from it.

<img width="413" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/64b04ecc-2772-4c37-8d75-35204ef0df08">

The message shown is the HTTP response text received with the 410 error.

This might not be the optimal long-run solution. We may also want to consider [better/more error codes from feeds](https://github.com/proofcarryingdata/zupass/issues/659) and better mechanisms for feed deprecation in the future. However, it solves the current problem without requiring user action and without silently deleting the subscription.