### PR TITLE
Set up custom ticket signer logic for telegramService

### DIFF
--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -889,7 +889,7 @@ export class TelegramService {
    * except for the Edge City ticket PCDs, which should have the
    * Lemonade public key as a signer.
    */
-  private async getTicketExpectedSigner(
+  private async getExpectedTicketSigner(
     pcd: ZKEdDSAEventTicketPCD
   ): Promise<[string, string]> {
     const {
@@ -927,7 +927,7 @@ export class TelegramService {
 
       let signerMatch = false;
 
-      const expectedSigner = await this.getTicketExpectedSigner(pcd);
+      const expectedSigner = await this.getExpectedTicketSigner(pcd);
 
       signerMatch =
         pcd.claim.signer[0] === expectedSigner[0] &&

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -2,6 +2,8 @@ import { autoRetry } from "@grammyjs/auto-retry";
 import { Menu } from "@grammyjs/menu";
 import { getEdDSAPublicKey } from "@pcd/eddsa-pcd";
 import {
+  EDGE_CITY_EVENT_ID,
+  LEMONADE_EDDSA_PUBKEY,
   NullifierHashPayload,
   PayloadType,
   ReactDataPayload,
@@ -881,6 +883,34 @@ export class TelegramService {
     }
   }
 
+  /**
+   * Returns the expected EdDSA public key for a given ticket PCD.
+   * All ticket PCDs should have the Zupass public key as a signer,
+   * except for the Edge City ticket PCDs, which should have the
+   * Lemonade public key as a signer.
+   */
+  private async getTicketExpectedSigner(
+    pcd: ZKEdDSAEventTicketPCD
+  ): Promise<[string, string]> {
+    const {
+      validEventIds,
+      partialTicket: { eventId }
+    } = pcd.claim;
+    if (
+      (validEventIds?.length === 1 &&
+        validEventIds[0] === EDGE_CITY_EVENT_ID) ||
+      (eventId && eventId === EDGE_CITY_EVENT_ID)
+    ) {
+      return LEMONADE_EDDSA_PUBKEY;
+    }
+    if (!process.env.SERVER_EDDSA_PRIVATE_KEY)
+      throw new Error(`Missing server eddsa private key .env value`);
+    const ZUPASS_EDDSA_PUBKEY = await getEdDSAPublicKey(
+      process.env.SERVER_EDDSA_PRIVATE_KEY
+    );
+    return ZUPASS_EDDSA_PUBKEY;
+  }
+
   private async verifyZKEdDSAEventTicketPCD(
     serializedZKEdDSATicket: string
   ): Promise<ZKEdDSAEventTicketPCD | null> {
@@ -897,23 +927,21 @@ export class TelegramService {
 
       let signerMatch = false;
 
-      if (!process.env.SERVER_EDDSA_PRIVATE_KEY)
-        throw new Error(`Missing server eddsa private key .env value`);
-
-      // This Pubkey value should work for staging + prod as well, but needs to be tested
-      const TICKETING_PUBKEY = await getEdDSAPublicKey(
-        process.env.SERVER_EDDSA_PRIVATE_KEY
-      );
+      const expectedSigner = await this.getTicketExpectedSigner(pcd);
 
       signerMatch =
-        pcd.claim.signer[0] === TICKETING_PUBKEY[0] &&
-        pcd.claim.signer[1] === TICKETING_PUBKEY[1];
+        pcd.claim.signer[0] === expectedSigner[0] &&
+        pcd.claim.signer[1] === expectedSigner[1];
 
       span?.setAttribute("signerMatch", signerMatch);
+
+      if (!signerMatch) {
+        throw new Error("Signer of pcd is invalid");
+      }
+
       if (
         // TODO: wrap in a MultiProcessService?
-        (await ZKEdDSAEventTicketPCDPackage.verify(pcd)) &&
-        signerMatch
+        await ZKEdDSAEventTicketPCDPackage.verify(pcd)
       ) {
         return pcd;
       } else {

--- a/packages/lib/passport-interface/src/edgecity.ts
+++ b/packages/lib/passport-interface/src/edgecity.ts
@@ -1,0 +1,5 @@
+export const EDGE_CITY_EVENT_ID = "31f76e79-09ed-59ee-aab0-befa73a56baf";
+export const LEMONADE_EDDSA_PUBKEY = [
+  "08ea870be3a405ef554d2b1ab50c496f1277e0fee0b3b2516ef405158cd44a02",
+  "1d854a02e0324e02ec43703f2657eca621adc6af64043db705b743554ed8be04"
+];

--- a/packages/lib/passport-interface/src/edgecity.ts
+++ b/packages/lib/passport-interface/src/edgecity.ts
@@ -1,5 +1,5 @@
 export const EDGE_CITY_EVENT_ID = "31f76e79-09ed-59ee-aab0-befa73a56baf";
-export const LEMONADE_EDDSA_PUBKEY = [
+export const LEMONADE_EDDSA_PUBKEY: [string, string] = [
   "08ea870be3a405ef554d2b1ab50c496f1277e0fee0b3b2516ef405158cd44a02",
   "1d854a02e0324e02ec43703f2657eca621adc6af64043db705b743554ed8be04"
 ];

--- a/packages/lib/passport-interface/src/index.ts
+++ b/packages/lib/passport-interface/src/index.ts
@@ -52,5 +52,6 @@ export * from "./api/requestUser";
 export * from "./api/requestVerifyTicket";
 export * from "./api/requestVerifyTicketById";
 export * from "./api/requestVerifyToken";
+export * from "./edgecity";
 export * from "./zuconnect";
 export * from "./zuzalu";


### PR DESCRIPTION
This fix unblocks setting up the Telegram group for the Edge City event.

Edge City ticket PCDs are currently signed by the Lemonade server, rather than the Zupass server. Right now, telegramService's PCD verification logic assumes that all ticket PCDs are signed by Zupass server, so we modify the verification logic to check against the Lemonade public key when we find that the event is Edge City.