### PR TITLE
Attach vscode debugger to passport-server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to passport-server",
+      "port": 4321,
+      "restart": true,
+      "cwd": "${workspaceRoot}"
+    }
+  ]
+}

--- a/apps/passport-server/package.json
+++ b/apps/passport-server/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "rm -rf ./build && yarn tsc -p ./tsconfig.json",
-    "start:dev": "NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=development ts-node-dev --respawn --watch=.env,.env.local src/main.ts",
+    "start:dev": "NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=development ts-node-dev --inspect=4321 --respawn --watch=.env,.env.local src/main.ts",
     "dev:worker": "nodemon -w src/multiprocess/worker.ts --exec \"yarn tsc -p ./tsconfig.json\"",
     "dev": "yarn tsc -p ./tsconfig.json && concurrently -r \"yarn start:dev\" \"yarn dev:worker\"",
     "start": "NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=production PORT=8080 node -r source-map-support/register build/src/main.js",


### PR DESCRIPTION
Beginnings of addressing #569

This tells `passport-server` to listen for debugger requests on port 4321, and provides a VSCode `launch.json` config to attach a debugger on that port. I've tested it and it works, allows us to set breakpoints, step through code, etc.

I investigated attaching a debugger to tests, but this seems a bit harder: the `ts-mocha` test process is fairly short-lived, and rather than attaching to it, we would want to launch it from VSCode. As far as I can tell, this might require having a configuration for each workspace's tests, rather than a generic one for the entire test suite.