### PR TITLE
Enable mandatory return types in eslint

### DIFF
--- a/apps/consumer-client/build.ts
+++ b/apps/consumer-client/build.ts
@@ -28,7 +28,7 @@ run(process.argv[2])
   .then(() => console.log("Built consumer client"))
   .catch((err) => console.error(err));
 
-async function run(command: string) {
+async function run(command: string): Promise<void> {
   switch (command) {
     case "build":
       const clientRes = await build({ ...consumerClientAppOpts, minify: true });

--- a/apps/consumer-client/src/components/Core.tsx
+++ b/apps/consumer-client/src/components/Core.tsx
@@ -11,7 +11,7 @@ export const Container = styled.div`
   margin-bottom: 8px;
 `;
 
-export const HomeLink = () => {
+export const HomeLink = (): JSX.Element => {
   return <Link to={"/"}>Home</Link>;
 };
 
@@ -21,7 +21,7 @@ export const CodeLink = ({
 }: {
   file: string;
   children: React.ReactNode;
-}) => {
+}): JSX.Element => {
   return <a href={PCD_GITHUB_URL + file}>{children}</a>;
 };
 
@@ -31,7 +31,7 @@ export const CollapsableCode = ({
 }: {
   code: string;
   label?: string;
-}) => {
+}): JSX.Element => {
   const [collapsed, setCollapsed] = useState(true);
 
   const toggle = useCallback(() => {

--- a/apps/consumer-client/src/components/PendingPCDStatusDisplay.tsx
+++ b/apps/consumer-client/src/components/PendingPCDStatusDisplay.tsx
@@ -10,7 +10,7 @@ export const PendingPCDStatusDisplay = ({
 }: {
   status: PendingPCDStatus;
   pendingPCDError: string;
-}) => {
+}): JSX.Element => {
   const StyledDiv = styled.div`
     margin: 10px 0 5px 0;
     border: 1px solid ${statusColor[status]};

--- a/apps/consumer-client/src/pages/Home.tsx
+++ b/apps/consumer-client/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { PCD_GITHUB_URL } from "../constants";
 
-function Page() {
+function Page(): JSX.Element {
   return (
     <div>
       <h1>Example Zupass Integrations</h1>

--- a/apps/consumer-client/src/pages/examples/add-pcd.tsx
+++ b/apps/consumer-client/src/pages/examples/add-pcd.tsx
@@ -32,7 +32,7 @@ import { ExampleContainer } from "../../components/ExamplePage";
 import { EVERYONE_SEMAPHORE_GROUP_URL, ZUPASS_URL } from "../../constants";
 import { sendZupassRequest } from "../../util";
 
-export default function Page() {
+export default function Page(): JSX.Element {
   const [signedMessage, setSignedMessage] = useState("1");
 
   return (
@@ -66,12 +66,14 @@ export default function Page() {
           cols={40}
           rows={1}
           value={signedMessage}
-          onChange={(e) => {
+          onChange={(e): void => {
             setSignedMessage(e.target.value);
           }}
         />
         <br />
-        <button onClick={() => addSignatureProofPCD(signedMessage)}>
+        <button
+          onClick={(): Promise<void> => addSignatureProofPCD(signedMessage)}
+        >
           prove and add a signature proof
         </button>
         <br />
@@ -98,7 +100,7 @@ export default function Page() {
   );
 }
 
-function AddEthAddrPCDButton() {
+function AddEthAddrPCDButton(): JSX.Element {
   const [pcdStr] = useZupassPopupMessages();
   const [isActive, setIsActive] = useState(false);
 
@@ -114,7 +116,7 @@ function AddEthAddrPCDButton() {
       alert("Please install MetaMask to use this dApp!");
     }
 
-    (async function () {
+    (async function (): Promise<void> {
       await ethereum.request({ method: "eth_requestAccounts" });
       const pcd = await SemaphoreSignaturePCDPackage.deserialize(parsed.pcd);
       const signature = await provider
@@ -152,7 +154,7 @@ function AddEthAddrPCDButton() {
 
   return (
     <button
-      onClick={() => {
+      onClick={(): void => {
         setIsActive(true);
         zupassSignIn("eth-pcd");
       }}
@@ -162,7 +164,7 @@ function AddEthAddrPCDButton() {
   );
 }
 
-async function zupassSignIn(originalSiteName: string) {
+async function zupassSignIn(originalSiteName: string): Promise<void> {
   openSignedZuzaluSignInPopup(
     ZUPASS_URL,
     window.location.origin + "#/popup",
@@ -170,7 +172,7 @@ async function zupassSignIn(originalSiteName: string) {
   );
 }
 
-function AddEthGroupPCDButton() {
+function AddEthGroupPCDButton(): JSX.Element {
   const [pcdStr] = useZupassPopupMessages();
   const [isActive, setIsActive] = useState(false);
 
@@ -186,7 +188,7 @@ function AddEthGroupPCDButton() {
       alert("Please install MetaMask to use this dApp!");
     }
 
-    (async function () {
+    (async function (): Promise<void> {
       await ethereum.request({ method: "eth_requestAccounts" });
       const pcd = await SemaphoreSignaturePCDPackage.deserialize(parsed.pcd);
 
@@ -257,7 +259,7 @@ function AddEthGroupPCDButton() {
   return (
     <button
       disabled
-      onClick={() => {
+      onClick={(): void => {
         setIsActive(true);
         zupassSignIn("eth-group-pcd");
       }}
@@ -267,7 +269,7 @@ function AddEthGroupPCDButton() {
   );
 }
 
-async function addGroupMembershipProofPCD() {
+async function addGroupMembershipProofPCD(): Promise<void> {
   const url = constructZupassPcdProveAndAddRequestUrl<
     typeof SemaphoreGroupPCDPackage
   >(
@@ -314,7 +316,7 @@ async function addGroupMembershipProofPCD() {
   sendZupassRequest(url);
 }
 
-async function addEdDSAPCD() {
+async function addEdDSAPCD(): Promise<void> {
   const proofUrl = constructZupassPcdProveAndAddRequestUrl<
     typeof EdDSAPCDPackage
   >(
@@ -346,7 +348,7 @@ async function addEdDSAPCD() {
   sendZupassRequest(proofUrl);
 }
 
-async function addSignatureProofPCD(messageToSign: string) {
+async function addSignatureProofPCD(messageToSign: string): Promise<void> {
   const proofUrl = constructZupassPcdProveAndAddRequestUrl<
     typeof SemaphoreSignaturePCDPackage
   >(
@@ -374,7 +376,7 @@ async function addSignatureProofPCD(messageToSign: string) {
   sendZupassRequest(proofUrl);
 }
 
-async function addIdentityPCD() {
+async function addIdentityPCD(): Promise<void> {
   const newIdentity = await SemaphoreIdentityPCDPackage.prove({
     identity: new Identity()
   });
@@ -391,7 +393,7 @@ async function addIdentityPCD() {
   sendZupassRequest(url);
 }
 
-async function addWebAuthnPCD() {
+async function addWebAuthnPCD(): Promise<void> {
   // Register a new WebAuthn credential for testing.
   const generatedRegistrationOptions = await generateRegistrationOptions({
     rpName: "consumer-client",

--- a/apps/consumer-client/src/pages/examples/get-without-proving.tsx
+++ b/apps/consumer-client/src/pages/examples/get-without-proving.tsx
@@ -9,7 +9,7 @@ import { ExampleContainer } from "../../components/ExamplePage";
 import { ZUPASS_URL } from "../../constants";
 import { sendZupassRequest } from "../../util";
 
-export default function Page() {
+export default function Page(): JSX.Element {
   const [zupassPCDStr] = useZupassPopupMessages();
 
   const formatted = useMemo(() => {
@@ -38,7 +38,7 @@ export default function Page() {
   );
 }
 
-function getProofWithoutProving() {
+function getProofWithoutProving(): void {
   const url = getWithoutProvingUrl(
     ZUPASS_URL,
     window.location.origin + "#/popup",

--- a/apps/consumer-client/src/pages/examples/group-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/group-proof.tsx
@@ -20,7 +20,7 @@ import {
   ZUPASS_URL
 } from "../../constants";
 
-export default function Page() {
+export default function Page(): JSX.Element {
   const [zupassPCDStr, zupassPendingPCDStr] = useZupassPopupMessages();
   const [pendingPCDStatus, pendingPCDError, serverPCDStr] = usePendingPCD(
     zupassPendingPCDStr,
@@ -28,7 +28,7 @@ export default function Page() {
   );
   const pcdStr = usePCDMultiplexer(zupassPCDStr, serverPCDStr);
   const [valid, setValid] = useState<boolean | undefined>();
-  const onVerified = (valid: boolean) => {
+  const onVerified = (valid: boolean): void => {
     setValid(valid);
   };
   const { proof, group } = useSemaphoreGroupProof(
@@ -66,7 +66,7 @@ export default function Page() {
       </p>
       <ExampleContainer>
         <button
-          onClick={() =>
+          onClick={(): void =>
             requestMembershipProof(
               debugChecked,
               serverProving,
@@ -81,7 +81,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={debugChecked}
-            onChange={() => {
+            onChange={(): void => {
               setDebugChecked((checked) => !checked);
             }}
           />
@@ -91,7 +91,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={serverProving}
-            onChange={() => {
+            onChange={(): void => {
               setServerProving((checked: boolean) => !checked);
             }}
           />
@@ -127,7 +127,7 @@ function requestMembershipProof(
   debug: boolean,
   proveOnServer: boolean,
   originalSiteName: string
-) {
+): void {
   const popupUrl = window.location.origin + "#/popup";
   const proofUrl = constructZupassPcdGetRequestUrl<
     typeof SemaphoreGroupPCDPackage

--- a/apps/consumer-client/src/pages/examples/signature-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/signature-proof.tsx
@@ -11,7 +11,7 @@ import { ExampleContainer } from "../../components/ExamplePage";
 import { PendingPCDStatusDisplay } from "../../components/PendingPCDStatusDisplay";
 import { ZUPASS_SERVER_URL, ZUPASS_URL } from "../../constants";
 
-export default function Page() {
+export default function Page(): JSX.Element {
   const [zupassPCDStr, zupassPendingPCDStr] = useZupassPopupMessages();
   const [pendingPCDStatus, pendingPCDError, serverPCDStr] = usePendingPCD(
     zupassPendingPCDStr,
@@ -22,7 +22,7 @@ export default function Page() {
   const [signatureProofValid, setSignatureProofValid] = useState<
     boolean | undefined
   >();
-  const onProofVerified = (valid: boolean) => {
+  const onProofVerified = (valid: boolean): void => {
     setSignatureProofValid(valid);
   };
 
@@ -48,7 +48,7 @@ export default function Page() {
           placeholder="Message to sign"
           type="text"
           value={messageToSign}
-          onChange={(e) => setMessageToSign(e.target.value)}
+          onChange={(e): void => setMessageToSign(e.target.value)}
         />
         <br />
         <button
@@ -70,7 +70,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={serverProving}
-            onChange={() => {
+            onChange={(): void => {
               setServerProving((checked: boolean) => !checked);
             }}
           />

--- a/apps/consumer-client/src/pages/examples/zk-eddsa-event-ticket-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/zk-eddsa-event-ticket-proof.tsx
@@ -19,7 +19,7 @@ import { CodeLink, CollapsableCode, HomeLink } from "../../components/Core";
 import { ExampleContainer } from "../../components/ExamplePage";
 import { ZUPASS_URL } from "../../constants";
 
-export default function Page() {
+export default function Page(): JSX.Element {
   const watermark = generateSnarkMessageHash(
     "consumer-client zk-eddsa-event-ticket-pcd challenge"
   );
@@ -89,7 +89,7 @@ export default function Page() {
   const [pcdStr] = useZupassPopupMessages();
 
   const [valid, setValid] = useState<boolean | undefined>();
-  const onVerified = (valid: boolean) => {
+  const onVerified = (valid: boolean): void => {
     setValid(valid);
   };
 
@@ -121,7 +121,7 @@ export default function Page() {
       </p>
       <ExampleContainer>
         <button
-          onClick={() =>
+          onClick={(): void =>
             openZKEdDSAEventTicketPopup(
               ZUPASS_URL,
               window.location.origin + "#/popup",
@@ -144,7 +144,7 @@ export default function Page() {
           cols={45}
           rows={12}
           value={validEventIdsInput}
-          onChange={(e) => {
+          onChange={(e): void => {
             setValidEventIdsInput(e.target.value);
           }}
         />
@@ -153,7 +153,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealTicketId}
-            onChange={() => {
+            onChange={(): void => {
               setRevealTicketId((checked) => !checked);
             }}
           />
@@ -164,7 +164,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealEventId}
-            onChange={() => {
+            onChange={(): void => {
               setRevealEventId((checked) => !checked);
             }}
           />
@@ -175,7 +175,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealProductId}
-            onChange={() => {
+            onChange={(): void => {
               setRevealProductId((checked) => !checked);
             }}
           />
@@ -186,7 +186,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealTimestampConsumed}
-            onChange={() => {
+            onChange={(): void => {
               setRevealTimestampConsumed((checked) => !checked);
             }}
           />
@@ -197,7 +197,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealTimestampSigned}
-            onChange={() => {
+            onChange={(): void => {
               setRevealTimestampSigned((checked) => !checked);
             }}
           />
@@ -208,7 +208,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealAttendeeSemaphoreId}
-            onChange={() => {
+            onChange={(): void => {
               setRevealAttendeeSemaphoreId((checked) => !checked);
             }}
           />
@@ -219,7 +219,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealIsConsumed}
-            onChange={() => {
+            onChange={(): void => {
               setRevealIsConsumed((checked) => !checked);
             }}
           />
@@ -230,7 +230,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealIsRevoked}
-            onChange={() => {
+            onChange={(): void => {
               setRevealIsRevoked((checked) => !checked);
             }}
           />
@@ -241,7 +241,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealAttendeeEmail}
-            onChange={() => {
+            onChange={(): void => {
               setRevealAttendeeEmail((checked) => !checked);
             }}
           />
@@ -252,7 +252,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealAttendeeName}
-            onChange={() => {
+            onChange={(): void => {
               setRevealAttendeeName((checked) => !checked);
             }}
           />
@@ -263,7 +263,7 @@ export default function Page() {
           <input
             type="checkbox"
             checked={revealFieldsUserProvided}
-            onChange={() => {
+            onChange={(): void => {
               setRevealFieldsUserProvided((checked) => !checked);
             }}
           />
@@ -277,7 +277,7 @@ export default function Page() {
           cols={45}
           rows={12}
           value={validDisplayEventIdsInput}
-          onChange={(e) => {
+          onChange={(e): void => {
             setDisplayValidEventIdsInput(e.target.value);
           }}
         />
@@ -287,7 +287,7 @@ export default function Page() {
           cols={45}
           rows={12}
           value={validDisplayProductIdsInput}
-          onChange={(e) => {
+          onChange={(e): void => {
             setDisplayValidProductIdsInput(e.target.value);
           }}
         />
@@ -404,7 +404,7 @@ export function openZKEdDSAEventTicketPopup(
   displayValidEventIds: string[],
   displayValidProductIds: string[],
   externalNullifier?: string
-) {
+): void {
   const args: ZKEdDSAEventTicketPCDArgs = {
     ticket: {
       argumentType: ArgumentTypeName.PCD,

--- a/apps/consumer-client/src/pages/examples/zk-eddsa-frog-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/zk-eddsa-frog-proof.tsx
@@ -18,7 +18,7 @@ import { CollapsableCode, HomeLink } from "../../components/Core";
 import { ExampleContainer } from "../../components/ExamplePage";
 import { ZUPASS_URL } from "../../constants";
 
-export default function Page() {
+export default function Page(): JSX.Element {
   const externalNullifier = generateSnarkMessageHash(
     "consumer-client-nullifier"
   ).toString();
@@ -30,7 +30,7 @@ export default function Page() {
   const [pcdStr] = useZupassPopupMessages();
 
   const [valid, setValid] = useState<boolean | undefined>();
-  const onVerified = (valid: boolean) => {
+  const onVerified = (valid: boolean): void => {
     setValid(valid);
   };
 
@@ -52,7 +52,7 @@ export default function Page() {
       </p>
       <ExampleContainer>
         <button
-          onClick={() =>
+          onClick={(): void =>
             openZKEdDSAFrogPopup(
               ZUPASS_URL,
               window.location.origin + "#/popup",
@@ -111,7 +111,7 @@ export function openZKEdDSAFrogPopup(
   popupUrl: string,
   externalNullifier: string,
   watermark: string
-) {
+): void {
   const args: ZKEdDSAFrogPCDArgs = {
     frog: {
       argumentType: ArgumentTypeName.PCD,

--- a/apps/consumer-client/src/pages/examples/zu-auth/ZuAuthButton.tsx
+++ b/apps/consumer-client/src/pages/examples/zu-auth/ZuAuthButton.tsx
@@ -64,11 +64,11 @@ export default function ZuAuthButton({
   validProductIds,
   authenticated,
   setAuthenticated
-}: ZuAuthButtonProps) {
+}: ZuAuthButtonProps): JSX.Element {
   const [pcdStr] = useZupassPopupMessages();
 
   useEffect(() => {
-    (async function requestAuthentication() {
+    (async function requestAuthentication(): Promise<void> {
       if (pcdStr) {
         const authenticated = await authenticate(pcdStr);
 
@@ -81,7 +81,7 @@ export default function ZuAuthButton({
     <button
       onClick={
         !authenticated
-          ? async () => {
+          ? async (): Promise<void> => {
               openZKEdDSAEventTicketPopup(
                 ticketFieldsToReveal,
                 BigInt(await generateNonce()),
@@ -89,7 +89,7 @@ export default function ZuAuthButton({
                 validProductIds
               );
             }
-          : async () => {
+          : async (): Promise<void> => {
               await logout();
 
               setAuthenticated(false);

--- a/apps/consumer-client/src/pages/examples/zu-auth/example.tsx
+++ b/apps/consumer-client/src/pages/examples/zu-auth/example.tsx
@@ -10,7 +10,7 @@ import { isLoggedIn } from "./utils";
  * supporting both anonymous and non-anonymous authentication flows making
  * proofs on top of ZK EdDSA Ticket Event PCD.
  */
-export default function ZuAuthExample() {
+export default function ZuAuthExample(): JSX.Element {
   const [authenticated, setAuthenticated] = useState<any | false>(false);
 
   const [fieldsToReveal, setFieldsToReveal] =
@@ -33,7 +33,7 @@ export default function ZuAuthExample() {
   const exampleValidProductIds: string[] = [];
 
   useEffect(() => {
-    (async function () {
+    (async function (): Promise<void> {
       setAuthenticated(await isLoggedIn());
 
       const savedFields = JSON.parse(localStorage.getItem("fieldsToReveal"));
@@ -44,7 +44,7 @@ export default function ZuAuthExample() {
     })();
   }, []);
 
-  function toggleFieldToReveal(fieldName: string) {
+  function toggleFieldToReveal(fieldName: string): void {
     setFieldsToReveal((prevState: EdDSATicketFieldsToReveal) => {
       const revealedFields = {
         ...prevState,
@@ -85,7 +85,7 @@ export default function ZuAuthExample() {
                   type="checkbox"
                   disabled={!!authenticated}
                   checked={fieldsToReveal[fieldName]}
-                  onChange={() => toggleFieldToReveal(fieldName)}
+                  onChange={(): void => toggleFieldToReveal(fieldName)}
                 />
                 {fieldName}
               </label>

--- a/apps/consumer-client/src/pages/examples/zu-auth/utils.ts
+++ b/apps/consumer-client/src/pages/examples/zu-auth/utils.ts
@@ -34,7 +34,7 @@ export function openZKEdDSAEventTicketPopup(
   watermark: bigint,
   validEventIds: string[],
   validProductIds: string[]
-) {
+): void {
   const args: ZKEdDSAEventTicketPCDArgs = {
     ticket: {
       argumentType: ArgumentTypeName.PCD,

--- a/apps/consumer-client/src/pages/popup.tsx
+++ b/apps/consumer-client/src/pages/popup.tsx
@@ -3,7 +3,7 @@ import { useZupassPopupSetup } from "@pcd/passport-interface";
 /**
  * This popup sends requests to, and receives PCDs from Zupass.
  */
-export default function ZupassPopupRedirect() {
+export default function ZupassPopupRedirect(): JSX.Element {
   const error = useZupassPopupSetup();
   return <div>{error}</div>;
 }

--- a/apps/consumer-client/src/util.ts
+++ b/apps/consumer-client/src/util.ts
@@ -2,7 +2,7 @@
  * Popup window will redirect to Zupass to request a proof.
  * Open the popup window under the current domain, let it redirect there.
  */
-export function sendZupassRequest(proofUrl: string) {
+export function sendZupassRequest(proofUrl: string): void {
   const popupUrl = `#/popup?proofUrl=${encodeURIComponent(proofUrl)}`;
   window.open(popupUrl, "_blank", "width=450,height=600,top=100,popup");
 }

--- a/apps/consumer-server/src/application.ts
+++ b/apps/consumer-server/src/application.ts
@@ -4,7 +4,7 @@ import { ApplicationContext } from "./types";
 
 const services: ServiceInitializer[] = [startServer];
 
-export async function startApplication() {
+export async function startApplication(): Promise<void> {
   const context: ApplicationContext = {};
 
   for (const service of services) {

--- a/apps/consumer-server/src/services/metrics.ts
+++ b/apps/consumer-server/src/services/metrics.ts
@@ -3,7 +3,7 @@ import { Metric } from "./types";
 
 const metrics: Metric[] = [];
 
-export async function startMetrics(context: ApplicationContext) {
+export async function startMetrics(context: ApplicationContext): Promise<void> {
   console.log("[INIT] Starting metrics");
 
   for (const metric of metrics) {

--- a/apps/consumer-server/src/services/telemetry.ts
+++ b/apps/consumer-server/src/services/telemetry.ts
@@ -3,7 +3,7 @@ import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentation
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ApplicationContext } from "../types";
 
-export function startTelemetry(_context: ApplicationContext) {
+export function startTelemetry(_context: ApplicationContext): void {
   const sdk: NodeSDK = new HoneycombSDK({
     instrumentations: [getNodeAutoInstrumentations()]
   });

--- a/apps/kudosbot-client/build.ts
+++ b/apps/kudosbot-client/build.ts
@@ -34,7 +34,7 @@ run(process.argv[2])
   .then(() => console.log("Built kudosbot client"))
   .catch((err) => console.error(err));
 
-async function run(command: string) {
+async function run(command: string): Promise<void> {
   switch (command) {
     case "build":
       const clientRes = await build({ ...consumerClientAppOpts, minify: true });

--- a/apps/kudosbot-client/src/components/Core.tsx
+++ b/apps/kudosbot-client/src/components/Core.tsx
@@ -7,7 +7,7 @@ export const CollapsableCode = ({
 }: {
   code: string;
   label?: string;
-}) => {
+}): JSX.Element => {
   const [collapsed, setCollapsed] = useState(true);
 
   const toggle = useCallback(() => {

--- a/apps/kudosbot-client/src/components/SingleKudosDisplay.tsx
+++ b/apps/kudosbot-client/src/components/SingleKudosDisplay.tsx
@@ -2,7 +2,10 @@ import { useSemaphoreSignatureProof } from "@pcd/passport-interface";
 import { useState } from "react";
 import { CollapsableCode } from "./Core";
 
-const SingleKudosDisplay = (props: { proof: string; id: number }) => {
+const SingleKudosDisplay = (props: {
+  proof: string;
+  id: number;
+}): JSX.Element => {
   const [signatureProofValid, setSignatureProofValid] = useState<
     boolean | undefined
   >();

--- a/apps/kudosbot-client/src/pages/KudosDisplay.tsx
+++ b/apps/kudosbot-client/src/pages/KudosDisplay.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 import SingleKudosDisplay from "../components/SingleKudosDisplay";
 import { KUDOSBOT_LIST_URL } from "../constants";
 
-const KudosDisplay = () => {
+const KudosDisplay = (): JSX.Element => {
   const [rawProofs, setRawProofs] = useState<string[]>([]);
 
-  const fetchAllProofs = async () => {
+  const fetchAllProofs = async (): Promise<void> => {
     const response = await fetch(KUDOSBOT_LIST_URL);
     if (response.status !== 200) {
       return;

--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -86,7 +86,7 @@ run(process.argv[2])
   .then(() => console.log("Built Zupass client"))
   .catch((err) => console.error(err));
 
-async function run(command: string) {
+async function run(command: string): Promise<void> {
   compileHtml();
 
   switch (command) {
@@ -143,7 +143,7 @@ async function run(command: string) {
   }
 }
 
-function compileHtml() {
+function compileHtml(): void {
   const indexHtmlTemplateSource = fs
     .readFileSync(path.join("public", "index.hbs"))
     .toString();

--- a/apps/passport-client/components/core/Button.tsx
+++ b/apps/passport-client/components/core/Button.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
-import styled, { css } from "styled-components";
+import styled, { FlattenSimpleInterpolation, css } from "styled-components";
 
 export function Button({
   children,
@@ -16,7 +16,7 @@ export function Button({
   size?: "large" | "small";
   type?: "submit" | "button" | "reset";
   disabled?: boolean;
-}) {
+}): JSX.Element {
   const Btn =
     style === "danger"
       ? BtnDanger
@@ -53,7 +53,7 @@ const buttonStyle = `
 
 export const BtnBase = styled.button<{ size?: "large" | "small" }>`
   ${buttonStyle}
-  ${({ disabled }) =>
+  ${({ disabled }): FlattenSimpleInterpolation =>
     disabled === true
       ? css`
           cursor: not-allowed;
@@ -61,7 +61,7 @@ export const BtnBase = styled.button<{ size?: "large" | "small" }>`
         `
       : css``}
 
-  ${({ size }: { size?: "large" | "small" }) =>
+  ${({ size }: { size?: "large" | "small" }): FlattenSimpleInterpolation =>
     size === undefined || size === "large"
       ? css``
       : css`
@@ -92,7 +92,7 @@ const BtnSecondary = styled(BtnBase)`
 export const LinkButton = styled(Link)<{ $primary?: boolean }>`
   ${buttonStyle}
 
-  ${({ $primary }: { $primary?: boolean }) => css`
+  ${({ $primary }: { $primary?: boolean }): FlattenSimpleInterpolation => css`
     color: var(--bg-dark-primary) !important;
     display: block;
     width: 100%;
@@ -114,7 +114,7 @@ export const CircleButton = styled.button<{
   diameter: number;
   padding: number;
 }>`
-  ${(p) => {
+  ${(p): string => {
     const size = p.diameter + 2 * p.padding + "px";
     return `width: ${size};height: ${size};`;
   }};
@@ -122,7 +122,7 @@ export const CircleButton = styled.button<{
   border-radius: 99px;
   border: none;
   margin: 0;
-  padding: ${(p) => p.padding}px;
+  padding: ${(p): number => p.padding}px;
   background: transparent;
   user-select: none;
 

--- a/apps/passport-client/components/core/Chip.tsx
+++ b/apps/passport-client/components/core/Chip.tsx
@@ -20,7 +20,7 @@ export function Chip({
   onClick?: () => void;
   disabled?: boolean;
   checked?: boolean;
-}) {
+}): JSX.Element {
   return (
     <Container onClick={onClick} disabled={disabled} checked={checked}>
       {icon}
@@ -42,15 +42,16 @@ const Container = styled.div<{
   border-radius: 6px;
   padding: 2px 6px;
   border: 1px solid
-    ${(p) =>
+    ${(p): string =>
       p.checked
         ? "rgba(var(--white-rgb), 0.3)"
         : "rgba(var(--white-rgb), 0.1)"};
-  background: ${(p) =>
+  background: ${(p): string =>
     p.checked ? "rgba(var(--white-rgb), 0.05)" : "transparent"};
-  color: ${(p) => (p.checked ? "var(--white)" : "rgba(var(--white-rgb), 0.5)")};
-  cursor: ${(p) => !p.disabled && p.onClick && "pointer"};
-  pointer-events: ${(p) => (p.disabled ? "none" : "auto")};
+  color: ${(p): string =>
+    p.checked ? "var(--white)" : "rgba(var(--white-rgb), 0.5)"};
+  cursor: ${(p): string => !p.disabled && p.onClick && "pointer"};
+  pointer-events: ${(p): string => (p.disabled ? "none" : "auto")};
 `;
 
 const Label = styled.div`
@@ -59,9 +60,10 @@ const Label = styled.div`
 
 export const ChipsContainer = styled.div<{ direction: "row" | "column" }>`
   display: flex;
-  align-items: ${(p) => (p.direction === "row" ? "center" : "flex-start")};
+  align-items: ${(p): string =>
+    p.direction === "row" ? "center" : "flex-start"};
   justify-content: flex-start;
   flex-wrap: wrap;
   gap: 8px;
-  flex-direction: ${(p) => (p.direction === "row" ? "row" : "column")};
+  flex-direction: ${(p): string => (p.direction === "row" ? "row" : "column")};
 `;

--- a/apps/passport-client/components/core/Input.tsx
+++ b/apps/passport-client/components/core/Input.tsx
@@ -29,7 +29,9 @@ interface EmailCodeInputProps extends InputHTMLAttributes<HTMLInputElement> {
   ref?: Ref<HTMLInputElement>;
 }
 
-export const ConfirmationCodeInput = (inputProps: EmailCodeInputProps) => {
+export const ConfirmationCodeInput = (
+  inputProps: EmailCodeInputProps
+): JSX.Element => {
   return (
     <BigInput
       type="text"

--- a/apps/passport-client/components/core/RedactedText.tsx
+++ b/apps/passport-client/components/core/RedactedText.tsx
@@ -1,7 +1,7 @@
-import styled, { css } from "styled-components";
+import styled, { FlattenSimpleInterpolation, css } from "styled-components";
 
 export const RedactedText = styled.div<{ redacted: boolean }>`
-  ${({ redacted }) =>
+  ${({ redacted }): FlattenSimpleInterpolation =>
     redacted
       ? css`
           color: transparent;

--- a/apps/passport-client/components/core/RippleLoader.tsx
+++ b/apps/passport-client/components/core/RippleLoader.tsx
@@ -1,6 +1,6 @@
 // See CSS in global-zupass.css
 
-export const RippleLoader = () => {
+export const RippleLoader = (): JSX.Element => {
   return (
     <div className="loaderWrapper">
       <div className="loader">

--- a/apps/passport-client/components/core/Toggle.tsx
+++ b/apps/passport-client/components/core/Toggle.tsx
@@ -56,7 +56,7 @@ export const ToggleSwitch = ({
   label: string;
   checked: boolean;
   onChange: () => void;
-}) => {
+}): JSX.Element => {
   const handleChange = useCallback(() => {
     onChange();
   }, [onChange]);

--- a/apps/passport-client/components/core/index.tsx
+++ b/apps/passport-client/components/core/index.tsx
@@ -7,42 +7,42 @@ import { BigInput } from "./Input";
 export { BigInput, Button, Spacer };
 
 export const H1 = styled.h1<{ col?: string }>`
-  color: ${(p) => p.col || "var(--accent-dark)"};
+  color: ${(p): string => p.col || "var(--accent-dark)"};
   letter-spacing: 3.5px;
   font-size: 36px;
   font-weight: 200;
 `;
 
 export const H2 = styled.h2<{ col?: string }>`
-  color: ${(p) => p.col || "var(--accent-dark)"};
+  color: ${(p): string => p.col || "var(--accent-dark)"};
   letter-spacing: 3.5px;
   font-size: 22px;
   font-weight: 300;
 `;
 
 export const H3 = styled.h3<{ col?: string }>`
-  color: ${(p) => p.col || "var(--white)"};
+  color: ${(p): string => p.col || "var(--white)"};
   letter-spacing: 0.5px;
   font-size: 22px;
   font-weight: 500;
 `;
 
 export const H4 = styled.h4<{ col?: string }>`
-  color: ${(p) => p.col || "var(--white)"};
+  color: ${(p): string => p.col || "var(--white)"};
   letter-spacing: 1px;
   font-size: 20px;
   font-weight: 400;
 `;
 
 export const H5 = styled.h5<{ col?: string }>`
-  color: ${(p) => p.col || "var(--white)"};
+  color: ${(p): string => p.col || "var(--white)"};
   letter-spacing: 1px;
   font-size: 18px;
   font-weight: 400;
 `;
 
 export const Caption = styled.caption<{ col?: string }>`
-  color: ${(p) => p.col || "var(--white)"};
+  color: ${(p): string => p.col || "var(--white)"};
   letter-spacing: 1px;
   font-size: 14px;
   font-weight: 500;
@@ -62,13 +62,13 @@ export const HR = styled.hr`
 `;
 
 export const CenterColumn = styled.div<{ w?: number }>`
-  width: ${(p) => (p.w ?? 280) + "px"};
+  width: ${(p): string => (p.w ?? 280) + "px"};
   margin: 0 auto;
 `;
 
 export const Placeholder = styled.div<{ minH?: number }>`
   width: 100%;
-  ${(p) => (p.minH ? `min-height: ${p.minH}px` : "")};
+  ${(p): string => (p.minH ? `min-height: ${p.minH}px` : "")};
 `;
 
 export const TextCenter = styled.div`
@@ -90,12 +90,12 @@ export const PreWrap = styled.pre`
   overflow: hidden;
 `;
 
-export function ZuLogo() {
+export function ZuLogo(): JSX.Element {
   return (
     <img draggable="false" src={icons.logo} width="160px" height="155px" />
   );
 }
 
-export const SupportLink = () => {
+export const SupportLink = (): JSX.Element => {
   return <a href={`mailto:${ZUPASS_SUPPORT_EMAIL}`}>{ZUPASS_SUPPORT_EMAIL}</a>;
 };

--- a/apps/passport-client/components/modals/AdhocModal.tsx
+++ b/apps/passport-client/components/modals/AdhocModal.tsx
@@ -2,7 +2,7 @@ import { ComponentProps } from "react";
 import { Modal } from "react-responsive-modal";
 import { createGlobalStyle } from "styled-components";
 
-export function AdhocModal(props: ComponentProps<typeof Modal>) {
+export function AdhocModal(props: ComponentProps<typeof Modal>): JSX.Element {
   return (
     <>
       <ModalStyle />

--- a/apps/passport-client/components/modals/AnotherDeviceChangedPasswordModal.tsx
+++ b/apps/passport-client/components/modals/AnotherDeviceChangedPasswordModal.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { useDispatch } from "../../src/appHooks";
 import { Button, H2 } from "../core";
 
-export function AnotherDeviceChangedPasswordModal() {
+export function AnotherDeviceChangedPasswordModal(): JSX.Element {
   const dispatch = useDispatch();
 
   const onClick = useCallback(() => {

--- a/apps/passport-client/components/modals/ChangedPasswordModal.tsx
+++ b/apps/passport-client/components/modals/ChangedPasswordModal.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { useDispatch } from "../../src/appHooks";
 import { Button, H2 } from "../core";
 
-export function ChangedPasswordModal() {
+export function ChangedPasswordModal(): JSX.Element {
   const dispatch = useDispatch();
 
   const close = useCallback(() => {

--- a/apps/passport-client/components/modals/ConfirmSkipSetupModal.tsx
+++ b/apps/passport-client/components/modals/ConfirmSkipSetupModal.tsx
@@ -10,7 +10,7 @@ interface ConfirmSkipSetupModalProps {
 
 export function ConfirmSkipSetupModal({
   onConfirm
-}: ConfirmSkipSetupModalProps) {
+}: ConfirmSkipSetupModalProps): JSX.Element {
   const dispatch = useDispatch();
 
   const close = useCallback(() => {

--- a/apps/passport-client/components/modals/ErrorPopup.tsx
+++ b/apps/passport-client/components/modals/ErrorPopup.tsx
@@ -9,7 +9,7 @@ export function ErrorPopup({
 }: {
   error: AppError;
   onClose: () => void;
-}) {
+}): JSX.Element {
   const ignore = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
   return (
     <ErrorBg onClick={onClose}>

--- a/apps/passport-client/components/modals/FrogCryptoExportPCDsModal.tsx
+++ b/apps/passport-client/components/modals/FrogCryptoExportPCDsModal.tsx
@@ -8,7 +8,7 @@ import { H3 } from "../core";
 import { BtnBase } from "../core/Button";
 import { ActionButton } from "../screens/FrogScreens/Button";
 
-export function FrogCryptoExportPCDsModal() {
+export function FrogCryptoExportPCDsModal(): JSX.Element {
   const dispatch = useDispatch();
   const pcds = usePCDsInFolder(FrogCryptoFolderName);
 
@@ -32,7 +32,7 @@ export function FrogCryptoExportPCDsModal() {
 
       <ActionButton
         ButtonComponent={BtnBase}
-        onClick={async () => {
+        onClick={async (): Promise<void> => {
           try {
             const serialized = stringify(
               await Promise.all(pcds.map(EdDSAFrogPCDPackage.serialize))

--- a/apps/passport-client/components/modals/FrogCryptoUpdateTelegramModal.tsx
+++ b/apps/passport-client/components/modals/FrogCryptoUpdateTelegramModal.tsx
@@ -13,7 +13,7 @@ export function FrogCryptoUpdateTelegramModal({
 }: {
   revealed: boolean;
   refreshAll: () => Promise<void>;
-}) {
+}): JSX.Element {
   const credentialManager = useCredentialManager();
   const dispatch = useDispatch();
 
@@ -54,7 +54,7 @@ export function FrogCryptoUpdateTelegramModal({
       </>
       <ActionButton
         ButtonComponent={BtnBase}
-        onClick={async () => {
+        onClick={async (): Promise<void> => {
           try {
             await requestFrogCryptoUpdateTelegramHandleSharing(
               appConfig.zupassServer,

--- a/apps/passport-client/components/modals/InfoModal.tsx
+++ b/apps/passport-client/components/modals/InfoModal.tsx
@@ -2,7 +2,7 @@ import { icons } from "@pcd/passport-ui";
 import { ZUPASS_GITHUB_REPOSITORY_URL } from "@pcd/util";
 import { CenterColumn, Spacer, SupportLink, TextCenter } from "../core";
 
-export function InfoModal() {
+export function InfoModal(): JSX.Element {
   return (
     <div>
       <Spacer h={32} />

--- a/apps/passport-client/components/modals/InvalidUserModal.tsx
+++ b/apps/passport-client/components/modals/InvalidUserModal.tsx
@@ -11,7 +11,7 @@ import { AccountExportButton } from "../shared/AccountExportButton";
  * setting {@link AppState.modal} to `{ modalType: "invalid-participant" }`. This modal
  * explains what's going on + suggest paths to resolve the problem.
  */
-export function InvalidUserModal() {
+export function InvalidUserModal(): JSX.Element {
   const dispatch = useDispatch();
   const onLogoutClick = useCallback(() => {
     if (

--- a/apps/passport-client/components/modals/Modal.tsx
+++ b/apps/passport-client/components/modals/Modal.tsx
@@ -1,6 +1,10 @@
 import { icons } from "@pcd/passport-ui";
 import React, { ReactNode, useCallback, useEffect } from "react";
-import styled, { createGlobalStyle, css } from "styled-components";
+import styled, {
+  FlattenSimpleInterpolation,
+  createGlobalStyle,
+  css
+} from "styled-components";
 import { useDispatch, useModal } from "../../src/appHooks";
 import { AppState } from "../../src/state";
 import { assertUnreachable } from "../../src/util";
@@ -25,7 +29,7 @@ export function MaybeModal({
 }: {
   fullScreen?: boolean;
   isProveOrAddScreen?: boolean;
-}) {
+}): JSX.Element {
   const dispatch = useDispatch();
   const modal = useModal();
 
@@ -37,7 +41,7 @@ export function MaybeModal({
 
   // Close on escape
   useEffect(() => {
-    const listener = (e: KeyboardEvent) => {
+    const listener = (e: KeyboardEvent): void => {
       if (e.key === "Escape" && dismissable) {
         close();
       }
@@ -61,7 +65,7 @@ export function MaybeModal({
   );
 }
 
-function isModalDismissable(modal: AppState["modal"]) {
+function isModalDismissable(modal: AppState["modal"]): boolean {
   const nonDismissable: AppState["modal"]["modalType"][] = [
     "invalid-participant",
     "changed-password",
@@ -75,7 +79,10 @@ function isModalDismissable(modal: AppState["modal"]) {
   return !nonDismissable.includes(modal.modalType);
 }
 
-function getModalBody(modal: AppState["modal"], isProveOrAddScreen: boolean) {
+function getModalBody(
+  modal: AppState["modal"],
+  isProveOrAddScreen: boolean
+): JSX.Element | null {
   switch (modal.modalType) {
     case "info":
       return <InfoModal />;
@@ -117,7 +124,7 @@ export function Modal(props: {
   onClose?: () => void;
   children: ReactNode;
   fullScreen?: boolean;
-}) {
+}): JSX.Element {
   const ignore = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
   return (
     <>
@@ -159,7 +166,7 @@ const ModalBg = styled.div<{ $fullScreen?: boolean }>`
   background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(4px);
   z-index: 999;
-  padding: ${(props) => (props.$fullScreen ? "0" : "0 12px")};
+  padding: ${(props): string => (props.$fullScreen ? "0" : "0 12px")};
 `;
 
 const ModalWrap = styled.div<{ fullScreen?: boolean }>`
@@ -175,7 +182,7 @@ const ModalWrap = styled.div<{ fullScreen?: boolean }>`
   padding: 12px;
   border-radius: 12px;
 
-  ${({ fullScreen }) =>
+  ${({ fullScreen }): FlattenSimpleInterpolation =>
     fullScreen &&
     css`
       width: 100vw;

--- a/apps/passport-client/components/modals/PrivacyNoticeModal.tsx
+++ b/apps/passport-client/components/modals/PrivacyNoticeModal.tsx
@@ -9,7 +9,7 @@ import { Button, H2 } from "../core";
 import { RippleLoader } from "../core/RippleLoader";
 import { PrivacyNotice } from "../shared/PrivacyNotice";
 
-export function PrivacyNoticeModal() {
+export function PrivacyNoticeModal(): JSX.Element {
   const dispatch = useDispatch();
   const identity = useIdentity();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);

--- a/apps/passport-client/components/modals/RequireAddPasswordModal.tsx
+++ b/apps/passport-client/components/modals/RequireAddPasswordModal.tsx
@@ -18,7 +18,7 @@ import { ScreenLoader } from "../shared/ScreenLoader";
  * This uncloseable modal is shown to users of Zupass who have a sync key,
  * and have never created a password. It asks them to create a password.
  */
-export function RequireAddPasswordModal() {
+export function RequireAddPasswordModal(): JSX.Element {
   useSyncE2EEStorage();
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();

--- a/apps/passport-client/components/modals/ResolveSubscriptionError.tsx
+++ b/apps/passport-client/components/modals/ResolveSubscriptionError.tsx
@@ -22,7 +22,7 @@ import { Button, H2 } from "../core";
 import { PermissionsView } from "../screens/AddSubscriptionScreen";
 import { Spinner } from "../shared/Spinner";
 
-export function ResolveSubscriptionErrorModal() {
+export function ResolveSubscriptionErrorModal(): JSX.Element {
   const subscriptions = useSubscriptions().value;
   const id = useResolvingSubscriptionId();
   const subscription = subscriptions.getSubscription(id);
@@ -67,7 +67,7 @@ function FetchError({
 }: {
   subscription: Subscription;
   subscriptions: FeedSubscriptionManager;
-}) {
+}): JSX.Element {
   const [polling, setPolling] = useState<boolean>(false);
   const [stillFailing, setStillFailing] = useState<boolean>(false);
   const [error, setError] = useState<SubscriptionFetchError>();
@@ -128,7 +128,7 @@ function PermissionError({
   subscription: Subscription;
   subscriptions: FeedSubscriptionManager;
   error: SubscriptionPermissionError;
-}) {
+}): JSX.Element {
   // We got here because the feed served an action for which permission has
   // not been granted. This has two possible causes:
   // 1. The feed has added new permissions since the subscription was
@@ -146,7 +146,7 @@ function PermissionError({
   useEffect(() => {
     setCheckingPermissions(true);
 
-    async function checkPermissions() {
+    async function checkPermissions(): Promise<void> {
       try {
         const response = await subscriptions.listFeeds(
           subscription.providerUrl
@@ -241,7 +241,7 @@ function PermissionUpdate({
 }: {
   subscription: Subscription;
   newPermissions: PCDPermission[];
-}) {
+}): JSX.Element {
   const [outcome, setOutcome] = useState<"fail" | "success" | "">("");
   const dispatch = useDispatch();
 

--- a/apps/passport-client/components/modals/SettingsModal.tsx
+++ b/apps/passport-client/components/modals/SettingsModal.tsx
@@ -9,7 +9,7 @@ export function SettingsModal({
   isProveOrAddScreen
 }: {
   isProveOrAddScreen: boolean;
-}) {
+}): JSX.Element {
   const dispatch = useDispatch();
   const self = useSelf();
   const hasSetupPassword = useHasSetupPassword();

--- a/apps/passport-client/components/modals/UpgradeAccountModal.tsx
+++ b/apps/passport-client/components/modals/UpgradeAccountModal.tsx
@@ -18,7 +18,7 @@ import { ScreenLoader } from "../shared/ScreenLoader";
  * This uncloseable modal is shown to users of Zupass who have a sync key,
  * and have never created a password. It asks them to create a password.
  */
-export function UpgradeAccountModal() {
+export function UpgradeAccountModal(): JSX.Element {
   useSyncE2EEStorage();
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();

--- a/apps/passport-client/components/screens/AddScreen/AddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/AddScreen.tsx
@@ -29,7 +29,7 @@ import { ProveAndAddScreen } from "./ProveAndAddScreen";
  * PCD can either be a `SerializedPCD` passed in via a url, or one that
  * is freshly generated in Zupass via a proving screen.
  */
-export function AddScreen() {
+export function AddScreen(): JSX.Element {
   useSyncE2EEStorage();
   useRequirePassword();
   const dispatch = useDispatch();
@@ -70,7 +70,7 @@ export function AddScreen() {
   return screen;
 }
 
-function getScreen(request: PCDRequest) {
+function getScreen(request: PCDRequest): JSX.Element | null {
   switch (request.type) {
     case PCDRequestType.ProveAndAdd:
       return <ProveAndAddScreen request={request as PCDProveAndAddRequest} />;

--- a/apps/passport-client/components/screens/AddScreen/JustAddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/JustAddScreen.tsx
@@ -16,7 +16,11 @@ import { SyncingPCDs } from "../../shared/SyncingPCDs";
  * Screen that allows the user to respond to a `PCDAddRequest` and add
  * a PCD into their wallet without proving it.
  */
-export function JustAddScreen({ request }: { request: PCDAddRequest }) {
+export function JustAddScreen({
+  request
+}: {
+  request: PCDAddRequest;
+}): JSX.Element {
   const dispatch = useDispatch();
   const [added, setAdded] = useState(false);
   const { error, pcd } = useDeserialized(request.pcd);
@@ -47,7 +51,7 @@ export function JustAddScreen({ request }: { request: PCDAddRequest }) {
       </>
     );
   } else {
-    content = <AddedPCD onCloseClick={() => window.close()} />;
+    content = <AddedPCD onCloseClick={(): void => window.close()} />;
   }
 
   return (

--- a/apps/passport-client/components/screens/AddScreen/ProveAndAddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/ProveAndAddScreen.tsx
@@ -19,7 +19,7 @@ export function ProveAndAddScreen({
   request
 }: {
   request: PCDProveAndAddRequest;
-}) {
+}): JSX.Element {
   const syncSettled = useIsSyncSettled();
   const dispatch = useDispatch();
   const [proved, setProved] = useState(false);
@@ -51,7 +51,7 @@ export function ProveAndAddScreen({
   } else {
     content = (
       <AddedPCD
-        onCloseClick={() => {
+        onCloseClick={(): void => {
           if (request.returnPCD) {
             safeRedirect(request.returnUrl, serializedPCD);
           } else {

--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -39,7 +39,7 @@ import { Spinner } from "../shared/Spinner";
 
 const DEFAULT_FEEDS_URL = appConfig.zupassServer + "/feeds";
 
-export function AddSubscriptionScreen() {
+export function AddSubscriptionScreen(): JSX.Element {
   useSyncE2EEStorage();
   const query = useQuery();
   const url = query?.get("url") ?? "";
@@ -118,7 +118,7 @@ export function AddSubscriptionScreen() {
           autoCapitalize="off"
           disabled={fetching}
           value={providerUrl}
-          onChange={(e) => {
+          onChange={(e): void => {
             setProviderUrl(e.target.value);
           }}
         />
@@ -164,7 +164,7 @@ export function SubscriptionInfoRow({
   providerName: string;
   info: Feed;
   showErrors: boolean;
-}) {
+}): JSX.Element {
   const existingSubscriptions =
     subscriptions.getSubscriptionsByProviderAndFeedId(providerUrl, info.id);
   const subscription = existingSubscriptions[0];
@@ -223,7 +223,7 @@ function SubscribeSection({
   providerUrl: string;
   providerName: string;
   info: Feed;
-}) {
+}): JSX.Element {
   const identity = useIdentity();
   const pcds = usePCDCollection();
   const dispatch = useDispatch();
@@ -241,7 +241,7 @@ function SubscribeSection({
   });
 
   const onSubscribeClick = useCallback(() => {
-    (async () => {
+    (async (): Promise<void> => {
       dispatch({
         type: "add-subscription",
         providerUrl,
@@ -292,7 +292,7 @@ export function PermissionsView({
   permissions
 }: {
   permissions: PCDPermission[];
-}) {
+}): JSX.Element {
   return (
     <ul>
       {permissions.map((p, i) => (
@@ -302,7 +302,11 @@ export function PermissionsView({
   );
 }
 
-function SinglePermission({ permission }: { permission: PCDPermission }) {
+function SinglePermission({
+  permission
+}: {
+  permission: PCDPermission;
+}): JSX.Element {
   if (isAppendToFolderPermission(permission)) {
     return (
       <PermissionListItem>
@@ -334,7 +338,7 @@ function AlreadySubscribed({
   existingSubscription
 }: {
   existingSubscription: Subscription;
-}) {
+}): JSX.Element {
   const dispatch = useDispatch();
   const onUnsubscribeClick = useCallback(() => {
     if (

--- a/apps/passport-client/components/screens/ChangePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/ChangePasswordScreen.tsx
@@ -21,7 +21,7 @@ import { AppContainer } from "../shared/AppContainer";
 import { NewPasswordForm } from "../shared/NewPasswordForm";
 import { PasswordInput } from "../shared/PasswordInput";
 
-export function ChangePasswordScreen() {
+export function ChangePasswordScreen(): JSX.Element {
   useSyncE2EEStorage();
   const self = useSelf();
   const hasSetupPassword = useHasSetupPassword();

--- a/apps/passport-client/components/screens/DevconnectCheckinByIdScreen.tsx
+++ b/apps/passport-client/components/screens/DevconnectCheckinByIdScreen.tsx
@@ -27,7 +27,7 @@ import {
   CardOutlineExpanded
 } from "../shared/PCDCard";
 
-export function DevconnectCheckinByIdScreen() {
+export function DevconnectCheckinByIdScreen(): JSX.Element {
   useLaserScannerKeystrokeInput();
   const { loading: verifyingTicketId, ticketId } = useTicketId();
 
@@ -60,7 +60,7 @@ export function DevconnectCheckinByIdScreen() {
   );
 }
 
-function CheckInById({ ticketId }: { ticketId: string }) {
+function CheckInById({ ticketId }: { ticketId: string }): JSX.Element {
   const { loading: checkingTicket, result: checkTicketByIdResult } =
     useCheckTicketById(ticketId);
 
@@ -104,7 +104,7 @@ function useTicketId(): TicketId {
     if (!id) {
       const pcdStr = query.get("pcd");
       const decodedPCD = decodeQRPayload(pcdStr);
-      const verify = async () => {
+      const verify = async (): Promise<void> => {
         const pcd = await ZKEdDSAEventTicketPCDPackage.deserialize(
           JSON.parse(decodedPCD).pcd
         );
@@ -129,7 +129,7 @@ function useTicketId(): TicketId {
   return { loading, ticketId, error };
 }
 
-function TicketErrorContent({ error }: { error: TicketError }) {
+function TicketErrorContent({ error }: { error: TicketError }): JSX.Element {
   let errorContent = null;
 
   switch (error.name) {
@@ -202,7 +202,7 @@ function TicketErrorContent({ error }: { error: TicketError }) {
   return <ErrorContainer>{errorContent}</ErrorContainer>;
 }
 
-export function TicketError({ error }: { error: TicketError }) {
+export function TicketError({ error }: { error: TicketError }): JSX.Element {
   const usingLaserScanner = loadUsingLaserScanner();
   return (
     <>
@@ -220,7 +220,7 @@ export function TicketError({ error }: { error: TicketError }) {
   );
 }
 
-function ScanAnotherTicket() {
+function ScanAnotherTicket(): JSX.Element {
   const onClick = useCallback(() => {
     window.location.href = "/#/scan";
   }, []);
@@ -232,7 +232,7 @@ function ScanAnotherTicket() {
   );
 }
 
-function Home() {
+function Home(): JSX.Element {
   const onClick = useCallback(() => {
     window.location.href = "/#/";
   }, []);
@@ -253,7 +253,7 @@ export function UserReadyForCheckin({
 }: {
   ticketData: CheckTicketByIdResponseValue;
   ticketId: string;
-}) {
+}): JSX.Element {
   return (
     <>
       <TicketInfoSection ticketData={ticketData} />
@@ -304,7 +304,7 @@ export function useCheckTicketById(ticketId: string | undefined):
   }
 }
 
-function CheckInSection({ ticketId }: { ticketId: string }) {
+function CheckInSection({ ticketId }: { ticketId: string }): JSX.Element {
   const dispatchContext = useStateContext();
   const [inProgress, setInProgress] = useState(false);
   const [checkedIn, setCheckedIn] = useState(false);
@@ -372,7 +372,7 @@ function TicketInfoSection({
   ticketData
 }: {
   ticketData: CheckTicketByIdResponseValue;
-}) {
+}): JSX.Element {
   return (
     <CardOutlineExpanded>
       <CardHeader>

--- a/apps/passport-client/components/screens/EnterConfirmationCodeScreen.tsx
+++ b/apps/passport-client/components/screens/EnterConfirmationCodeScreen.tsx
@@ -19,7 +19,7 @@ import { AppContainer } from "../shared/AppContainer";
 import { InlineError } from "../shared/InlineError";
 import { ResendCodeButton } from "../shared/ResendCodeButton";
 
-export function EnterConfirmationCodeScreen() {
+export function EnterConfirmationCodeScreen(): JSX.Element {
   const query = useQuery();
   const email = query?.get("email");
   const isReset = query?.get("isReset");
@@ -97,7 +97,7 @@ export function EnterConfirmationCodeScreen() {
           <ConfirmationCodeInput
             autoFocus
             value={input}
-            onChange={(e) => setInput(e.target.value.replace(/\D/g, ""))}
+            onChange={(e): void => setInput(e.target.value.replace(/\D/g, ""))}
             placeholder="confirmation code"
             disabled={verifyingCode}
           />

--- a/apps/passport-client/components/screens/FrogScreens/Button.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/Button.tsx
@@ -8,7 +8,7 @@ import React, {
 } from "react";
 import { useInView } from "react-intersection-observer";
 import { ParallaxBanner, ParallaxProvider } from "react-scroll-parallax";
-import styled, { keyframes } from "styled-components";
+import styled, { Keyframes, keyframes } from "styled-components";
 import { Container } from "tsparticles-engine";
 import {
   useCelestialPondParticles,
@@ -36,7 +36,7 @@ export function ActionButton({
    * The component to use for the button. Defaults to Button.
    */
   ButtonComponent?: React.ComponentType<React.ComponentProps<typeof Button>>;
-}) {
+}): JSX.Element {
   const [loading, setLoading] = useState(false);
   // Every user click increment the trigger count, which will trigger the
   // useEffect to kick onClick action below.
@@ -147,7 +147,7 @@ export const FrogSearchButton = forwardRef(
 
       // nb: we always need this so we can disable animation when button starts as
       // enabled
-      return () => {
+      return (): void => {
         container.stop();
       };
     }, [container, disabled, pending]);
@@ -188,7 +188,7 @@ export const Button = styled.button<{ pending?: boolean }>`
   &:disabled {
     background-color: rgba(var(--white-rgb), 0.2);
     filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
-    cursor: ${(props) => (props.pending ? "wait" : "unset")};
+    cursor: ${(props): string => (props.pending ? "wait" : "unset")};
   }
 `;
 
@@ -464,7 +464,7 @@ export const WrithingVoidSearchButton = forwardRef(
 );
 
 const WrithingVoidCover = styled.div<{ visible: boolean }>`
-  pointer-events: ${({ visible }) => (visible ? "auto" : "none")};
+  pointer-events: ${({ visible }): string => (visible ? "auto" : "none")};
   position: fixed;
   width: 100%;
   height: 100%;
@@ -476,8 +476,9 @@ const WrithingVoidCover = styled.div<{ visible: boolean }>`
   align-items: center;
   justify-content: center;
 
-  background-color: ${({ visible }) => (visible ? "#000000" : "transparent")};
-  transition: ${({ visible }) =>
+  background-color: ${({ visible }): string =>
+    visible ? "#000000" : "transparent"};
+  transition: ${({ visible }): string =>
     visible
       ? "background-color 4s ease-in"
       : "background-color 3s ease-out 1s"};
@@ -523,21 +524,23 @@ const WrithingImage = styled.div<{ visible: boolean }>`
 
   border-radius: 50%;
 
-  opacity: ${({ visible }) => (visible ? "100%" : "20%")};
-  width: ${({ visible }) => (visible ? "min(80vw, 80vh)" : "0")};
-  height: ${({ visible }) => (visible ? "min(80vw, 80vh)" : "0")};
+  opacity: ${({ visible }): string => (visible ? "100%" : "20%")};
+  width: ${({ visible }): string => (visible ? "min(80vw, 80vh)" : "0")};
+  height: ${({ visible }): string => (visible ? "min(80vw, 80vh)" : "0")};
   box-shadow:
     0 0 0 0 rgba(255, 255, 255, 0.2) inset,
     0 0 0 0 rgba(255, 255, 255, 0.2);
 
-  transition: ${({ visible }) =>
+  transition: ${({ visible }): string =>
     visible
       ? "width 16s ease-in, height 16s ease-in, opacity 4s ease-in"
       : "all 4s cubic-bezier(1,0,1,.6)"};
   animation:
     ${rotating} 600s linear infinite,
-    ${({ visible }) => (visible ? pulse : noop)} 8s linear 16s infinite;
+    ${({ visible }): Keyframes => (visible ? pulse : noop)} 8s linear 16s
+      infinite;
   -webkit-animation:
     ${rotating} 600s linear infinite,
-    ${({ visible }) => (visible ? pulse : noop)} 8s linear 16s infinite;
+    ${({ visible }): Keyframes => (visible ? pulse : noop)} 8s linear 16s
+      infinite;
 `;

--- a/apps/passport-client/components/screens/FrogScreens/Countdown.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/Countdown.tsx
@@ -9,7 +9,7 @@ const MESSAGE_CUT_OFF = 60 * 60 * 24 * 2; // 2 days
 /**
  * A countdown timer towards the end of this season.
  */
-export function Countdown() {
+export function Countdown(): JSX.Element {
   const [timeLeft, setTimeLeft] = useState(
     (THE_END.getTime() - Date.now()) / 1000
   );
@@ -57,7 +57,7 @@ export function Countdown() {
 
 const THE_END_ANIMATION_SHOWN_KEY = "frogcrypto-the-end-animation-shown";
 
-function TheEnd() {
+function TheEnd(): JSX.Element {
   const [visible, setVisible] = useState(false);
   const dismiss = useCallback(() => {
     setVisible(false);
@@ -98,8 +98,8 @@ const Container = styled.div<{ visible: boolean }>`
   top: 0;
   left: 0;
   background-color: black;
-  pointer-events: ${({ visible }) => (visible ? "auto" : "none")};
-  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  pointer-events: ${({ visible }): string => (visible ? "auto" : "none")};
+  opacity: ${({ visible }): number => (visible ? 1 : 0)};
   transition: opacity 2s ease-in-out;
 
   display: flex;

--- a/apps/passport-client/components/screens/FrogScreens/DexTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/DexTab.tsx
@@ -40,7 +40,7 @@ export function DexTab({
 }: {
   possibleFrogs?: DexFrog[];
   pcds: EdDSAFrogPCD[];
-}) {
+}): JSX.Element {
   const dispatch = useDispatch();
   const [mode, setMode] = useState<"grid" | "list">("list");
   const groupedPCDs = useGroupedPCDs(pcds || []);
@@ -54,7 +54,7 @@ export function DexTab({
   return (
     <>
       <Button
-        onClick={() =>
+        onClick={(): void =>
           dispatch({
             type: "set-modal",
             modal: {
@@ -70,7 +70,10 @@ export function DexTab({
         <span style={{ marginRight: "16px" }}>
           Owned: {Object.keys(groupedPCDs).length.toString().padStart(3, "0")}
         </span>
-        <Button onClick={() => setMode("list")} disabled={mode === "list"}>
+        <Button
+          onClick={(): void => setMode("list")}
+          disabled={mode === "list"}
+        >
           <img
             src={icons.inputObject}
             draggable={false}
@@ -78,7 +81,10 @@ export function DexTab({
             height={16}
           />
         </Button>
-        <Button onClick={() => setMode("grid")} disabled={mode === "grid"}>
+        <Button
+          onClick={(): void => setMode("grid")}
+          disabled={mode === "grid"}
+        >
           <img src={icons.grid} draggable={false} width={16} height={16} />
         </Button>
       </ButtonGroup>
@@ -100,7 +106,7 @@ export function DexTab({
       {focusedFrogs && (
         <FrogsModal
           pcds={focusedFrogs}
-          onClose={() => setFocusedFrogs(null)}
+          onClose={(): void => setFocusedFrogs(null)}
           color={RARITIES[focusedFrogs[0].claim.data.rarity].color}
         />
       )}
@@ -116,7 +122,7 @@ const DexList = ({
   possibleFrogs: DexFrog[];
   pcds: FrogsById;
   onClick: Dispatch<SetStateAction<EdDSAFrogPCD[]>>;
-}) => {
+}): JSX.Element => {
   return (
     <table>
       <tbody>
@@ -140,7 +146,7 @@ const DexList = ({
           return (
             <tr
               key={id}
-              onClick={() => onClick(frogPCDs.pcds)}
+              onClick={(): void => onClick(frogPCDs.pcds)}
               style={{ cursor: "pointer" }}
             >
               <Cell>{id}</Cell>
@@ -166,7 +172,7 @@ const DexGrid = ({
   possibleFrogs: DexFrog[];
   pcds: FrogsById;
   onClick: Dispatch<SetStateAction<EdDSAFrogPCD[]>>;
-}) => {
+}): JSX.Element => {
   return (
     <CardGrid>
       {possibleFrogs.map(({ id, rarity }) => {
@@ -190,7 +196,10 @@ const DexGrid = ({
 
         return (
           <CardContainer key={id}>
-            <FrogCard rarity={rarity} onClick={() => onClick(frogPCDs.pcds)}>
+            <FrogCard
+              rarity={rarity}
+              onClick={(): void => onClick(frogPCDs.pcds)}
+            >
               <span>{frogPCDs.frog.name}</span>
               <img src={frogPCDs.frog.imageUrl} draggable={false} />
             </FrogCard>
@@ -238,11 +247,11 @@ const Cell = styled.td`
 
 const RarityBadge = styled.div<{ rarity: Rarity }>`
   padding: 2px;
-  border: 1px solid ${({ rarity }) => RARITIES[rarity].color};
+  border: 1px solid ${({ rarity }): string => RARITIES[rarity].color};
   border-radius: 2px;
   font-size: 8px;
   color: var(--white);
-  background: ${({ rarity }) => RARITIES[rarity].color};
+  background: ${({ rarity }): string => RARITIES[rarity].color};
 
   text-align: center;
   vertical-align: middle;
@@ -250,7 +259,7 @@ const RarityBadge = styled.div<{ rarity: Rarity }>`
 
 const UnknownRarityBadge = styled(RarityBadge)`
   background: rgba(var(--white-rgb), 0.05);
-  color: ${({ rarity }) => RARITIES[rarity].color};
+  color: ${({ rarity }): string => RARITIES[rarity].color};
 `;
 
 const UnknownCell = styled(Cell)`
@@ -264,9 +273,9 @@ const CardGrid = styled.div`
 `;
 
 const FrogCard = styled.div<{ rarity: Rarity }>`
-  border: 2px solid ${({ rarity }) => RARITIES[rarity].color};
-  background-color: ${({ rarity }) => RARITIES[rarity].color};
-  background: ${({ rarity }) => RARITIES[rarity].color};
+  border: 2px solid ${({ rarity }): string => RARITIES[rarity].color};
+  background-color: ${({ rarity }): string => RARITIES[rarity].color};
+  background: ${({ rarity }): string => RARITIES[rarity].color};
 
   border-radius: 8px;
   display: flex;
@@ -296,7 +305,7 @@ const FrogCard = styled.div<{ rarity: Rarity }>`
 
 const SkeletonCard = styled(FrogCard)`
   background: rgba(var(--white-rgb), 0.05);
-  border: 2px dashed ${({ rarity }) => RARITIES[rarity].color};
+  border: 2px dashed ${({ rarity }): string => RARITIES[rarity].color};
 
   cursor: unset;
   filter: opacity(40%);

--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -23,11 +23,11 @@ export function FrogFolder({
 }: {
   onFolderClick: (folder: string) => void;
   Container: React.ComponentType<any>;
-}) {
+}): JSX.Element {
   const fetchTimestamp = useFetchTimestamp();
 
   return (
-    <Container onClick={() => onFolderClick(FrogCryptoFolderName)}>
+    <Container onClick={(): void => onFolderClick(FrogCryptoFolderName)}>
       <img
         draggable="false"
         src="/images/frogs/pixel_frog.png"
@@ -91,7 +91,7 @@ function useFetchTimestamp(): number | null {
 /**
  * A countdown to a hard coded game start date.
  */
-function CountDown({ timestamp }: { timestamp: number }) {
+function CountDown({ timestamp }: { timestamp: number }): JSX.Element {
   const end = useMemo(() => {
     return new Date(timestamp);
   }, [timestamp]);
@@ -184,6 +184,6 @@ const bounceKeyframes = keyframes`
 `;
 
 const BounceText = styled.span<{ delay: number }>`
-  animation: ${bounceKeyframes} 5s infinite ${(p) => p.delay}s;
-  -webkit-animation: ${bounceKeyframes} 5s infinite ${(p) => p.delay}s;
+  animation: ${bounceKeyframes} 5s infinite ${(p): number => p.delay}s;
+  -webkit-animation: ${bounceKeyframes} 5s infinite ${(p): number => p.delay}s;
 `;

--- a/apps/passport-client/components/screens/FrogScreens/FrogHomeSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogHomeSection.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
+import { TypewriterClass } from "typewriter-effect";
 import { appConfig } from "../../../src/appConfig";
 import {
   useCredentialManager,
@@ -103,7 +104,7 @@ export function FrogHomeSection(): JSX.Element {
 
       {frogSubs.length === 0 && (
         <TypistText
-          onInit={(typewriter): any =>
+          onInit={(typewriter): TypewriterClass =>
             typewriter
               .typeString(
                 isFromSubscriptionRef.current
@@ -139,7 +140,7 @@ export function FrogHomeSection(): JSX.Element {
         (frogPCDs.length === 0 && !myScore ? (
           <>
             <TypistText
-              onInit={(typewriter): any => {
+              onInit={(typewriter): TypewriterClass => {
                 const text = isFromSubscriptionRef.current
                   ? `you hear a whisper. "come back again when you're stronger."`
                   : "you're certain you saw a frog wearing a monocle.";

--- a/apps/passport-client/components/screens/FrogScreens/FrogHomeSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogHomeSection.tsx
@@ -1,5 +1,6 @@
 import { isEdDSAFrogPCD } from "@pcd/eddsa-frog-pcd";
 import {
+  Feed,
   FrogCryptoFolderName,
   FrogCryptoUserStateResponseValue,
   Subscription,
@@ -48,7 +49,7 @@ type TabId = (typeof TABS)[number]["tab"];
 /**
  * Renders FrogCrypto UI including rendering all EdDSAFrogPCDs.
  */
-export function FrogHomeSection() {
+export function FrogHomeSection(): JSX.Element {
   const frogPCDs = usePCDsInFolder(FrogCryptoFolderName).filter(isEdDSAFrogPCD);
   const subs = useSubscriptions();
   const frogSubs = useMemo(
@@ -102,7 +103,7 @@ export function FrogHomeSection() {
 
       {frogSubs.length === 0 && (
         <TypistText
-          onInit={(typewriter) =>
+          onInit={(typewriter): any =>
             typewriter
               .typeString(
                 isFromSubscriptionRef.current
@@ -122,7 +123,7 @@ export function FrogHomeSection() {
             // frog holders cannot retreat
             frogPCDs.length === 0 && !myScore && (
               <ActionButton
-                onClick={() => {
+                onClick={(): Promise<Feed | null> => {
                   retreatRef.current = true;
                   return initFrog();
                 }}
@@ -138,7 +139,7 @@ export function FrogHomeSection() {
         (frogPCDs.length === 0 && !myScore ? (
           <>
             <TypistText
-              onInit={(typewriter) => {
+              onInit={(typewriter): any => {
                 const text = isFromSubscriptionRef.current
                   ? `you hear a whisper. "come back again when you're stronger."`
                   : "you're certain you saw a frog wearing a monocle.";
@@ -174,7 +175,7 @@ export function FrogHomeSection() {
                     <Button
                       key={t}
                       disabled={tab === t}
-                      onClick={() => setTab(t)}
+                      onClick={(): void => setTab(t)}
                     >
                       {label}
                     </Button>
@@ -209,7 +210,10 @@ export function FrogHomeSection() {
 /**
  * Fetch the user's frog crypto state as well as the ability to refetch.
  */
-export function useUserFeedState(subscriptions: Subscription[]) {
+export function useUserFeedState(subscriptions: Subscription[]): {
+  userState: FrogCryptoUserStateResponseValue;
+  refreshUserState: () => Promise<void>;
+} {
   const [userState, setUserState] =
     useState<FrogCryptoUserStateResponseValue | null>(null);
   const credentialManager = useCredentialManager();

--- a/apps/passport-client/components/screens/FrogScreens/FrogManagerScreen.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogManagerScreen.tsx
@@ -8,7 +8,7 @@ import { Button, ButtonGroup } from "./Button";
 import { ManageFeedsSection } from "./ManageFeedsSection";
 import { ManageFrogsSection } from "./ManageFrogsSection";
 
-export function FrogManagerScreen() {
+export function FrogManagerScreen(): JSX.Element {
   useSyncE2EEStorage();
   const syncSettled = useIsSyncSettled();
 
@@ -21,10 +21,16 @@ export function FrogManagerScreen() {
   return (
     <AppContainer bg="gray">
       <ButtonGroup>
-        <Button disabled={tab === "frogs"} onClick={() => setTab("frogs")}>
+        <Button
+          disabled={tab === "frogs"}
+          onClick={(): void => setTab("frogs")}
+        >
           Frogs
         </Button>
-        <Button disabled={tab === "feeds"} onClick={() => setTab("feeds")}>
+        <Button
+          disabled={tab === "feeds"}
+          onClick={(): void => setTab("feeds")}
+        >
           Feeds
         </Button>
       </ButtonGroup>

--- a/apps/passport-client/components/screens/FrogScreens/FrogSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogSubscriptionScreen.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useSwipeable } from "react-swipeable";
 import styled from "styled-components";
+import { TypewriterClass } from "typewriter-effect";
 import {
   useIsSyncSettled,
   useSelf,
@@ -81,7 +82,7 @@ export function FrogSubscriptionScreen(): JSX.Element {
     <AppContainer bg="gray">
       <Container>
         <TypistText
-          onInit={(typewriter): any =>
+          onInit={(typewriter): TypewriterClass =>
             typewriter.typeString(
               "You have chosen the path less traveled. What do you desire? Speak, and they shall be yours"
             )

--- a/apps/passport-client/components/screens/FrogScreens/FrogSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogSubscriptionScreen.tsx
@@ -24,7 +24,7 @@ export const FROM_SUBSCRIPTION_PARAM_KEY = "fromFrogSubscription";
 /**
  * A screen where the user can subscribe to new frog feeds via deeplink.
  */
-export function FrogSubscriptionScreen() {
+export function FrogSubscriptionScreen(): JSX.Element {
   useSyncE2EEStorage();
   const syncSettled = useIsSyncSettled();
 
@@ -81,14 +81,14 @@ export function FrogSubscriptionScreen() {
     <AppContainer bg="gray">
       <Container>
         <TypistText
-          onInit={(typewriter) =>
+          onInit={(typewriter): any =>
             typewriter.typeString(
               "You have chosen the path less traveled. What do you desire? Speak, and they shall be yours"
             )
           }
         >
           <Form
-            onSubmit={(e) => {
+            onSubmit={(e): void => {
               e.preventDefault();
               window.location.href = `/#/frogscriptions/${e.target["feedCode"]?.value}`;
             }}
@@ -135,7 +135,7 @@ const CHEAT_CODE_ACTIVATION_SEQUENCE = [
 /**
  * A ambient module that listens for cheatcode and redirect user to frogscription
  */
-export function useCheatCodeActivation() {
+export function useCheatCodeActivation(): void {
   const redirect = useCallback(() => {
     window.location.replace(`/#/frogscriptions`);
   }, []);
@@ -183,7 +183,7 @@ export function useCheatCodeActivation() {
   }, [ref]);
 
   useEffect(() => {
-    const listener = (e) => {
+    const listener = (e): void => {
       checkProgress(e.key);
     };
     document.addEventListener("keydown", listener);

--- a/apps/passport-client/components/screens/FrogScreens/FrogsModal.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogsModal.tsx
@@ -14,7 +14,7 @@ export function FrogsModal({
   pcds: EdDSAFrogPCD[];
   color;
   onClose: () => void;
-}) {
+}): JSX.Element {
   const [focused, setFocused] = useState<number | null>(0);
   const focusedPCD = pcds[focused ?? 0];
 
@@ -76,8 +76,8 @@ const Container = styled.div<{ index: number; count: number; color: string }>`
 
   > div > div {
     padding: 0;
-    border: 1px solid ${({ color }) => color};
-    box-shadow: ${({ index, count, color }) => {
+    border: 1px solid ${({ color }): string => color};
+    box-shadow: ${({ index, count, color }): string => {
       return [..._.range(-1, -index - 1, -1), ..._.range(1, count - index)]
         .map((i) => {
           const offset = i * 2;
@@ -97,15 +97,15 @@ const ButtonContainer = styled.div<{ disabled: boolean }>`
   justify-content: center;
   align-items: center;
   flex: 1 1 0;
-  cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
+  cursor: ${({ disabled }): string => (disabled ? "default" : "pointer")};
   user-select: none;
   font-size: 32px;
-  color: ${({ disabled }) =>
+  color: ${({ disabled }): string =>
     disabled ? "rgba(var(--white-rgb), 0.2)" : "rgba(var(--white-rgb), 0.8)"};
   padding: 8px;
 
   &:hover {
-    color: ${({ disabled }) =>
+    color: ${({ disabled }): string =>
       disabled ? "rgba(var(--white-rgb), 0.2)" : "rgba(var(--white-rgb), 1)"};
   }
 `;

--- a/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
@@ -44,7 +44,7 @@ export function GetFrogTab({
   userState: FrogCryptoUserStateResponseValue;
   subscriptions: Subscription[];
   refreshUserState: () => Promise<void>;
-}) {
+}): JSX.Element {
   const { value: subManager } = useSubscriptions();
   const userStateByFeedId = useMemo(
     () => _.keyBy(userState.feeds, (feed) => feed.feedId),
@@ -106,7 +106,7 @@ const SearchButton = ({
   score: number | undefined;
   subManager: FeedSubscriptionManager;
   active: boolean;
-}) => {
+}): JSX.Element => {
   const dispatch = useDispatch();
   const countDown = useCountDown(nextFetchAt || 0);
   const canFetch = active && (!nextFetchAt || nextFetchAt < Date.now());
@@ -237,7 +237,7 @@ const SearchButton = ({
 /**
  * Returns the last issued frog PCD in the frog crypto folder.
  */
-const useGetLastFrog = () => {
+const useGetLastFrog = (): (() => EdDSAFrogPCD) => {
   const pcdCollection = usePCDCollection();
   const getLastFrog = useCallback(
     () =>
@@ -260,7 +260,7 @@ const useGetLastFrog = () => {
 /**
  * Returns a random loading message that changes every 3 seconds.
  */
-const LoadingMessages = ({ biome }: { biome: string }) => {
+const LoadingMessages = ({ biome }: { biome: string }): JSX.Element => {
   const messages = useMemo(
     () => [
       `Searching ${biome}...`,
@@ -308,7 +308,7 @@ const LoadingMessages = ({ biome }: { biome: string }) => {
  * readable duration until the timestamp. Returns an empty string if the
  * timestamp is in the past.
  */
-function useCountDown(timestamp: number) {
+function useCountDown(timestamp: number): string {
   const end = useMemo(() => new Date(timestamp), [timestamp]);
   const getDiffText = useCallback((end: Date) => {
     const now = new Date();

--- a/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
@@ -17,9 +17,11 @@ import { useCredentialManager } from "../../../src/appHooks";
 import { ErrorMessage } from "../../core/error";
 import { useAdminError } from "./useAdminError";
 
-export function ManageFeedsSection() {
+export function ManageFeedsSection(): JSX.Element {
   const [newFeedsText, setNewFeedsText] = useState<string>("");
-  const onTextChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const onTextChange = (
+    event: React.ChangeEvent<HTMLTextAreaElement>
+  ): void => {
     setNewFeedsText(event.target.value);
   };
   const { newFeeds, newFeedsError } = useMemo(() => {
@@ -64,7 +66,7 @@ export function ManageFeedsSection() {
         <>
           <h2>(Preview) New/Updated Feeds</h2>
           <DataTable data={newFeeds} />
-          <button onClick={() => updateFeeds(newFeeds)}>
+          <button onClick={(): void => updateFeeds(newFeeds)}>
             Add/Update Feeds
           </button>
         </>
@@ -77,7 +79,7 @@ export function ManageFeedsSection() {
       {error && <ErrorMessage>Error fetching feeds: {error}</ErrorMessage>}
       <DataTable
         data={feeds}
-        onEditFeed={(feed) => {
+        onEditFeed={(feed): void => {
           setNewFeedsText(feedUnparser([feed]));
         }}
       />
@@ -105,7 +107,7 @@ function useFeeds(): {
   const credentialManager = useCredentialManager();
   const [pcd, setPcd] = useState<SerializedPCD>();
   useEffect(() => {
-    const fetchPcd = async () => {
+    const fetchPcd = async (): Promise<void> => {
       const pcd = await credentialManager.requestCredential({
         signatureType: "sempahore-signature-pcd"
       });
@@ -122,7 +124,7 @@ function useFeeds(): {
   useEffect(() => {
     const abortController = new AbortController();
 
-    const doRequest = async () => {
+    const doRequest = async (): Promise<void> => {
       if (!pcd) {
         setError("Waiting for PCD to be ready");
         return;
@@ -278,7 +280,7 @@ export function DataTable({
 }: {
   data: FrogCryptoDbFeedData[];
   onEditFeed?: (feed: FrogCryptoDbFeedData) => void;
-}) {
+}): JSX.Element {
   const data = rawData.map(({ uuid, feed }) => ({
     uuid,
     ...feed
@@ -302,15 +304,15 @@ export function DataTable({
       noDataMessage="No Feeds"
       customRenderCell={{
         ...keys.reduce((acc, key) => {
-          acc[key] = (row) => {
+          acc[key] = (row): any => {
             return typeof row[key] === "undefined" ? "<undefined>" : row[key];
           };
           return acc;
         }, {}),
-        private: (row) => {
+        private: (row): string => {
           return String(row["private"]);
         },
-        activeUntil: (row) => {
+        activeUntil: (row): JSX.Element | string => {
           const activeUntil = row["activeUntil"];
           if (!activeUntil) {
             return "<undefined>";
@@ -346,14 +348,14 @@ export function DataTable({
             </div>
           );
         },
-        description: (row) => {
+        description: (row): JSX.Element => {
           return (
             <Description title={row["description"]}>
               {row["description"]}
             </Description>
           );
         },
-        biomes: (row) => {
+        biomes: (row): JSX.Element | string => {
           const biomes = row["biomes"];
           if (!biomes) {
             return "<undefined>";
@@ -368,7 +370,7 @@ export function DataTable({
             </div>
           );
         },
-        codes: (row) => {
+        codes: (row): JSX.Element | string => {
           const codes = row["codes"];
           if (!codes) {
             return "<undefined>";
@@ -385,7 +387,7 @@ export function DataTable({
       containerStyle={{ maxHeight: "400px", overflow: "auto" }}
       cellStyle={{ padding: "8px" }}
       headerStyle={{ padding: "8px" }}
-      onRowEdit={(args, row) => {
+      onRowEdit={(args, row): void => {
         const feed = rawData.find((feed) => feed.uuid === row.uuid);
         onEditFeed?.(feed);
       }}

--- a/apps/passport-client/components/screens/FrogScreens/ManageFrogsSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ManageFrogsSection.tsx
@@ -15,10 +15,12 @@ import { useCredentialManager } from "../../../src/appHooks";
 import { ErrorMessage } from "../../core/error";
 import { useAdminError } from "./useAdminError";
 
-export function ManageFrogsSection() {
+export function ManageFrogsSection(): JSX.Element {
   const [newFrogs, setNewFrogs] = useState<FrogCryptoFrogData[]>([]);
   const [newFrogsError, setNewFrogsError] = useState<string>();
-  const onTextChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const onTextChange = (
+    event: React.ChangeEvent<HTMLTextAreaElement>
+  ): void => {
     try {
       const parsedData = frogParser(event.target.value);
       setNewFrogs(parsedData);
@@ -59,7 +61,7 @@ export function ManageFrogsSection() {
         <>
           <h2>(Preview) New/Updated Frogs</h2>
           <DataTable data={newFrogs} />
-          <button onClick={() => updateFrogs(newFrogs)}>
+          <button onClick={(): void => updateFrogs(newFrogs)}>
             Add/Update Frogs
           </button>
         </>
@@ -71,7 +73,7 @@ export function ManageFrogsSection() {
       {isLoading && <p>Loading...</p>}
       {error && <ErrorMessage>Error fetching frogs: {error}</ErrorMessage>}
       <button
-        onClick={() => deleteFrogs(selectedFrogIds)}
+        onClick={(): void => deleteFrogs(selectedFrogIds)}
         disabled={selectedFrogIds.length === 0}
       >
         Delete Selected Frogs{" "}
@@ -110,7 +112,7 @@ function useFrogs(): {
   const credentialManager = useCredentialManager();
   const [pcd, setPcd] = useState<SerializedPCD>();
   useEffect(() => {
-    const fetchPcd = async () => {
+    const fetchPcd = async (): Promise<void> => {
       const pcd = await credentialManager.requestCredential({
         signatureType: "sempahore-signature-pcd"
       });
@@ -129,7 +131,7 @@ function useFrogs(): {
   useEffect(() => {
     const abortController = new AbortController();
 
-    const doRequest = async () => {
+    const doRequest = async (): Promise<void> => {
       if (!pcd) {
         setError("Waiting for PCD to be ready");
         return;
@@ -268,7 +270,7 @@ export function DataTable({
   data: FrogCryptoFrogData[];
   checkedIds?: number[];
   setCheckedIds?: Dispatch<SetStateAction<number[]>>;
-}) {
+}): JSX.Element {
   const keys =
     data.length > 0
       ? _.chain(data).map(Object.keys).flatten().uniq().value()
@@ -288,12 +290,12 @@ export function DataTable({
       showMultiSelect={!!setCheckedIds}
       customRenderCell={{
         ...keys.reduce((acc, key) => {
-          acc[key] = (row) => {
+          acc[key] = (row): any => {
             return typeof row[key] === "undefined" ? "<undefined>" : row[key];
           };
           return acc;
         }, {}),
-        description: (row) => {
+        description: (row): JSX.Element => {
           return (
             <Description title={row["description"]}>
               {row["description"]}
@@ -301,14 +303,14 @@ export function DataTable({
           );
         }
       }}
-      onRowSelect={(args, row) => {
+      onRowSelect={(args, row): void => {
         setCheckedIds?.((rowIds) =>
           row.checked
             ? rowIds.filter((id) => id !== row.id)
             : [...rowIds, row.id]
         );
       }}
-      onAllRowSelect={(args, allrows) => {
+      onAllRowSelect={(args, allrows): void => {
         setCheckedIds?.((ids) =>
           ids.length === allrows.length ? [] : allrows.map((row) => row.id)
         );

--- a/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
@@ -20,7 +20,7 @@ export function ScoreTab({
 }: {
   score?: FrogCryptoScore;
   refreshScore: () => Promise<void>;
-}) {
+}): JSX.Element {
   const [scores, setScores] = useState<FrogCryptoScore[]>([]);
   const refreshScores = useCallback(async () => {
     requestFrogCryptoGetScoreboard(appConfig.zupassServer).then((res) => {
@@ -44,7 +44,7 @@ export function ScoreTab({
         score.has_telegram_username && (
           <TelegramShareButton
             score={score}
-            refreshAll={async () => {
+            refreshAll={async (): Promise<void> => {
               Promise.all([refreshScore(), refreshScores()]);
             }}
           />
@@ -73,7 +73,7 @@ function ScoreTable({
   title: string;
   scores: FrogCryptoScore[];
   myScore?: FrogCryptoScore;
-}) {
+}): JSX.Element {
   const scoresByLevel = useMemo(() => groupScores(scores), [scores]);
 
   return (
@@ -145,13 +145,13 @@ function TelegramShareButton({
 }: {
   score: FrogCryptoScore;
   refreshAll: () => Promise<void>;
-}) {
+}): JSX.Element {
   const revealed = !!score.telegram_username;
   const dispatch = useDispatch();
 
   return (
     <ActionButton
-      onClick={async () => {
+      onClick={async (): Promise<void> => {
         dispatch({
           type: "set-modal",
           modal: {
@@ -196,7 +196,7 @@ export const SCORES = [
 /**
  * Returns the emoji and title for a given score.
  */
-export function scoreToEmoji(score: number) {
+export function scoreToEmoji(score: number): string {
   const index = SCORES.findIndex((item) => item.score > score);
   if (index === -1) {
     return `${SCORES[SCORES.length - 1].emoji} ${
@@ -214,7 +214,12 @@ export function scoreToEmoji(score: number) {
 /**
  * Group the scores by level.
  */
-export function groupScores(scores: FrogCryptoScore[]) {
+export function groupScores(scores: FrogCryptoScore[]): {
+  scores: FrogCryptoScore[];
+  score: number;
+  emoji: string;
+  title: string;
+}[] {
   const groups = SCORES.map((item) => ({
     ...item,
     scores: [] as FrogCryptoScore[]

--- a/apps/passport-client/components/screens/FrogScreens/TypistText.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/TypistText.tsx
@@ -18,14 +18,14 @@ export function TypistText({
    * Action button with the label will be rendered at the end of the adventure text.
    */
   children: React.ReactNode;
-}) {
+}): JSX.Element {
   const [ready, setReady] = useState(false);
 
   return (
     <>
       <TypewriterContainer>
         <Typewriter
-          onInit={(typewriter) => {
+          onInit={(typewriter): void => {
             onInit(typewriter)
               .callFunction(() => {
                 setReady(true);

--- a/apps/passport-client/components/screens/FrogScreens/useAdminError.ts
+++ b/apps/passport-client/components/screens/FrogScreens/useAdminError.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-export function useAdminError(error: string) {
+export function useAdminError(error: string): void {
   useEffect(() => {
     if (error?.includes("not authorized")) {
       alert("you're not admin, bye bye");

--- a/apps/passport-client/components/screens/FrogScreens/useFrogParticles.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/useFrogParticles.tsx
@@ -15,11 +15,13 @@ import { Emitter } from "tsparticles-plugin-emitters/types/Options/Classes/Emitt
 
 const fpsLimit = 120;
 
-export function useFrogParticles(ref: React.RefObject<HTMLDivElement> | null) {
+export function useFrogParticles(
+  ref: React.RefObject<HTMLDivElement> | null
+): Container {
   const [ready, setReady] = useState(false);
   const [container, setContainer] = useState<Container | null>(null);
   useEffect(() => {
-    const load = async () => {
+    const load = async (): Promise<void> => {
       await loadFull(tsParticles);
       setReady(true);
     };
@@ -119,7 +121,7 @@ export function useFrogParticles(ref: React.RefObject<HTMLDivElement> | null) {
   return container;
 }
 
-export function useFrogConfetti() {
+export function useFrogConfetti(): () => Promise<void> {
   const [container, setContainer] = useState<Container | null>(null);
   // destroy confetti when component unmounts. this stops the confetti but if we
   // don't do this, confetii plays again when we switch back to GetFrog
@@ -135,7 +137,7 @@ export function useFrogConfetti() {
 
   const [ready, setReady] = useState(false);
   useEffect(() => {
-    const load = async () => {
+    const load = async (): Promise<void> => {
       await loadFull(tsParticles);
       setReady(true);
     };
@@ -340,11 +342,11 @@ export function useFrogConfetti() {
 
 export function useCelestialPondParticles(
   ref: React.RefObject<HTMLDivElement> | null
-) {
+): Container {
   const [ready, setReady] = useState(false);
   const [container, setContainer] = useState<Container | null>(null);
   useEffect(() => {
-    const load = async () => {
+    const load = async (): Promise<void> => {
       await loadFull(tsParticles);
       setReady(true);
     };
@@ -448,10 +450,10 @@ export function useCelestialPondParticles(
 
 export function useWrithingVoidParticles(
   ref: React.RefObject<HTMLDivElement> | null
-) {
+): () => Promise<Container> {
   const [ready, setReady] = useState(false);
   useEffect(() => {
-    const load = async () => {
+    const load = async (): Promise<void> => {
       await loadFull(tsParticles);
       setReady(true);
     };

--- a/apps/passport-client/components/screens/GetWithoutProvingScreen.tsx
+++ b/apps/passport-client/components/screens/GetWithoutProvingScreen.tsx
@@ -32,7 +32,7 @@ import { SyncingPCDs } from "../shared/SyncingPCDs";
  * Screen that allows the user to respond to a request from a third
  * party website asking for a particular PCD.
  */
-export function GetWithoutProvingScreen() {
+export function GetWithoutProvingScreen(): JSX.Element {
   useSyncE2EEStorage();
   const location = useLocation();
   const dispatch = useDispatch();
@@ -129,9 +129,9 @@ export function GetWithoutProvingScreen() {
           <Spacer h={16} />
           <Select
             value={options.find((o) => o.id === selectedPCDID)}
-            onChange={(o) => setSelectedPCDID(o.id)}
+            onChange={(o): void => setSelectedPCDID(o.id)}
             options={options}
-            noOptionsMessage={() => "No matching PCDs"}
+            noOptionsMessage={(): string => "No matching PCDs"}
           />
           <Spacer h={16} />
           <Button onClick={onSendClick}>Send</Button>

--- a/apps/passport-client/components/screens/HaloScreen/AddHaloScreen.tsx
+++ b/apps/passport-client/components/screens/HaloScreen/AddHaloScreen.tsx
@@ -32,7 +32,7 @@ export function AddHaloScreen({
   pk2: string;
   rnd: string;
   rndsig: string;
-}) {
+}): JSX.Element {
   const location = useLocation();
   const dispatch = useDispatch();
   const [added, setAdded] = useState(false);
@@ -42,7 +42,7 @@ export function AddHaloScreen({
   const syncSettled = useIsSyncSettled();
 
   useEffect(() => {
-    const generatePCD = async () => {
+    const generatePCD = async (): Promise<void> => {
       const args: HaLoNoncePCDArgs = {
         pk2: {
           argumentType: ArgumentTypeName.String,
@@ -85,7 +85,7 @@ export function AddHaloScreen({
     }
   }, [dispatch, pcd]);
 
-  const onLoginClick = () => {
+  const onLoginClick = (): void => {
     clearAllPendingRequests();
     setPendingHaloRequest(location.search);
     window.location.href = "/#/login?redirectedFromAction=true";

--- a/apps/passport-client/components/screens/HaloScreen/HaloScreen.tsx
+++ b/apps/passport-client/components/screens/HaloScreen/HaloScreen.tsx
@@ -11,7 +11,7 @@ import { AddHaloScreen } from "./AddHaloScreen";
  * Specific landing page for adding a HaloNoncePCD, which in the case of Zupass
  * corresponds to a specific Zuzalu Experience.
  */
-export function HaloScreen() {
+export function HaloScreen(): JSX.Element {
   useSyncE2EEStorage();
   const syncSettled = useIsSyncSettled();
   const location = useLocation();
@@ -41,7 +41,7 @@ export function HaloScreen() {
   return screen;
 }
 
-function getScreen(params: URLSearchParams) {
+function getScreen(params: URLSearchParams): JSX.Element | null {
   const pk2 = params.get("pk2");
   const rnd = params.get("rnd");
   const rndsig = params.get("rndsig");

--- a/apps/passport-client/components/screens/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen.tsx
@@ -38,7 +38,7 @@ const FOLDER_QUERY_PARAM = "folder";
 /**
  * Show the user their Zupass, an overview of cards / PCDs.
  */
-export function HomeScreenImpl() {
+export function HomeScreenImpl(): JSX.Element {
   useSyncE2EEStorage();
   const self = useSelf();
   const navigate = useNavigate();
@@ -186,7 +186,7 @@ function FolderDetails({
   folder: string;
   onFolderClick: (folder: string) => void;
   noChildFolders: boolean;
-}) {
+}): JSX.Element {
   const onUpOneClick = useCallback(() => {
     onFolderClick(getParentFolder(folder));
   }, [folder, onFolderClick]);
@@ -210,7 +210,7 @@ function FolderCard({
 }: {
   folder: string;
   onFolderClick: (folder: string) => void;
-}) {
+}): JSX.Element {
   const onClick = useCallback(() => {
     onFolderClick(folder);
   }, [folder, onFolderClick]);

--- a/apps/passport-client/components/screens/ImportBackupScreen.tsx
+++ b/apps/passport-client/components/screens/ImportBackupScreen.tsx
@@ -16,7 +16,7 @@ import { MaybeModal } from "../modals/Modal";
 import { AppContainer } from "../shared/AppContainer";
 import { ScreenNavigation } from "../shared/ScreenNavigation";
 
-export function useImportScreenState() {
+export function useImportScreenState(): { imported?: number; error?: string } {
   return useSelector<AppState["importScreen"]>((s) => s.importScreen, []);
 }
 
@@ -45,7 +45,7 @@ type ImportState =
   // The selected file is not valid.
   | { state: "invalid-file" };
 
-export function ImportBackupScreen() {
+export function ImportBackupScreen(): JSX.Element {
   // We intentionally avoid the use of useSyncE2EEStorage here, to avoid
   // background changes to the PCD collection during import
 
@@ -86,7 +86,7 @@ export function ImportBackupScreen() {
   // Responds to the user having selected a file to import, or to changes in
   // the user's current PCD collection.
   useEffect(() => {
-    (async () => {
+    (async (): Promise<void> => {
       // If a file has been selected, and isn't invalid or already imported
       if (
         filesContent.length > 0 &&
@@ -135,7 +135,7 @@ export function ImportBackupScreen() {
           // Before importing, we want to filter the PCDs down to those which
           // are valid to import, so we can tell the user how many new PCDs to
           // expect
-          const preImportFilter = (pcd: PCD) => {
+          const preImportFilter = (pcd: PCD): boolean => {
             // If the user has a semaphore identity PCD, don't import another
             if (
               userHasSemaphoreIdentity &&
@@ -263,7 +263,9 @@ export function ImportBackupScreen() {
                 To begin, select a backup file by clicking the button below.
               </p>
               <Spacer h={8} />
-              <Button onClick={() => openFilePicker()}>Select File</Button>
+              <Button onClick={(): void => openFilePicker()}>
+                Select File
+              </Button>
               <Spacer h={8} />
             </>
           )}
@@ -276,7 +278,9 @@ export function ImportBackupScreen() {
                     already have. You may try to restore from another backup.
                   </p>
                   <Spacer h={8} />
-                  <Button onClick={() => openFilePicker()}>Select File</Button>
+                  <Button onClick={(): void => openFilePicker()}>
+                    Select File
+                  </Button>
                   <Spacer h={8} />
                 </>
               )}
@@ -301,7 +305,7 @@ export function ImportBackupScreen() {
                                 checked={importState.selectedFolders.has(
                                   folder
                                 )}
-                                onChange={() => toggleFolder(folder)}
+                                onChange={(): void => toggleFolder(folder)}
                               ></input>
                               <span>
                                 {folder === "" ? "Main Folder" : folder} (
@@ -360,7 +364,9 @@ export function ImportBackupScreen() {
                 select a valid Zupass backup to import your data from.
               </p>
               <Spacer h={8} />
-              <Button onClick={() => openFilePicker()}>Select File</Button>
+              <Button onClick={(): void => openFilePicker()}>
+                Select File
+              </Button>
               <Spacer h={8} />
             </>
           )}

--- a/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
@@ -32,7 +32,7 @@ import { InlineError } from "../../shared/InlineError";
 import { PasswordInput } from "../../shared/PasswordInput";
 import { ScreenLoader } from "../../shared/ScreenLoader";
 
-export function AlreadyRegisteredScreen() {
+export function AlreadyRegisteredScreen(): JSX.Element {
   const dispatch = useDispatch();
   const self = useSelf();
   const query = useQuery();

--- a/apps/passport-client/components/screens/LoginScreens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/CreatePasswordScreen.tsx
@@ -12,7 +12,7 @@ import { AppContainer } from "../../shared/AppContainer";
 import { NewPasswordForm } from "../../shared/NewPasswordForm";
 import { ScreenLoader } from "../../shared/ScreenLoader";
 
-export function CreatePasswordScreen() {
+export function CreatePasswordScreen(): JSX.Element {
   const dispatch = useDispatch();
   const self = useSelf();
   const query = useQuery();
@@ -64,7 +64,7 @@ export function CreatePasswordScreen() {
     }
   }, [dispatch, email, token]);
 
-  const openSkipModal = () =>
+  const openSkipModal = (): void =>
     dispatch({
       type: "set-modal",
       modal: {

--- a/apps/passport-client/components/screens/LoginScreens/LoginInterstitialScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/LoginInterstitialScreen.tsx
@@ -17,7 +17,7 @@ import { CenterColumn } from "../../core";
 import { RippleLoader } from "../../core/RippleLoader";
 import { AppContainer } from "../../shared/AppContainer";
 
-export function LoginInterstitialScreen() {
+export function LoginInterstitialScreen(): JSX.Element {
   useSyncE2EEStorage();
   const navigate = useNavigate();
   const loadedIssuedPCDs = useLoadedIssuedPCDs();

--- a/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
@@ -35,7 +35,7 @@ import {
 import { AppContainer } from "../../shared/AppContainer";
 import { InlineError } from "../../shared/InlineError";
 
-export function LoginScreen() {
+export function LoginScreen(): JSX.Element {
   const dispatch = useDispatch();
   const [error, setError] = useState<string | undefined>();
   const query = useQuery();

--- a/apps/passport-client/components/screens/LoginScreens/NewPassportScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/NewPassportScreen.tsx
@@ -23,7 +23,7 @@ import { ScreenLoader } from "../../shared/ScreenLoader";
  * Show the user that we're generating their Zupass. Direct them to the email
  * verification link.
  */
-export function NewPassportScreen() {
+export function NewPassportScreen(): JSX.Element {
   const query = useQuery();
   const email = query.get("email");
 
@@ -40,7 +40,7 @@ export function NewPassportScreen() {
   return <SendEmailVerification email={email} />;
 }
 
-function SendEmailVerification({ email }: { email: string }) {
+function SendEmailVerification({ email }: { email: string }): JSX.Element {
   const identity = useIdentity();
   const dispatch = useDispatch();
   const [error, setError] = useState<string | undefined>();
@@ -200,7 +200,9 @@ function SendEmailVerification({ email }: { email: string }) {
             <Spacer h={8} />
             <ConfirmationCodeInput
               value={token}
-              onChange={(e) => setToken(e.target.value.replace(/\D/g, ""))}
+              onChange={(e): void =>
+                setToken(e.target.value.replace(/\D/g, ""))
+              }
               autoFocus
               placeholder="code from email"
             />

--- a/apps/passport-client/components/screens/LoginScreens/PrivacyNoticeScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/PrivacyNoticeScreen.tsx
@@ -5,7 +5,7 @@ import { MaybeModal } from "../../modals/Modal";
 import { AppContainer } from "../../shared/AppContainer";
 import { PrivacyNotice } from "../../shared/PrivacyNotice";
 
-export function PrivacyNoticeScreen() {
+export function PrivacyNoticeScreen(): JSX.Element {
   const query = useQuery();
   const email = query.get("email");
   const token = query.get("token");

--- a/apps/passport-client/components/screens/LoginScreens/SyncExistingScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/SyncExistingScreen.tsx
@@ -20,7 +20,7 @@ import { InlineError } from "../../shared/InlineError";
  * already logged in before. Backups happen automatically
  * on first login.
  */
-export function SyncExistingScreen() {
+export function SyncExistingScreen(): JSX.Element {
   const dispatch = useDispatch();
   const [encryptionKey, setEncryptionKey] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -39,7 +39,7 @@ export function SyncExistingScreen() {
       return;
     }
 
-    const load = async () => {
+    const load = async (): Promise<void> => {
       setIsLoading(true);
       const storageResult = await requestDownloadAndDecryptStorage(
         appConfig.zupassServer,

--- a/apps/passport-client/components/screens/MissingScreen.tsx
+++ b/apps/passport-client/components/screens/MissingScreen.tsx
@@ -3,7 +3,7 @@ import { CenterColumn, H1, Spacer, TextCenter } from "../core";
 import { LinkButton } from "../core/Button";
 import { AppContainer } from "../shared/AppContainer";
 
-export function MissingScreen() {
+export function MissingScreen(): JSX.Element {
   const loc = useLocation();
 
   return (

--- a/apps/passport-client/components/screens/NoWASMScreen.tsx
+++ b/apps/passport-client/components/screens/NoWASMScreen.tsx
@@ -2,7 +2,7 @@ import { isDuringDevconnect } from "../../src/devconnectUtils";
 import { H2, Spacer, TextCenter } from "../core";
 import { AppContainer } from "../shared/AppContainer";
 
-export function NoWASMScreen() {
+export function NoWASMScreen(): JSX.Element {
   return (
     <>
       <AppContainer bg="primary">

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
@@ -25,7 +25,11 @@ import { GenericProveSection } from "./GenericProveSection";
  * HTML input fields that users will fill in by hand. For arguments that
  * are objects, supports loading from a URL.
  */
-export function GenericProveScreen({ req }: { req: PCDGetRequest }) {
+export function GenericProveScreen({
+  req
+}: {
+  req: PCDGetRequest;
+}): JSX.Element {
   const dispatch = useDispatch();
 
   const onProve = useCallback(

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -47,7 +47,7 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
     serializedPCD: SerializedPCD<PCDOf<T>> | undefined,
     pendingPCD: PendingPCD | undefined
   ) => void;
-}) {
+}): JSX.Element {
   const rollbar = useAppRollbar();
   const pcds = usePCDCollection();
   const [args, setArgs] = useState<ArgsOf<T>>(

--- a/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
@@ -24,7 +24,7 @@ import { GenericProveScreen } from "./GenericProveScreen";
 import { SemaphoreGroupProveScreen } from "./SemaphoreGroupProveScreen";
 import { SemaphoreSignatureProveScreen } from "./SemaphoreSignatureProveScreen";
 
-export function ProveScreen() {
+export function ProveScreen(): JSX.Element {
   useSyncE2EEStorage();
   const syncSettled = useIsSyncSettled();
   const location = useLocation();
@@ -86,7 +86,7 @@ export function ProveScreen() {
   return screen;
 }
 
-function getScreen(request: PCDGetRequest) {
+function getScreen(request: PCDGetRequest): JSX.Element | null {
   if (request.type !== PCDRequestType.Get) {
     return null;
   }

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -28,7 +28,7 @@ export function SemaphoreGroupProveScreen({
   req
 }: {
   req: PCDGetRequest<typeof SemaphoreGroupPCDPackage>;
-}) {
+}): JSX.Element {
   const [error, setError] = useState<string | undefined>();
   const [group, setGroup] = useState<SerializedSemaphoreGroup | null>(null);
   const identity = useIdentity();
@@ -36,7 +36,7 @@ export function SemaphoreGroupProveScreen({
   const isLoading = group === null;
 
   useEffect(() => {
-    const fetchGroup = async () => {
+    const fetchGroup = async (): Promise<void> => {
       console.log("fetching semaphore group", req.args.group.remoteUrl);
       const semaphoreGroupResult = await requestSemaphoreGroup(
         req.args.group.remoteUrl

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
@@ -30,7 +30,7 @@ export function SemaphoreSignatureProveScreen({
   req
 }: {
   req: PCDGetRequest<typeof SemaphoreSignaturePCDPackage>;
-}) {
+}): JSX.Element {
   // Create a zero-knowledge proof using the identity in DispatchContext
   const self = useSelf();
   const identity = useIdentity();

--- a/apps/passport-client/components/screens/ScanScreen.tsx
+++ b/apps/passport-client/components/screens/ScanScreen.tsx
@@ -12,7 +12,7 @@ import { AppContainer } from "../shared/AppContainer";
 import { IndicateIfOffline } from "../shared/IndicateIfOffline";
 
 // Scan a PCD QR code, then go to /verify to verify and display the proof.
-export function ScanScreen() {
+export function ScanScreen(): JSX.Element {
   const usingLaserScanner = loadUsingLaserScanner();
   useLaserScannerKeystrokeInput();
   const nav = useNavigate();
@@ -22,7 +22,7 @@ export function ScanScreen() {
       {!usingLaserScanner && (
         <>
           <QrReader
-            onResult={(result, error) => {
+            onResult={(result, error): void => {
               if (result != null) {
                 console.log(
                   `Got result, considering redirect`,
@@ -73,7 +73,7 @@ export function ScanScreen() {
   );
 }
 
-function CloseButton() {
+function CloseButton(): JSX.Element {
   const nav = useNavigate();
   const onClose = useCallback(() => nav("/"), [nav]);
   return (
@@ -83,7 +83,7 @@ function CloseButton() {
   );
 }
 
-function ViewFinder() {
+function ViewFinder(): JSX.Element {
   return (
     <ScanOverlayWrap>
       <CloseButton />
@@ -128,15 +128,15 @@ const Guidebox = styled.div`
 
 const Corner = styled.div<{ top?: boolean; left?: boolean }>`
   position: absolute;
-  ${(p) => (p.top ? "top: 0" : "bottom: 0")};
-  ${(p) => (p.left ? "left: 0" : "right: 0")};
+  ${(p): string => (p.top ? "top: 0" : "bottom: 0")};
+  ${(p): string => (p.left ? "left: 0" : "right: 0")};
   border: 2px solid white;
-  ${(p) => (p.left ? "border-right: none" : "border-left: none")};
-  ${(p) => (p.top ? "border-bottom: none" : "border-top: none")};
+  ${(p): string => (p.left ? "border-right: none" : "border-left: none")};
+  ${(p): string => (p.top ? "border-bottom: none" : "border-top: none")};
   width: 16px;
   height: 16px;
-  ${(p) => (p.left && p.top ? "border-radius: 8px 0 0 0;" : "")};
-  ${(p) => (p.left && !p.top ? "border-radius: 0 0 0 8px;" : "")};
-  ${(p) => (!p.left && p.top ? "border-radius: 0 8px 0 0;" : "")};
-  ${(p) => (!p.left && !p.top ? "border-radius: 0 0 8px 0;" : "")};
+  ${(p): string => (p.left && p.top ? "border-radius: 8px 0 0 0;" : "")};
+  ${(p): string => (p.left && !p.top ? "border-radius: 0 0 0 8px;" : "")};
+  ${(p): string => (!p.left && p.top ? "border-radius: 0 8px 0 0;" : "")};
+  ${(p): string => (!p.left && !p.top ? "border-radius: 0 0 8px 0;" : "")};
 `;

--- a/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
+++ b/apps/passport-client/components/screens/SecondPartyTicketVerifyScreen.tsx
@@ -76,7 +76,7 @@ function isDevconnectTicket(pcd: PCD): boolean {
 // truth of the claim being made, e.g. that a ticket is a Zuzalu ticket,
 // since the presented ticket does not match any known pattern of event ID,
 // product ID and signing key.
-export function SecondPartyTicketVerifyScreen() {
+export function SecondPartyTicketVerifyScreen(): JSX.Element {
   const query = useQuery();
   const encodedQRPayload = query.get("pcd");
   const id = query.get("id");
@@ -105,7 +105,7 @@ export function SecondPartyTicketVerifyScreen() {
 
   // Verify the ticket and record the result
   useEffect(() => {
-    (async () => {
+    (async (): Promise<void> => {
       if (pcd) {
         const result = await verify(pcd, serializedPCD);
         setVerifyResult(result);
@@ -119,7 +119,7 @@ export function SecondPartyTicketVerifyScreen() {
 
   // If this is a Devconnect ticket, check the ticket
   useEffect(() => {
-    (async () => {
+    (async (): Promise<void> => {
       if (pcd && isZKEdDSAEventTicketPCD(pcd) && isDevconnectTicket(pcd)) {
         const result = await devconnectCheckByIdWithOffline(
           pcd.claim.partialTicket.ticketId,
@@ -300,7 +300,7 @@ export function SecondPartyTicketVerifyScreen() {
   );
 }
 
-function WaitingForCheckAndVerify() {
+function WaitingForCheckAndVerify(): JSX.Element {
   return (
     <AppContainer bg={"gray"}>
       <Spacer h={48} />
@@ -331,7 +331,7 @@ function VerifiedAndKnownTicket({
   publicKeyName: string;
   ticketName: string | undefined;
   eventName: string;
-}) {
+}): JSX.Element {
   return (
     <CardContainerExpanded>
       <CardOutlineExpanded>
@@ -349,13 +349,16 @@ function VerifiedAndKnownTicket({
   );
 }
 
-function useDecodedPayload(encodedQRPayload: string) {
+function useDecodedPayload(encodedQRPayload: string): {
+  pcd: PCD;
+  serializedPCD: SerializedPCD<PCD>;
+} {
   const [pcd, setPcd] = useState<PCD>(null);
   const [serializedPCD, setSerializedPCD] = useState<SerializedPCD>(null);
   const pcds = usePCDCollection();
 
   useEffect(() => {
-    (async () => {
+    (async (): Promise<void> => {
       try {
         if (encodedQRPayload) {
           // decodedPCD is a JSON.stringify'd {@link SerializedPCD}

--- a/apps/passport-client/components/screens/ServerErrorScreen.tsx
+++ b/apps/passport-client/components/screens/ServerErrorScreen.tsx
@@ -8,7 +8,7 @@ import { AppContainer } from "../shared/AppContainer";
  * Items on the screen can be filled in via the `title` and `description` query params,
  * e.g., https://zupass.org/#/server-error?title=Custom+Error&description=Your+text+here.
  */
-export function ServerErrorScreen() {
+export function ServerErrorScreen(): JSX.Element {
   const [query] = useSearchParams();
   const title = query.get("title");
   const description = query.get("description");

--- a/apps/passport-client/components/screens/SubscriptionsScreen.tsx
+++ b/apps/passport-client/components/screens/SubscriptionsScreen.tsx
@@ -18,7 +18,7 @@ import { AppContainer } from "../shared/AppContainer";
 import { ScreenNavigation } from "../shared/ScreenNavigation";
 import { SubscriptionInfoRow } from "./AddSubscriptionScreen";
 
-export function SubscriptionsScreen() {
+export function SubscriptionsScreen(): JSX.Element {
   useSyncE2EEStorage();
   const { value: subs } = useSubscriptions();
   const self = useSelf();
@@ -65,7 +65,7 @@ function SubscriptionTree({
   subscriptions
 }: {
   subscriptions: FeedSubscriptionManager;
-}) {
+}): JSX.Element {
   const byProvider = Array.from(
     subscriptions.getSubscriptionsByProvider().entries()
   );
@@ -92,7 +92,7 @@ function SingleProvider({
   subscriptions: FeedSubscriptionManager;
   providerUrl: string;
   subscriptionsList: Subscription[];
-}) {
+}): JSX.Element {
   const providerName = subscriptions.getProvider(providerUrl).providerName;
   return (
     <ProviderContainer>

--- a/apps/passport-client/components/screens/TermsScreen.tsx
+++ b/apps/passport-client/components/screens/TermsScreen.tsx
@@ -1,7 +1,7 @@
 import styled, { createGlobalStyle } from "styled-components";
 import { PrivacyNoticeText } from "../shared/PrivacyNotice";
 
-export function TermsScreen() {
+export function TermsScreen(): JSX.Element {
   return (
     <Container>
       <GlobalStyle />

--- a/apps/passport-client/components/shared/AccountExportButton.tsx
+++ b/apps/passport-client/components/shared/AccountExportButton.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../src/appHooks";
 import { LinkButton } from "../core/Button";
 
-export function AccountExportButton() {
+export function AccountExportButton(): JSX.Element {
   const user = useSelf();
   const pcds = usePCDCollection();
   const subscriptions = useSubscriptions();
@@ -21,7 +21,7 @@ export function AccountExportButton() {
   }, []);
 
   useEffect(() => {
-    (async () => {
+    (async (): Promise<void> => {
       // Since we already use this data for remote sync, we know that it's
       // sufficient for loading an account on to a new device.
       const { serializedStorage, storageHash } = await serializeStorage(

--- a/apps/passport-client/components/shared/AddedPCD.tsx
+++ b/apps/passport-client/components/shared/AddedPCD.tsx
@@ -6,7 +6,11 @@ import { Button, H1 } from "../core";
  * their Zupass. PCDs can be added by third party websites via uploading
  * a `SerializedPCD`, or by requesting a new PCD to be proved by Zupass.
  */
-export function AddedPCD({ onCloseClick }: { onCloseClick: () => void }) {
+export function AddedPCD({
+  onCloseClick
+}: {
+  onCloseClick: () => void;
+}): JSX.Element {
   return (
     <AddedPCDContainer>
       <H1>Added</H1>

--- a/apps/passport-client/components/shared/AppContainer.tsx
+++ b/apps/passport-client/components/shared/AppContainer.tsx
@@ -15,7 +15,7 @@ export function AppContainer({
 }: {
   bg: "primary" | "gray";
   children?: ReactNode;
-}) {
+}): JSX.Element {
   const dispatch = useDispatch();
   const error = useAppError();
   useUserShouldAgreeNewPrivacyNotice();
@@ -53,7 +53,7 @@ export function AppContainer({
 
 const GlobalBackground = createGlobalStyle<{ color: string }>`
   html {
-    background-color: ${(p) => p.color};
+    background-color: ${(p): string => p.color};
   }
 `;
 

--- a/apps/passport-client/components/shared/AppHeader.tsx
+++ b/apps/passport-client/components/shared/AppHeader.tsx
@@ -13,7 +13,7 @@ function AppHeaderImpl({
 }: {
   children?: React.ReactNode;
   isProveOrAddScreen?: boolean;
-}) {
+}): JSX.Element {
   const dispatch = useDispatch();
 
   const setModal = useCallback(

--- a/apps/passport-client/components/shared/IndicateIfOffline.tsx
+++ b/apps/passport-client/components/shared/IndicateIfOffline.tsx
@@ -8,7 +8,7 @@ export function IndicateIfOffline({
 }: {
   children?: React.ReactNode | React.ReactNode[];
   marginBottom?: string;
-}) {
+}): JSX.Element | undefined {
   const isOffline = useIsOffline();
   if (!isOffline) {
     return undefined;

--- a/apps/passport-client/components/shared/InlineError.tsx
+++ b/apps/passport-client/components/shared/InlineError.tsx
@@ -1,7 +1,7 @@
 import { Spacer } from "@pcd/passport-ui";
 import { ErrorMessage } from "../core/error";
 
-export function InlineError({ error }: { error?: string }) {
+export function InlineError({ error }: { error?: string }): JSX.Element {
   return (
     <>
       {error && (

--- a/apps/passport-client/components/shared/LoadingIssuedPCDs.tsx
+++ b/apps/passport-client/components/shared/LoadingIssuedPCDs.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { useLoadedIssuedPCDs } from "../../src/appHooks";
 import { RippleLoader } from "../core/RippleLoader";
 
-export function LoadingIssuedPCDs() {
+export function LoadingIssuedPCDs(): JSX.Element | null {
   const loadedIssuedPCDs = useLoadedIssuedPCDs();
 
   if (loadedIssuedPCDs) {

--- a/apps/passport-client/components/shared/MainIdentityCard.tsx
+++ b/apps/passport-client/components/shared/MainIdentityCard.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { useSelf } from "../../src/appHooks";
 import { Spacer, TextCenter } from "../core";
 
-export function MainIdentityCard({ user }: { user?: User }) {
+export function MainIdentityCard({ user }: { user?: User }): JSX.Element {
   const self = useSelf();
   const actualUser = user ?? self;
 

--- a/apps/passport-client/components/shared/NewPasswordForm.tsx
+++ b/apps/passport-client/components/shared/NewPasswordForm.tsx
@@ -37,10 +37,10 @@ export function NewPasswordForm({
   autoFocus,
   setError,
   error
-}: NewPasswordForm) {
+}: NewPasswordForm): JSX.Element {
   const confirmPasswordRef = useRef<HTMLInputElement>(null);
 
-  const checkPasswordAndSubmit = async (e: UIEvent) => {
+  const checkPasswordAndSubmit = async (e: UIEvent): Promise<void> => {
     e.preventDefault();
     if (password === "") {
       setError("Enter a password");
@@ -74,12 +74,12 @@ export function NewPasswordForm({
       <input hidden readOnly value={email} />
       <PasswordInput
         value={password}
-        setValue={(value) => {
+        setValue={(value): void => {
           setError("");
           setPassword(value);
         }}
         placeholder={passwordInputPlaceholder || "Password"}
-        onEnter={(e) => {
+        onEnter={(e): void => {
           e.preventDefault();
           confirmPasswordRef.current.focus();
         }}
@@ -93,7 +93,7 @@ export function NewPasswordForm({
         inputRef={confirmPasswordRef}
         onEnter={checkPasswordAndSubmit}
         value={confirmPassword}
-        setValue={(value) => {
+        setValue={(value): void => {
           setError("");
           setConfirmPassword(value);
         }}

--- a/apps/passport-client/components/shared/PCDArgs.tsx
+++ b/apps/passport-client/components/shared/PCDArgs.tsx
@@ -50,7 +50,7 @@ export function PCDArgs<T extends PCDPackage>({
   args: ArgsOf<T>;
   setArgs: React.Dispatch<React.SetStateAction<ArgsOf<T>>>;
   options?: ArgsDisplayOptions<ArgsOf<T>>;
-}) {
+}): JSX.Element {
   const [showAll, setShowAll] = useState(false);
   const [visible, hidden] = _.partition(
     Object.entries(args),
@@ -70,7 +70,9 @@ export function PCDArgs<T extends PCDPackage>({
       ))}
       {hidden.length > 0 && (
         <>
-          <ShowMoreButton onClick={() => setShowAll((showAll) => !showAll)}>
+          <ShowMoreButton
+            onClick={(): void => setShowAll((showAll) => !showAll)}
+          >
             {showAll ? "▼ Hide" : "▶ Show"} {hidden.length} more inputs
           </ShowMoreButton>
           {
@@ -107,7 +109,7 @@ export function ArgInput<T extends PCDPackage, ArgName extends string>({
   setArgs: React.Dispatch<React.SetStateAction<ArgsOf<T>>>;
   defaultArg?: DisplayArg<typeof arg>;
   hidden?: boolean;
-}) {
+}): JSX.Element {
   const setArg = React.useCallback(
     (value: (typeof arg)["value"]) => {
       setArgs((args) => ({
@@ -176,7 +178,7 @@ export function StringArgInput({
   arg,
   setArg,
   ...rest
-}: ArgInputProps<StringArgument>) {
+}: ArgInputProps<StringArgument>): JSX.Element {
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setArg(e.target.value);
@@ -199,7 +201,7 @@ export function NumberArgInput({
   arg,
   setArg,
   ...rest
-}: ArgInputProps<NumberArgument>) {
+}: ArgInputProps<NumberArgument>): JSX.Element {
   const [valid, setValid] = useState(true);
   const validator = useCallback((arg: string): boolean => {
     try {
@@ -242,7 +244,7 @@ export function BigIntArgInput({
   arg,
   setArg,
   ...rest
-}: ArgInputProps<BigIntArgument>) {
+}: ArgInputProps<BigIntArgument>): JSX.Element {
   const [valid, setValid] = useState(true);
   const validator = useCallback((arg: string): boolean => {
     try {
@@ -284,7 +286,7 @@ export function BooleanArgInput({
   arg,
   setArg,
   ...rest
-}: ArgInputProps<BooleanArgument>) {
+}: ArgInputProps<BooleanArgument>): JSX.Element {
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setArg(e.target.checked);
@@ -312,7 +314,7 @@ export function ObjectArgInput({
   arg,
   setArg,
   ...rest
-}: ArgInputProps<ObjectArgument<any>>) {
+}: ArgInputProps<ObjectArgument<any>>): JSX.Element {
   const [_loading, setLoading] = useState(arg.remoteUrl !== undefined);
   const [loaded, setLoaded] = useState(false);
 
@@ -360,7 +362,7 @@ function ToggleListArgInput({
   arg,
   setArg,
   ...rest
-}: ArgInputProps<ToogleListArgument<ToggleList>>) {
+}: ArgInputProps<ToogleListArgument<ToggleList>>): JSX.Element {
   const [showAll, setShowAll] = useState(arg.userProvided);
 
   const type = isRevealListArgument(arg) ? "reveal" : "default";
@@ -408,7 +410,9 @@ function ToggleListArgInput({
       {...rest}
       end={
         entries.length ? (
-          <ShowMoreButton onClick={() => setShowAll((showAll) => !showAll)}>
+          <ShowMoreButton
+            onClick={(): void => setShowAll((showAll) => !showAll)}
+          >
             {showAll ? "▲" : "▼"}
           </ShowMoreButton>
         ) : undefined
@@ -422,7 +426,7 @@ function ToggleListArgInput({
               label={getLabel(key)}
               onClick={
                 arg.userProvided
-                  ? () => setArg({ ...arg.value, [key]: !value })
+                  ? (): void => setArg({ ...arg.value, [key]: !value })
                   : undefined
               }
               checked={value}
@@ -440,7 +444,7 @@ export function PCDArgInput({
   setArg,
   isValid,
   ...rest
-}: ArgInputProps<PCDArgument>) {
+}: ArgInputProps<PCDArgument>): JSX.Element {
   const pcdCollection = usePCDCollection();
   const relevantPCDs = useMemo(
     () =>
@@ -532,7 +536,7 @@ function ArgContainer({
   children?: React.ReactNode;
   /* optional element place at the end */
   end?: React.ReactNode;
-}) {
+}): JSX.Element {
   return (
     <ArgItemContainer hidden={hidden} error={!!error}>
       {!hideIcon && (
@@ -610,13 +614,13 @@ const End = styled.div`
 const ArgItemContainer = styled.div<{ hidden: boolean; error: boolean }>`
   border-radius: 16px;
   border: 1px solid;
-  border-color: ${({ error }) =>
+  border-color: ${({ error }): string =>
     error ? "var(--danger)" : "var(--primary-lite)"};
   background-color: rgba(var(--white-rgb), 0.01);
   align-items: center;
   padding: 8px 16px;
   gap: 16px;
-  display: ${({ hidden }) => (hidden ? "none" : "flex")};
+  display: ${({ hidden }): string => (hidden ? "none" : "flex")};
 `;
 
 const ArgItemIcon = styled.img`

--- a/apps/passport-client/components/shared/PCDCard.tsx
+++ b/apps/passport-client/components/shared/PCDCard.tsx
@@ -32,7 +32,7 @@ function PCDCardImpl({
   isMainIdentity?: boolean;
   onClick?: (id: string) => void;
   hideRemoveButton?: boolean;
-}) {
+}): JSX.Element {
   const clickHandler = useCallback(() => {
     onClick(pcd.id);
   }, [onClick, pcd.id]);
@@ -73,7 +73,7 @@ function HeaderContent({
 }: {
   pcd: PCD;
   isMainIdentity: boolean;
-}) {
+}): JSX.Element {
   const pcdPackage = usePackage(pcd);
 
   const displayOptions = useMemo(() => {
@@ -104,7 +104,7 @@ function CardFooterImpl({
 }: {
   pcd: PCD;
   isMainIdentity: boolean;
-}) {
+}): JSX.Element {
   const { dispatch } = useContext(StateContext);
 
   const onRemoveClick = useCallback(() => {
@@ -142,7 +142,7 @@ function getUI(
  * of ZK proofs, and can be configured to include different URLs in their QR
  * codes based on the type of ticket provided.
  */
-function TicketWrapper({ pcd }: { pcd: EdDSATicketPCD }) {
+function TicketWrapper({ pcd }: { pcd: EdDSATicketPCD }): JSX.Element {
   const Card = EdDSATicketPCDUI.renderCardBody;
   const identityPCD = useUserIdentityPCD();
   // Only Devconnect and ZuConnect tickets support ID-based verification
@@ -168,7 +168,7 @@ function CardBody({
 }: {
   pcd: PCD;
   isMainIdentity: boolean;
-}) {
+}): JSX.Element {
   const pcdCollection = usePCDCollection();
 
   if (isMainIdentity) {

--- a/apps/passport-client/components/shared/PCDCardList.tsx
+++ b/apps/passport-client/components/shared/PCDCardList.tsx
@@ -42,7 +42,7 @@ export function PCDCardList({
    * If true, all PCDs will be expanded. Otherwise, the last clicked PCD is expanded.
    */
   allExpanded?: boolean;
-}) {
+}): JSX.Element {
   const pcdCollection = usePCDCollection();
   const userIdentityPCD = useUserIdentityPCD();
   const userIdentityPCDId = userIdentityPCD?.id;
@@ -135,7 +135,7 @@ function ToolBar({
   sortOptions: SortOption[];
   sortState: SortState;
   onSortStateChange: (sortState: SortState) => void;
-}) {
+}): JSX.Element {
   if (sortOptions.length === 0) return null;
 
   return (
@@ -143,7 +143,7 @@ function ToolBar({
       <ToolBarText>Sort:</ToolBarText>
       {sortOptions.map((o) => {
         const active = sortState.sortBy === o.key;
-        const onClick = () => {
+        const onClick = (): void => {
           if (active && sortState.sortOrder === "asc") {
             onSortStateChange({
               sortBy: o.key,
@@ -170,7 +170,7 @@ function ToolBar({
   );
 }
 
-function SortIcon({ sortOrder }: { sortOrder?: "asc" | "desc" }) {
+function SortIcon({ sortOrder }: { sortOrder?: "asc" | "desc" }): JSX.Element {
   return (
     <SortIconContainer>
       <SortIconUp active={sortOrder === "asc"} />
@@ -225,7 +225,7 @@ const SortIconUp = styled.div<{ active: boolean }>`
   border: solid 5px transparent;
   background: transparent;
   border-bottom: solid 7px
-    ${(p) =>
+    ${(p): string =>
       p.active ? "var(--accent-darker)" : "rgba(var(--white-rgb), 0.8)"};
   border-top-width: 0;
 `;
@@ -238,7 +238,7 @@ const SortIconDown = styled.div<{ active: boolean }>`
   border: solid 5px transparent;
   background: transparent;
   border-top: solid 7px
-    ${(p) =>
+    ${(p): string =>
       p.active ? "var(--accent-darker)" : "rgba(var(--white-rgb), 0.8)"};
   border-bottom-width: 0;
 `;

--- a/apps/passport-client/components/shared/PasswordInput.tsx
+++ b/apps/passport-client/components/shared/PasswordInput.tsx
@@ -31,12 +31,12 @@ export function PasswordInput({
   showStrengthProgress,
   inputRef,
   onEnter
-}: SetPasswordInputProps) {
+}: SetPasswordInputProps): JSX.Element {
   return (
     <Container>
       <PasswordBigInput
         $showStrengthProgress={showStrengthProgress}
-        onKeyDown={(e) => {
+        onKeyDown={(e): void => {
           if (e.key === "Enter") {
             onEnter?.(e);
           }
@@ -46,7 +46,7 @@ export function PasswordInput({
         type={revealPassword ? "text" : "password"}
         placeholder={placeholder}
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e): void => setValue(e.target.value)}
       />
       {showStrengthProgress && (
         <PasswordStrengthProgressContainer>
@@ -59,7 +59,7 @@ export function PasswordInput({
           src={revealPassword ? icons.eyeClosed : icons.eyeOpen}
           width={24}
           height={24}
-          onClick={() => setRevealPassword((curr) => !curr)}
+          onClick={(): void => setRevealPassword((curr) => !curr)}
         />
       </ShowHidePasswordIconContainer>
     </Container>
@@ -68,8 +68,10 @@ export function PasswordInput({
 
 const PasswordBigInput = styled(BigInput)<{ $showStrengthProgress?: boolean }>`
   /* To account for show/hide password icon. We add it to both sides to preserve center text alignment. */
-  padding-right: ${(props) => (props.$showStrengthProgress ? "64px" : "40px")};
-  padding-left: ${(props) => (props.$showStrengthProgress ? "64px" : "40px")};
+  padding-right: ${(props): string =>
+    props.$showStrengthProgress ? "64px" : "40px"};
+  padding-left: ${(props): string =>
+    props.$showStrengthProgress ? "64px" : "40px"};
 `;
 
 const Container = styled.div`

--- a/apps/passport-client/components/shared/PasswordStrengthProgress.tsx
+++ b/apps/passport-client/components/shared/PasswordStrengthProgress.tsx
@@ -48,7 +48,8 @@ const ProgressPie = styled.div<{ progress: number; progressColor: string }>`
       transparent 60% 100%
     ),
     conic-gradient(
-      ${({ progressColor }) => progressColor} ${({ progress }) => progress}%,
+      ${({ progressColor }): string => progressColor}
+        ${({ progress }): number => progress}%,
       rgba(var(--white-rgb), 0.05) 5%
     );
 `;

--- a/apps/passport-client/components/shared/PrivacyNotice.tsx
+++ b/apps/passport-client/components/shared/PrivacyNotice.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 import styled from "styled-components";
 import { Button, Spacer, SupportLink } from "../core";
 
-export function PrivacyNoticeText() {
+export function PrivacyNoticeText(): JSX.Element {
   return (
     <Prose>
       <h2>ZUPASS PRIVACY NOTICE</h2>
@@ -250,7 +250,7 @@ export function PrivacyNoticeText() {
   );
 }
 
-export function PrivacyNotice() {
+export function PrivacyNotice(): JSX.Element {
   const [expanded, setExpanded] = useState(false);
 
   const toggleExpand = useCallback(() => setExpanded(!expanded), [expanded]);

--- a/apps/passport-client/components/shared/ResendCodeButton.tsx
+++ b/apps/passport-client/components/shared/ResendCodeButton.tsx
@@ -8,7 +8,9 @@ interface ResendCodeButtonProps {
   email: string;
 }
 
-export function ResendCodeButton({ email }: ResendCodeButtonProps) {
+export function ResendCodeButton({
+  email
+}: ResendCodeButtonProps): JSX.Element {
   const identity = useIdentity();
   // If not zero, this is the number of seconds the user will have
   // to wait before clicking this button again. Technically, this
@@ -37,7 +39,9 @@ export function ResendCodeButton({ email }: ResendCodeButtonProps) {
     startTimer();
   }, [startTimer]);
 
-  const handleClick = async (event: React.FormEvent<HTMLButtonElement>) => {
+  const handleClick = async (
+    event: React.FormEvent<HTMLButtonElement>
+  ): Promise<void> => {
     event.preventDefault();
     console.log("handling click");
     await requestConfirmationEmail(

--- a/apps/passport-client/components/shared/RollbarProvider.tsx
+++ b/apps/passport-client/components/shared/RollbarProvider.tsx
@@ -3,7 +3,11 @@ import React from "react";
 import { Configuration } from "rollbar";
 import { appConfig } from "../../src/appConfig";
 
-export function RollbarProvider({ children }: { children: React.ReactNode }) {
+export function RollbarProvider({
+  children
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
   if (
     appConfig.rollbarToken === undefined ||
     appConfig.rollbarEnvName === undefined

--- a/apps/passport-client/components/shared/ScreenLoader.tsx
+++ b/apps/passport-client/components/shared/ScreenLoader.tsx
@@ -5,7 +5,7 @@ import { RippleLoader } from "../core/RippleLoader";
 
 const textDisplayTimeout = 2000;
 
-export function ScreenLoader({ text }: { text?: string }) {
+export function ScreenLoader({ text }: { text?: string }): JSX.Element {
   const [textVisible, setTextVisible] = useState(false);
 
   useEffect(() => {

--- a/apps/passport-client/components/shared/ScreenNavigation.tsx
+++ b/apps/passport-client/components/shared/ScreenNavigation.tsx
@@ -2,7 +2,13 @@ import { icons } from "@pcd/passport-ui";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
-export function ScreenNavigation({ to, label }: { to: string; label: string }) {
+export function ScreenNavigation({
+  to,
+  label
+}: {
+  to: string;
+  label: string;
+}): JSX.Element {
   return (
     <Navigation>
       <BackLink to={to}>

--- a/apps/passport-client/components/shared/Select.tsx
+++ b/apps/passport-client/components/shared/Select.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 export default function Select<Option = unknown>(
   props: React.ComponentProps<typeof ReactSelect<Option>>
-) {
+): JSX.Element {
   return <StyledSelect classNamePrefix="Select" isSearchable {...props} />;
 }
 

--- a/apps/passport-client/components/shared/Spinner.tsx
+++ b/apps/passport-client/components/shared/Spinner.tsx
@@ -1,7 +1,13 @@
 import { icons } from "@pcd/passport-ui";
 import styled from "styled-components";
 
-export function Spinner({ text, show }: { text: string; show: boolean }) {
+export function Spinner({
+  text,
+  show
+}: {
+  text: string;
+  show: boolean;
+}): JSX.Element {
   return (
     <SpinnerWithText>
       <SpinnerContainer>

--- a/apps/passport-client/components/shared/SyncingPCDs.tsx
+++ b/apps/passport-client/components/shared/SyncingPCDs.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { ScreenLoader } from "./ScreenLoader";
 
-export function SyncingPCDs() {
+export function SyncingPCDs(): JSX.Element {
   return (
     <SyncingPCDsContainer>
       <div>

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -76,14 +76,15 @@ class App extends React.Component<object, AppState> {
   activePollTimout: NodeJS.Timeout | undefined = undefined;
 
   stateEmitter: StateEmitter = new Emitter();
-  update = (diff: Pick<AppState, keyof AppState>) => {
+  update = (diff: Pick<AppState, keyof AppState>): void => {
     this.setState(diff, () => {
       this.stateEmitter.emit(this.state);
     });
   };
 
-  dispatch = (action: Action) => dispatch(action, this.state, this.update);
-  componentDidMount() {
+  dispatch = (action: Action): Promise<void> =>
+    dispatch(action, this.state, this.update);
+  componentDidMount(): void {
     loadInitialState().then((s) => this.setState(s, this.startBackgroundJobs));
     setupBroadcastChannel(this.dispatch);
     setupUsingLaserScanning();
@@ -98,7 +99,7 @@ class App extends React.Component<object, AppState> {
     update: this.update
   };
 
-  render() {
+  render(): JSX.Element {
     const { state } = this;
 
     if (!state) {
@@ -129,7 +130,7 @@ class App extends React.Component<object, AppState> {
   }
 
   // Create a React error boundary
-  static getDerivedStateFromError(error: Error) {
+  static getDerivedStateFromError(error: Error): Partial<AppState> {
     console.log("App caught error", error);
     const { message, stack } = error;
     let shortStack = stack.substring(0, 280);
@@ -139,7 +140,7 @@ class App extends React.Component<object, AppState> {
     } as Partial<AppState>;
   }
 
-  startBackgroundJobs = () => {
+  startBackgroundJobs = (): void => {
     console.log("[JOB] Starting background jobs...");
     document.addEventListener("visibilitychange", () => {
       this.setupPolling();
@@ -150,7 +151,7 @@ class App extends React.Component<object, AppState> {
     this.generateCheckinCredential();
   };
 
-  generateCheckinCredential = async () => {
+  generateCheckinCredential = async (): Promise<void> => {
     // This ensures that the check-in credential is pre-cached before the
     // first check-in attempt.
     try {
@@ -160,12 +161,12 @@ class App extends React.Component<object, AppState> {
     }
   };
 
-  jobCheckConnectivity = async () => {
+  jobCheckConnectivity = async (): Promise<void> => {
     window.addEventListener("offline", () => this.setIsOffline(true));
     window.addEventListener("online", () => this.setIsOffline(false));
   };
 
-  setIsOffline(offline: boolean) {
+  setIsOffline(offline: boolean): void {
     console.log(`[CONNECTIVITY] ${offline ? "offline" : "online"}`);
     this.update({
       ...this.state,
@@ -197,7 +198,7 @@ class App extends React.Component<object, AppState> {
    * scheduled.  It may happen immediately after the window becomes visible,
    * but never less than than BG_POLL_INTERVAL_MS after the previous poll.
    */
-  setupPolling = async () => {
+  setupPolling = async (): Promise<void> => {
     if (!document.hidden) {
       if (!this.activePollTimout) {
         const nextPollDelay = Math.max(
@@ -225,7 +226,7 @@ class App extends React.Component<object, AppState> {
    * Periodic job for polling the server.  Is scheduled by setupPolling, and
    * will reschedule itself in the same way.
    */
-  jobPollServerUpdates = async () => {
+  jobPollServerUpdates = async (): Promise<void> => {
     // Mark that poll has started.
     console.log("[JOB] polling server for updates");
     this.activePollTimout = undefined;
@@ -239,7 +240,7 @@ class App extends React.Component<object, AppState> {
     }
   };
 
-  doPollServerUpdates = async () => {
+  doPollServerUpdates = async (): Promise<void> => {
     if (
       !this.state?.self ||
       !!this.state.userInvalid ||
@@ -267,12 +268,12 @@ class App extends React.Component<object, AppState> {
     }
   };
 
-  async startJobSyncOfflineCheckins() {
+  async startJobSyncOfflineCheckins(): Promise<void> {
     await this.jobSyncOfflineCheckins();
     setInterval(this.jobSyncOfflineCheckins, 1000 * 60);
   }
 
-  jobSyncOfflineCheckins = async () => {
+  jobSyncOfflineCheckins = async (): Promise<void> => {
     if (!this.state.self || this.state.offline) {
       return;
     }
@@ -317,7 +318,7 @@ class App extends React.Component<object, AppState> {
 
 const Router = React.memo(RouterImpl);
 
-function RouterImpl() {
+function RouterImpl(): JSX.Element {
   return (
     <HashRouter>
       <Routes>
@@ -381,7 +382,7 @@ function RouterImpl() {
  * on the scan screen so the laser scanner can be used. This flag will be
  * exclusively used on the Devconnect laser scanning devices.
  */
-function setupUsingLaserScanning() {
+function setupUsingLaserScanning(): void {
   const queryParams = new URLSearchParams(window.location.search.slice(1));
   const laserQueryParam = queryParams.get("laser");
   if (laserQueryParam === "true") {

--- a/apps/passport-client/src/appHooks.ts
+++ b/apps/passport-client/src/appHooks.ts
@@ -65,7 +65,7 @@ export function usePCDsInFolder(folder: string): PCD[] {
   return [...pcds.getAllPCDsInFolder(folder)];
 }
 
-export function useFolders(path: string) {
+export function useFolders(path: string): string[] {
   const pcds = usePCDCollection();
   return pcds.getFoldersInFolder(path);
 }
@@ -212,13 +212,13 @@ export function useSubscriptions(): Wrapper<FeedSubscriptionManager> {
 }
 
 // Hook that checks whether the user has set a password for their account
-export function useHasSetupPassword() {
+export function useHasSetupPassword(): boolean {
   const self = useSelf();
   return hasSetupPassword(self);
 }
 
 // Hook that when invoked, requires the user to set a password if they haven't already
-export function useRequirePassword() {
+export function useRequirePassword(): void {
   const self = useSelf();
   const hasSetupPassword = useHasSetupPassword();
   const dispatch = useDispatch();
@@ -233,13 +233,13 @@ export function useRequirePassword() {
 }
 
 // Hook that enables keystrokes to properly listen to laser scanning inputs from supported devices
-export function useLaserScannerKeystrokeInput() {
+export function useLaserScannerKeystrokeInput(): string {
   const [typedText, setTypedText] = useState("");
   const nav = useNavigate();
   const usingLaserScanner = loadUsingLaserScanner();
 
   useEffect(() => {
-    function handleKeyDown(event: KeyboardEvent) {
+    function handleKeyDown(event: KeyboardEvent): void {
       if (!usingLaserScanner) return;
       if (event.key === "Enter") {
         // Get the verify URL from the keystroke input and navigate to the last match, if it exists

--- a/apps/passport-client/src/broadcastChannel.ts
+++ b/apps/passport-client/src/broadcastChannel.ts
@@ -47,7 +47,7 @@ export function setupBroadcastChannel(
   if (channel === null) {
     channel = new BroadcastChannel(CHANNEL_NAME);
   }
-  channel.onmessage = (msg) => {
+  channel.onmessage = (msg): void => {
     // NOTE: We're using the "broadcast-channel" package which supports all
     // browsers, not the native BroadcastChannel API.  They have a subtly
     // different interface.  In particular, we get our message directly as an

--- a/apps/passport-client/src/defaultSubscriptions.ts
+++ b/apps/passport-client/src/defaultSubscriptions.ts
@@ -16,7 +16,7 @@ export function isDefaultSubscription(sub: Subscription): boolean {
 
 export async function addDefaultSubscriptions(
   subscriptions: FeedSubscriptionManager
-) {
+): Promise<void> {
   if (!subscriptions.hasProvider(DEFAULT_FEED_URL)) {
     subscriptions.addProvider(DEFAULT_FEED_URL, DEFAULT_FEED_PROVIDER_NAME);
   }

--- a/apps/passport-client/src/devconnectUtils.ts
+++ b/apps/passport-client/src/devconnectUtils.ts
@@ -1,6 +1,6 @@
 import { DEVCONNECT_2023_END, DEVCONNECT_2023_START } from "./sharedConstants";
 
-export function isDuringDevconnect() {
+export function isDuringDevconnect(): boolean {
   const currentTimeMs = new Date().getTime();
   return (
     currentTimeMs >= DEVCONNECT_2023_START &&
@@ -8,7 +8,7 @@ export function isDuringDevconnect() {
   );
 }
 
-export function getOutdatedBrowserErrorMessage() {
+export function getOutdatedBrowserErrorMessage(): string {
   let outdatedBrowserErrorMessage =
     "Proof failed. Please update your browser and device to the latest version. ";
   outdatedBrowserErrorMessage += isDuringDevconnect()

--- a/apps/passport-client/src/emitter.ts
+++ b/apps/passport-client/src/emitter.ts
@@ -10,7 +10,7 @@ export class Emitter<T> {
     return () => this.listeners.delete(l);
   }
 
-  public emit(t: T) {
+  public emit(t: T): void {
     for (const listener of this.listeners) {
       listener(t);
     }

--- a/apps/passport-client/src/localstorage.ts
+++ b/apps/passport-client/src/localstorage.ts
@@ -80,7 +80,9 @@ export async function loadSubscriptions(): Promise<FeedSubscriptionManager> {
 }
 
 const OFFLINE_TICKETS_KEY = "offline_tickets";
-export function saveOfflineTickets(offlineTickets: OfflineTickets | undefined) {
+export function saveOfflineTickets(
+  offlineTickets: OfflineTickets | undefined
+): void {
   if (!offlineTickets) {
     window.localStorage.removeItem(OFFLINE_TICKETS_KEY);
   } else {
@@ -108,7 +110,7 @@ export function loadOfflineTickets(): OfflineTickets {
 const CHECKED_IN_OFFLINE_TICKETS_KEY = "checked_in_offline_devconnect_tickets";
 export function saveCheckedInOfflineTickets(
   offlineTickets: OfflineDevconnectTicket[]
-) {
+): void {
   if (!offlineTickets) {
     window.localStorage.removeItem(CHECKED_IN_OFFLINE_TICKETS_KEY);
   } else {
@@ -220,11 +222,11 @@ export function loadPersistentSyncStatus(): PersistentSyncStatus {
   }
 }
 
-export function saveUsingLaserScanner(usingLaserScanner: boolean) {
+export function saveUsingLaserScanner(usingLaserScanner: boolean): void {
   window.localStorage["using_laser_scanner"] = usingLaserScanner.toString();
 }
 
-export function loadUsingLaserScanner() {
+export function loadUsingLaserScanner(): boolean {
   return window.localStorage["using_laser_scanner"] === "true";
 }
 

--- a/apps/passport-client/src/passportRequest.ts
+++ b/apps/passport-client/src/passportRequest.ts
@@ -31,7 +31,7 @@ export function validateRequest<T extends PCDRequest>(
 }
 
 // A javascript:... returnUrl allows a caller to exfiltrate user secrets.
-function validateReturnUrl(returnUrl: string) {
+function validateReturnUrl(returnUrl: string): void {
   const url = new URL(returnUrl);
   if (url.protocol === "https:") return;
   if (url.protocol === "http:" && url.hostname === "localhost") return;
@@ -39,14 +39,20 @@ function validateReturnUrl(returnUrl: string) {
 }
 
 // Redirects to the returnUrl with a pending server proof in the query string.
-export function safeRedirectPending(returnUrl: string, pendingPCD: PendingPCD) {
+export function safeRedirectPending(
+  returnUrl: string,
+  pendingPCD: PendingPCD
+): void {
   validateReturnUrl(returnUrl);
   const encPCD = encodeURIComponent(JSON.stringify(pendingPCD));
   window.location.href = `${returnUrl}?encodedPendingPCD=${encPCD}`;
 }
 
 // Redirects to the returnUrl with the serialized PCD in the query string.
-export function safeRedirect(returnUrl: string, serializedPCD?: SerializedPCD) {
+export function safeRedirect(
+  returnUrl: string,
+  serializedPCD?: SerializedPCD
+): void {
   validateReturnUrl(returnUrl);
   const hasQuery = returnUrl.includes("?");
   const queryMarker = hasQuery ? "&" : "?";

--- a/apps/passport-client/src/password.ts
+++ b/apps/passport-client/src/password.ts
@@ -26,7 +26,7 @@ export const setPassword = async (
   knownServerStorageRevision: string | undefined,
   dispatch: Dispatcher,
   update: ZuUpdate
-) => {
+): Promise<void> => {
   const crypto = await PCDCrypto.newInstance();
   const { salt: newSalt, key: newEncryptionKey } =
     await crypto.generateSaltAndEncryptionKey(newPassword);

--- a/apps/passport-client/src/registerServiceWorker.ts
+++ b/apps/passport-client/src/registerServiceWorker.ts
@@ -12,7 +12,7 @@ import { SERVICE_WORKER_ENABLED } from "./sharedConstants";
  * its caching of application code does not interfere with quick
  * iteration loops.
  */
-export async function registerServiceWorker() {
+export async function registerServiceWorker(): Promise<void> {
   if (!("serviceWorker" in navigator)) {
     console.log(`[SERVICE_WORKER] service workers not supported`);
     return;

--- a/apps/passport-client/src/useDeserialized.tsx
+++ b/apps/passport-client/src/useDeserialized.tsx
@@ -14,7 +14,7 @@ export function useDeserialized(pcd: SerializedPCD): {
   const [error, setError] = useState<Error | undefined>();
 
   useEffect(() => {
-    async function process() {
+    async function process(): Promise<void> {
       try {
         console.log("deserializing", pcd);
         const pcdPackage = pcds.getPackage(pcd.type);

--- a/apps/passport-client/src/useSyncE2EEStorage.tsx
+++ b/apps/passport-client/src/useSyncE2EEStorage.tsx
@@ -283,7 +283,10 @@ export async function mergeStorage(
     (await localFields.pcds.getHash()) != (await remoteFields.pcds.getHash())
   ) {
     identicalPCDs = false;
-    const pcdMergePredicate = (pcd: PCD, remotePCDs: PCDCollection) => {
+    const pcdMergePredicate = (
+      pcd: PCD,
+      remotePCDs: PCDCollection
+    ): boolean => {
       if (remotePCDs.hasPCDWithId(pcd.id)) {
         return false;
       } else {
@@ -532,7 +535,7 @@ export async function tryDeserializeNewStorage(
   }
 }
 
-export function useSyncE2EEStorage() {
+export function useSyncE2EEStorage(): void {
   const { dispatch } = useContext(StateContext);
 
   const load = useCallback(() => {

--- a/apps/passport-client/src/user.ts
+++ b/apps/passport-client/src/user.ts
@@ -8,7 +8,10 @@ import { appConfig } from "./appConfig";
 import { Dispatcher } from "./dispatch";
 
 // Starts polling the user from the server, in the background.
-export async function pollUser(self: User, dispatch: Dispatcher) {
+export async function pollUser(
+  self: User,
+  dispatch: Dispatcher
+): Promise<void> {
   try {
     console.log("[USER_POLL] polling user");
     const response = await requestUser(appConfig.zupassServer, self.uuid);
@@ -38,7 +41,7 @@ export async function pollUser(self: User, dispatch: Dispatcher) {
 }
 
 // Function that checks whether the user has set a password for their account
-export function hasSetupPassword(user: User) {
+export function hasSetupPassword(user: User): boolean {
   return user != null && user.salt != null;
 }
 
@@ -58,7 +61,7 @@ export function findIdentityPCD(
       (pcd as SemaphoreIdentityPCD).claim.identity.commitment.toString() ===
       identityCommitment
     ) {
-      return pcd;
+      return pcd as SemaphoreIdentityPCD;
     }
   }
   return undefined;

--- a/apps/passport-client/src/util.ts
+++ b/apps/passport-client/src/util.ts
@@ -10,21 +10,25 @@ export function assertUnreachable(_: never): never {
   throw new Error("Unreachable");
 }
 
-export function getHost(returnURL: string) {
+export function getHost(returnURL: string): string {
   const url = new URL(returnURL);
   return url.host;
 }
 
-export function getOrigin(returnURL: string) {
+export function getOrigin(returnURL: string): string {
   const url = new URL(returnURL);
   return url.origin;
 }
 
-export async function nextFrame() {
+export async function nextFrame(): Promise<void> {
   await sleep(50);
 }
 
-export function err(dispatch: Dispatcher, title: string, message: string) {
+export function err(
+  dispatch: Dispatcher,
+  title: string,
+  message: string
+): void {
   dispatch({
     type: "error",
     error: { title, message }
@@ -50,7 +54,7 @@ export function bigintToUuid(bigint: bigint): string {
   );
 }
 
-export function randomEmail() {
+export function randomEmail(): string {
   return uuid().slice(0, 8) + "@test.com";
 }
 
@@ -71,7 +75,7 @@ function getVerifyUrlPrefixes(): string[] {
 
 // Given an input string, check if there exists a ticket verify URL within it.
 // If so, return the last occurance of a verify URL. If not, return null.
-export function getLastValidVerifyUrl(inputString: string) {
+export function getLastValidVerifyUrl(inputString: string): string {
   const lastValidUrlStartIdx = _.chain(getVerifyUrlPrefixes())
     .map((verifyUrlPrefix) => inputString.lastIndexOf(verifyUrlPrefix))
     .max()

--- a/apps/passport-client/src/worker/service-worker.ts
+++ b/apps/passport-client/src/worker/service-worker.ts
@@ -90,10 +90,10 @@ function cacheNameForLog(cacheName: string): string {
  */
 const swLog = {
   tag: `[SERVICE_WORKER][${SW_BUILD_ID.substring(0, 4)}]`,
-  I: function (msg: any) {
+  I: function (msg: any): void {
     console.log(this.tag, msg);
   },
-  V: function (msg: any) {
+  V: function (msg: any): void {
     console.debug(this.tag, msg);
   }
 };
@@ -120,7 +120,7 @@ self.addEventListener("install", (event: ExtendableEvent) => {
   }
 
   event.waitUntil(
-    (async () => {
+    (async (): Promise<void> => {
       // Pre-populate our cache with all the resources to operate offline.
       await prePopulateCaches();
 
@@ -141,7 +141,7 @@ self.addEventListener("activate", (event: ExtendableEvent) => {
       windows ${SW_BUILD_ID}`
     );
     event.waitUntil(
-      (async () => {
+      (async (): any => {
         await swSelf.clients.claim();
         await swSelf.registration.unregister();
         for (const client of await swSelf.clients.matchAll()) {
@@ -155,7 +155,7 @@ self.addEventListener("activate", (event: ExtendableEvent) => {
   swLog.V(`activating ${SW_BUILD_ID}`);
 
   event.waitUntil(
-    (async () => {
+    (async (): Promise<void> => {
       // If supported, NavigationPreload allows fetches to start in parallel to
       // the running of our fetch event handler, as well as the bootup time of
       // an idle service-worker.  It's worth enabling to reduce latency.
@@ -190,7 +190,7 @@ self.addEventListener("fetch", (event: FetchEvent) => {
 
   swLog.V(`fetching ${event.request?.url}`);
   event.respondWith(
-    (async () => {
+    (async (): Promise<void> => {
       // Check stable cache first.  If we get a hit, we never fetch.
       const stableResp = await checkStableCache(event.request);
       if (stableResp) {

--- a/apps/passport-client/test/stateValidation.spec.ts
+++ b/apps/passport-client/test/stateValidation.spec.ts
@@ -82,7 +82,7 @@ describe("validateAppState", async function () {
         TAG_STR,
         undefined,
         undefined,
-        await (async () => {
+        await (async (): Promise<PCDCollection> => {
           const collection = new PCDCollection(pcdPackages);
           collection.add(await newEdSAPCD());
           return collection;

--- a/packages/lib/emitter/src/emitter.ts
+++ b/packages/lib/emitter/src/emitter.ts
@@ -10,7 +10,7 @@ export class Emitter<T = void> {
     return () => this.listeners.delete(l);
   }
 
-  public emit(t: T) {
+  public emit(t: T): void {
     for (const listener of Array.from(this.listeners)) {
       listener(t);
     }

--- a/packages/lib/emitter/test/emitter.spec.ts
+++ b/packages/lib/emitter/test/emitter.spec.ts
@@ -9,7 +9,7 @@ describe("Emitter", async function () {
   it("should call listeners on event emission", function () {
     const emitter = new Emitter<number>();
 
-    const callback = function (_number: number) {
+    const callback = function (_number: number): void {
       //
     };
 

--- a/packages/lib/passport-crypto/src/endToEndEncryption.ts
+++ b/packages/lib/passport-crypto/src/endToEndEncryption.ts
@@ -3,7 +3,7 @@ import { EncryptedPacket } from "./types";
 
 const cryptoPromise = PCDCrypto.newInstance();
 
-export async function getHash(str: string) {
+export async function getHash(str: string): Promise<string> {
   const crypto = await cryptoPromise;
   const hashed = crypto.cryptoHash(str);
   return hashed;

--- a/packages/lib/passport-crypto/src/libsodium.ts
+++ b/packages/lib/passport-crypto/src/libsodium.ts
@@ -1,5 +1,6 @@
 import _sodium from "libsodium-wrappers-sumo";
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function getSodium() {
   await _sodium.ready.catch((err) => {
     console.error("[Worker] libsodium error:", err);

--- a/packages/lib/passport-crypto/src/passportCrypto.ts
+++ b/packages/lib/passport-crypto/src/passportCrypto.ts
@@ -10,7 +10,7 @@ import { arrayBufferToHexString } from "./utils";
 export class PCDCrypto {
   private sodium: Sodium;
 
-  public static async newInstance() {
+  public static async newInstance(): Promise<PCDCrypto> {
     const sodium = await getSodium();
     return new PCDCrypto(sodium);
   }
@@ -19,7 +19,7 @@ export class PCDCrypto {
     this.sodium = sodium;
   }
 
-  public cryptoHash(str: string) {
+  public cryptoHash(str: string): string {
     return arrayBufferToHexString(this.sodium.crypto_hash(str));
   }
 
@@ -35,7 +35,10 @@ export class PCDCrypto {
    * Combines generateSalt and argon2 function, returns both a random salt
    * and the resulting 32-byte encryption key.
    */
-  public generateSaltAndEncryptionKey(password: Utf8String) {
+  public generateSaltAndEncryptionKey(password: Utf8String): {
+    key: string;
+    salt: string;
+  } {
     const salt = this.generateSalt();
     const key = this.argon2(password, salt, 32);
     return { key, salt };

--- a/packages/lib/passport-interface/src/EncryptedStorage.ts
+++ b/packages/lib/passport-interface/src/EncryptedStorage.ts
@@ -129,6 +129,8 @@ export async function serializeStorage(
 /**
  * Calculates a hash to uniquely identify the given seralized storage.
  */
-export async function getStorageHash(storage: SyncedEncryptedStorage) {
+export async function getStorageHash(
+  storage: SyncedEncryptedStorage
+): Promise<string> {
   return await getHash(stringify(storage));
 }

--- a/packages/lib/passport-interface/src/FeedCredential.ts
+++ b/packages/lib/passport-interface/src/FeedCredential.ts
@@ -54,7 +54,7 @@ async function deserializeAndVerify(
 export async function verifyFeedCredential(
   serializedPCD: SerializedPCD<SemaphoreSignaturePCD>,
   pcdVerifier?: (pcd: SerializedPCD<SemaphoreSignaturePCD>) => Promise<boolean>
-) {
+): Promise<{ pcd: SemaphoreSignaturePCD; payload: FeedCredentialPayload }> {
   if (pcdVerifier === undefined) {
     pcdVerifier = deserializeAndVerify;
   }

--- a/packages/lib/passport-interface/src/PassportInterface.ts
+++ b/packages/lib/passport-interface/src/PassportInterface.ts
@@ -60,7 +60,7 @@ export function getWithoutProvingUrl(
   zupassClientUrl: string,
   returnUrl: string,
   pcdType: string
-) {
+): string {
   const req: PCDGetWithoutProvingRequest = {
     type: PCDRequestType.GetWithoutProving,
     pcdType,
@@ -76,7 +76,7 @@ export function constructZupassPcdGetRequestUrl<T extends PCDPackage>(
   pcdType: T["name"],
   args: ArgsOf<T>,
   options?: ProveOptions
-) {
+): string {
   const req: PCDGetRequest<T> = {
     type: PCDRequestType.Get,
     returnUrl: returnUrl,
@@ -92,7 +92,7 @@ export function constructZupassPcdAddRequestUrl(
   zupassClientUrl: string,
   returnUrl: string,
   pcd: SerializedPCD
-) {
+): string {
   const req: PCDAddRequest = {
     type: PCDRequestType.Add,
     returnUrl: returnUrl,
@@ -111,7 +111,7 @@ export function constructZupassPcdProveAndAddRequestUrl<
   args: ArgsOf<T>,
   options?: ProveOptions,
   returnPCD?: boolean
-) {
+): string {
   const req: PCDProveAndAddRequest = {
     type: PCDRequestType.ProveAndAdd,
     returnUrl: returnUrl,

--- a/packages/lib/passport-interface/src/PassportPopup.ts
+++ b/packages/lib/passport-interface/src/PassportPopup.ts
@@ -4,13 +4,13 @@ import { useEffect, useState } from "react";
  * React hook that listens for PCDs and PendingPCDs from a Zupass popup window
  * using message passing and event listeners.
  */
-export function useZupassPopupMessages() {
+export function useZupassPopupMessages(): [string, string] {
   const [pcdStr, setPCDStr] = useState("");
   const [pendingPCDStr, setPendingPCDStr] = useState("");
 
   // Listen for PCDs coming back from the Zupass popup
   useEffect(() => {
-    function receiveMessage(ev: MessageEvent<any>) {
+    function receiveMessage(ev: MessageEvent<any>): void {
       // Extensions including Metamask apparently send messages to every page. Ignore those.
       if (ev.data.encodedPCD) {
         console.log("Received PCD", ev.data.encodedPCD);
@@ -21,7 +21,7 @@ export function useZupassPopupMessages() {
       }
     }
     window.addEventListener("message", receiveMessage, false);
-    return () => window.removeEventListener("message", receiveMessage);
+    return (): void => window.removeEventListener("message", receiveMessage);
   }, []);
 
   return [pcdStr, pendingPCDStr];
@@ -35,7 +35,7 @@ export function useZupassPopupMessages() {
  * that can be processed by the `useZupassPopupMessages` hook. PendingPCD requests
  * can further be processed by `usePendingPCD` and `usePCDMultiplexer`.
  */
-export function useZupassPopupSetup() {
+export function useZupassPopupSetup(): string {
   // Usually this page redirects immediately. If not, show an error.
   const [error, setError] = useState("");
 
@@ -99,7 +99,7 @@ export function useZupassPopupSetup() {
  * and popupUrl, which is the route where the useZupassPopupSetup hook is being
  * served from.
  */
-export function openZupassPopup(popupUrl: string, proofUrl: string) {
+export function openZupassPopup(popupUrl: string, proofUrl: string): void {
   const url = `${popupUrl}?proofUrl=${encodeURIComponent(proofUrl)}`;
   window.open(url, "_blank", "width=450,height=600,top=100,popup");
 }

--- a/packages/lib/passport-interface/src/PendingPCDIntegration.ts
+++ b/packages/lib/passport-interface/src/PendingPCDIntegration.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { requestServerProofStatus } from "./api/requestServerProofStatus";
 import { PendingPCD, PendingPCDStatus } from "./PendingPCDUtils";
+import { requestServerProofStatus } from "./api/requestServerProofStatus";
 
 /**
  * React hook that pings server on status of a PendingPCD. Returns a serialized
@@ -19,7 +19,7 @@ export function usePendingPCD(
   useEffect(() => {
     let interval: NodeJS.Timeout | undefined = undefined;
 
-    const getProofStatus = async () => {
+    const getProofStatus = async (): Promise<void> => {
       if (pendingPCDStr !== undefined && pendingPCDStr !== "") {
         const pendingPCD: PendingPCD = JSON.parse(pendingPCDStr);
 

--- a/packages/lib/passport-interface/src/PendingPCDUtils.ts
+++ b/packages/lib/passport-interface/src/PendingPCDUtils.ts
@@ -33,7 +33,7 @@ export enum PendingPCDStatus {
   NONE = "none"
 }
 
-export function isSettledPendingPCDStatus(status: PendingPCDStatus) {
+export function isSettledPendingPCDStatus(status: PendingPCDStatus): boolean {
   return [
     PendingPCDStatus.ERROR,
     PendingPCDStatus.COMPLETE,

--- a/packages/lib/passport-interface/src/SemaphoreGroupIntegration.ts
+++ b/packages/lib/passport-interface/src/SemaphoreGroupIntegration.ts
@@ -30,7 +30,7 @@ export function openGroupMembershipPopup(
   originalSiteName: string,
   signal?: string,
   externalNullifier?: string
-) {
+): void {
   const proofUrl = constructZupassPcdGetRequestUrl<
     typeof SemaphoreGroupPCDPackage
   >(
@@ -82,7 +82,11 @@ export function useSemaphoreGroupProof(
   originalSiteName: string,
   onVerified: (valid: boolean) => void,
   externalNullifier?: string
-) {
+): {
+  proof: SemaphoreGroupPCD | undefined;
+  group: SerializedSemaphoreGroup | undefined;
+  error: string | undefined;
+} {
   const semaphoreGroupPCD = useSerializedPCD(SemaphoreGroupPCDPackage, pcdStr);
   const [error, setError] = useState<string | undefined>();
   const [semaphoreGroup, setGroup] = useState<SerializedSemaphoreGroup>();

--- a/packages/lib/passport-interface/src/SemaphoreSignatureIntegration.ts
+++ b/packages/lib/passport-interface/src/SemaphoreSignatureIntegration.ts
@@ -1,6 +1,9 @@
 import { ArgumentTypeName } from "@pcd/pcd-types";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
-import { SemaphoreSignaturePCDPackage } from "@pcd/semaphore-signature-pcd";
+import {
+  SemaphoreSignaturePCD,
+  SemaphoreSignaturePCDPackage
+} from "@pcd/semaphore-signature-pcd";
 import { useEffect } from "react";
 import { constructZupassPcdGetRequestUrl } from "./PassportInterface";
 import { openZupassPopup } from "./PassportPopup";
@@ -19,7 +22,7 @@ export function openSemaphoreSignaturePopup(
   popupUrl: string,
   messageToSign: string,
   proveOnServer?: boolean
-) {
+): void {
   const proofUrl = constructZupassPcdGetRequestUrl<
     typeof SemaphoreSignaturePCDPackage
   >(
@@ -64,7 +67,7 @@ export function openSignedZuzaluUUIDPopup(
   urlToZupassClient: string,
   popupUrl: string,
   originalSiteName: string
-) {
+): void {
   const proofUrl = constructZupassPcdGetRequestUrl<
     typeof SemaphoreSignaturePCDPackage
   >(
@@ -107,7 +110,7 @@ export function openSignedZuzaluSignInPopup(
   zupassClientUrl: string,
   popupUrl: string,
   originalSiteName: string
-) {
+): void {
   const proofUrl = constructZupassPcdGetRequestUrl<
     typeof SemaphoreSignaturePCDPackage
   >(
@@ -142,7 +145,7 @@ export function openSignedZuzaluSignInPopup(
 export function useSemaphoreSignatureProof(
   pcdStr: string,
   onVerified: (valid: boolean) => void
-) {
+): { signatureProof: SemaphoreSignaturePCD | undefined } {
   const semaphoreSignaturePCD = useSerializedPCD(
     SemaphoreSignaturePCDPackage,
     pcdStr

--- a/packages/lib/passport-interface/src/SerializedPCDIntegration.ts
+++ b/packages/lib/passport-interface/src/SerializedPCDIntegration.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 export function useSerializedPCD<T extends PCDPackage>(
   proofPackage: T,
   serializedPCD: string
-) {
+): PCDOf<T> | undefined {
   const [pcd, setPCD] = useState<PCDOf<T>>();
 
   useEffect(() => {

--- a/packages/lib/passport-interface/src/SubscriptionManager.ts
+++ b/packages/lib/passport-interface/src/SubscriptionManager.ts
@@ -122,7 +122,7 @@ export class FeedSubscriptionManager {
       .getSubscriptionsByProvider()
       .entries()) {
       // Copy provider if not already known.
-      const ensureProvider = () => {
+      const ensureProvider = (): void => {
         if (!this.hasProvider(providerUrl)) {
           const otherProvider = other.getProvider(providerUrl);
           if (otherProvider === undefined) return; // other's state is illegal?
@@ -213,7 +213,7 @@ export class FeedSubscriptionManager {
   public async pollSingleSubscription(
     subscription: Subscription,
     credentialManager: CredentialManagerAPI
-  ) {
+  ): Promise<SubscriptionActions[]> {
     const actions = await this.fetchSingleSubscription(
       subscription,
       credentialManager
@@ -272,7 +272,10 @@ export class FeedSubscriptionManager {
   /**
    * Validates that the actions received in a feed are permitted by the user.
    */
-  private validateActions(subscription: Subscription, actions: PCDAction[]) {
+  private validateActions(
+    subscription: Subscription,
+    actions: PCDAction[]
+  ): void {
     const grantedPermissions = subscription.feed.permissions;
     const failedActions: PCDAction[] = [];
     for (const action of actions) {
@@ -478,7 +481,7 @@ export class FeedSubscriptionManager {
     providerUrl: string,
     providerName: string,
     timestampAdded?: number
-  ) {
+  ): SubscriptionProvider {
     if (this.hasProvider(providerUrl)) {
       throw new Error(`provider ${providerUrl} already exists`);
     }

--- a/packages/lib/passport-interface/src/User.ts
+++ b/packages/lib/passport-interface/src/User.ts
@@ -6,13 +6,13 @@ export function useFetchUser(
   zupassServerUrl: string,
   isZuzalu: boolean,
   uuid?: string
-) {
+): { user: User | null; error: string | null; loading: boolean } {
   const [user, setUser] = useState<User | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    const doLoad = async () => {
+    const doLoad = async (): Promise<void> => {
       if (uuid == undefined) {
         setUser(null);
         setError(null);

--- a/packages/lib/passport-interface/src/api/apiResult.ts
+++ b/packages/lib/passport-interface/src/api/apiResult.ts
@@ -53,7 +53,7 @@ export interface NamedAPIError {
 /**
  * Format a user-readable error message from a NamedAPIError instance.
  */
-export function getNamedAPIErrorMessage(e: NamedAPIError) {
+export function getNamedAPIErrorMessage(e: NamedAPIError): string {
   if (e.detailedMessage) {
     return e.name + ": " + e.detailedMessage;
   } else {

--- a/packages/lib/passport-interface/src/util/StorageBackedMap.ts
+++ b/packages/lib/passport-interface/src/util/StorageBackedMap.ts
@@ -39,7 +39,7 @@ export class StorageBackedMap<K, V> extends Map<K, V> {
    * Queues a microtask to sync to local storage once the current event loop
    *  has finished processing
    */
-  private queueSync() {
+  private queueSync(): void {
     if (!this.syncing) {
       this.syncing = true;
       queueMicrotask(() => this.syncToStorage());
@@ -61,7 +61,7 @@ export class StorageBackedMap<K, V> extends Map<K, V> {
    * Reloads data from storage, called in response to storage changes that
    * come from other tabs.
    */
-  private reloadFromStorage() {
+  private reloadFromStorage(): void {
     const storageData = window.localStorage.getItem(this.storageKey);
     let loadedData = [];
     if (storageData) {
@@ -85,7 +85,7 @@ export class StorageBackedMap<K, V> extends Map<K, V> {
   /**
    * Wraps Map.set(), and queues a sync after the change
    */
-  public set(key: K, value: V) {
+  public set(key: K, value: V): this {
     super.set(key, value);
     this.queueSync();
     return this;
@@ -94,7 +94,7 @@ export class StorageBackedMap<K, V> extends Map<K, V> {
   /**
    * Wraps Map.delete(), and queues a sync after the change
    */
-  public delete(key: K) {
+  public delete(key: K): boolean {
     if (super.delete(key)) {
       this.queueSync();
       return true;
@@ -106,7 +106,7 @@ export class StorageBackedMap<K, V> extends Map<K, V> {
   /**
    * Wraps Map.clear(), and queues a sync after the change
    */
-  public clear() {
+  public clear(): void {
     super.clear();
     this.queueSync();
   }

--- a/packages/lib/passport-interface/test/MockFeedApi.ts
+++ b/packages/lib/passport-interface/test/MockFeedApi.ts
@@ -8,6 +8,7 @@ import {
   FeedHost,
   ListFeedsResult,
   PollFeedRequest,
+  PollFeedResponseValue,
   PollFeedResult
 } from "../src";
 import { IFeedApi } from "../src/FeedAPI";
@@ -56,7 +57,9 @@ export class MockFeedApi implements IFeedApi {
                 }
               },
 
-              handleRequest: async (req: PollFeedRequest) => {
+              handleRequest: async (
+                req: PollFeedRequest
+              ): Promise<PollFeedResponseValue> => {
                 if (date) {
                   MockDate.set(date);
                 }
@@ -102,7 +105,9 @@ export class MockFeedApi implements IFeedApi {
                   signatureType: "sempahore-signature-pcd"
                 }
               },
-              handleRequest: async (req: PollFeedRequest) => {
+              handleRequest: async (
+                req: PollFeedRequest
+              ): Promise<PollFeedResponseValue> => {
                 if (date) {
                   MockDate.set(date);
                 }
@@ -145,7 +150,9 @@ export class MockFeedApi implements IFeedApi {
                 }
               },
 
-              handleRequest: async (req: PollFeedRequest) => {
+              handleRequest: async (
+                req: PollFeedRequest
+              ): Promise<PollFeedResponseValue> => {
                 if (date) {
                   MockDate.set(date);
                 }

--- a/packages/lib/passport-ui/src/Core.tsx
+++ b/packages/lib/passport-ui/src/Core.tsx
@@ -6,7 +6,7 @@ export function Spacer({
 }: {
   w?: 8 | 16 | 24 | 32 | 48 | 64;
   h?: 8 | 16 | 24 | 32 | 48 | 64 | 96 | 128 | 256 | 512;
-}) {
+}): JSX.Element {
   const width = w && `${w}px`;
   const height = h && `${h}px`;
   return <div style={{ width, height, userSelect: "none" }} />;

--- a/packages/lib/passport-ui/src/HiddenText.tsx
+++ b/packages/lib/passport-ui/src/HiddenText.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import styled from "./StyledWrapper";
 
-export function HiddenText({ text }: { text: string }) {
+export function HiddenText({ text }: { text: string }): JSX.Element {
   const [visible, setVisible] = useState(false);
 
   const onRevealClick = useCallback(() => {

--- a/packages/lib/passport-ui/src/ImageZoom.tsx
+++ b/packages/lib/passport-ui/src/ImageZoom.tsx
@@ -5,7 +5,7 @@ type ImageZoomProps = ComponentProps<"img"> & {
   options?: ZoomOptions;
 };
 
-export function ImageZoom({ options, ...props }: ImageZoomProps) {
+export function ImageZoom({ options, ...props }: ImageZoomProps): JSX.Element {
   const zoomRef = useRef<Zoom | null>(null);
 
   const getZoom = useCallback(() => {

--- a/packages/lib/passport-ui/src/QR.tsx
+++ b/packages/lib/passport-ui/src/QR.tsx
@@ -1,7 +1,7 @@
 import { gzip, ungzip } from "pako";
 import qr from "qr-image";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import styled, { css } from "./StyledWrapper";
+import styled, { FlattenSimpleInterpolation, css } from "./StyledWrapper";
 
 export function encodeQRPayload(unencoded: string): string {
   console.log(`encoding payload with length ${unencoded.length}`);
@@ -42,7 +42,7 @@ export function QRDisplayWithRegenerateAndStorage({
   loadedLogo?: React.ReactNode;
   fgColor?: string;
   bgColor?: string;
-}) {
+}): JSX.Element {
   /**
    * Generate a fresh identity-revealing proof every n ms. We regenerate before
    * the proof expires to allow for a few minutes of clock skew between prover
@@ -116,7 +116,7 @@ export function QRDisplay({
   fgColor?: string;
   bgColor?: string;
   saved: boolean;
-}) {
+}): JSX.Element {
   return (
     <QRWrap saved={saved}>
       {value !== undefined && (
@@ -133,7 +133,7 @@ export function QRDisplay({
 
 // Style constants
 const QRWrap = styled.div<{ saved: boolean }>`
-  ${({ saved }) => (saved ? css`` : css``)}
+  ${({ saved }): FlattenSimpleInterpolation => (saved ? css`` : css``)}
   height: 0;
   padding-bottom: 100%;
   position: relative;
@@ -149,7 +149,7 @@ export function QR({
   value: string;
   fgColor: string;
   bgColor: string;
-}) {
+}): JSX.Element {
   const [svgObject, setSvgObject] = useState<any | undefined>();
 
   useEffect(() => {

--- a/packages/lib/passport-ui/src/Toggle.tsx
+++ b/packages/lib/passport-ui/src/Toggle.tsx
@@ -56,7 +56,7 @@ export const ToggleSwitch = ({
   label: string;
   checked: boolean;
   onChange: () => void;
-}) => {
+}): JSX.Element => {
   const handleChange = useCallback(() => {
     onChange();
   }, [onChange]);

--- a/packages/lib/passport-ui/src/index.ts
+++ b/packages/lib/passport-ui/src/index.ts
@@ -3,6 +3,7 @@ export * from "./HiddenText";
 export * from "./ImageZoom";
 export * from "./QR";
 export { css, keyframes, default as styled } from "./StyledWrapper";
+export type { FlattenSimpleInterpolation } from "./StyledWrapper";
 export * from "./Toggle";
 export { icons };
 import * as icons from "./icons";

--- a/packages/lib/pcd-collection/src/PCDCollection.ts
+++ b/packages/lib/pcd-collection/src/PCDCollection.ts
@@ -233,7 +233,7 @@ export class PCDCollection {
     return Array.from(result);
   }
 
-  public bulkSetFolder(pcdIds: string[], folder: string) {
+  public bulkSetFolder(pcdIds: string[], folder: string): void {
     pcdIds.forEach((pcdId) => {
       if (!this.hasPCDWithId(pcdId)) {
         throw new Error(`can't set folder of pcd ${pcdId} - pcd doesn't exist`);
@@ -355,7 +355,7 @@ export class PCDCollection {
     this.addAll(deserialized, options);
   }
 
-  public async remove(pcdId: string) {
+  public async remove(pcdId: string): Promise<void> {
     this.pcds = this.pcds.filter((pcd) => pcd.id !== pcdId);
     this.folders = Object.fromEntries(
       Object.entries(this.folders).filter(([id]) => id !== pcdId)
@@ -370,11 +370,11 @@ export class PCDCollection {
     await this.deserializeAllAndAdd([serialized], options);
   }
 
-  public add(pcd: PCD, options?: AddPCDOptions) {
+  public add(pcd: PCD, options?: AddPCDOptions): void {
     this.addAll([pcd], options);
   }
 
-  public addAll(pcds: PCD[], options?: AddPCDOptions) {
+  public addAll(pcds: PCD[], options?: AddPCDOptions): void {
     const currentMap = new Map(this.pcds.map((pcd) => [pcd.id, pcd]));
     const toAddMap = new Map(pcds.map((pcd) => [pcd.id, pcd]));
 
@@ -427,11 +427,11 @@ export class PCDCollection {
     return this.getById(id) !== undefined;
   }
 
-  public getPCDsByType(type: string) {
+  public getPCDsByType(type: string): PCD[] {
     return this.pcds.filter((pcd) => pcd.type === type);
   }
 
-  private emitChange() {
+  private emitChange(): void {
     // Emit the change asynchronously, so we don't need to delay until
     // listeners are complete.
     setTimeout(() => this.changeEmitter.emit(), 0);

--- a/packages/lib/pcd-collection/src/util.ts
+++ b/packages/lib/pcd-collection/src/util.ts
@@ -100,7 +100,7 @@ export function splitPath(path: string): string[] {
 /**
  * Joins path segments with the separator, escaping each segment.
  */
-export function joinPath(...segments: string[]) {
+export function joinPath(...segments: string[]): string {
   return segments.map(escapePathSegment).join(PATH_SEP);
 }
 

--- a/packages/lib/pcd-collection/test/PCDCollection.spec.ts
+++ b/packages/lib/pcd-collection/test/PCDCollection.spec.ts
@@ -10,7 +10,7 @@ import chaiSpies from "chai-spies";
 
 chai.use(chaiSpies);
 
-async function newPCD(id?: string) {
+async function newPCD(id?: string): Promise<RSAPCD> {
   id = id ?? uuid();
   const pkey = new NodeRSA({ b: 512 });
 

--- a/packages/lib/pcd-collection/test/PCDFeedActions.spec.ts
+++ b/packages/lib/pcd-collection/test/PCDFeedActions.spec.ts
@@ -13,7 +13,7 @@ import {
   PCDPermissionType
 } from "../src";
 
-async function newPCD(id?: string) {
+async function newPCD(id?: string): Promise<RSAPCD> {
   id = id ?? uuid();
   const pkey = new NodeRSA({ b: 512 });
 

--- a/packages/lib/pcd-collection/test/permissions.spec.ts
+++ b/packages/lib/pcd-collection/test/permissions.spec.ts
@@ -17,7 +17,7 @@ import {
   isFolderAncestor
 } from "../src";
 
-async function newPCD(id?: string) {
+async function newPCD(id?: string): Promise<RSAPCD> {
   id = id ?? uuid();
   const pkey = new NodeRSA({ b: 512 });
 

--- a/packages/lib/util/src/Environment.ts
+++ b/packages/lib/util/src/Environment.ts
@@ -30,7 +30,7 @@ export function isBrowser(): boolean {
  * More info on: https://stackoverflow.com/questions/47879864/how-can-i-check-if-a-browser-supports-webassembly.
  * @returns true if WASM is supported, false otherwise.
  */
-export function isWebAssemblySupported() {
+export function isWebAssemblySupported(): boolean {
   try {
     if (
       typeof WebAssembly === "object" &&

--- a/packages/lib/util/src/Errors.ts
+++ b/packages/lib/util/src/Errors.ts
@@ -15,7 +15,10 @@ export function getErrorMessage(e: any | Error): string {
  * @param parameter Parameter to be checked.
  * @param parameterName Name of the parameter.
  */
-export function requireDefinedParameter(parameter: any, parameterName: string) {
+export function requireDefinedParameter(
+  parameter: any,
+  parameterName: string
+): void {
   if (typeof parameter === "undefined") {
     throw new Error(`${parameterName} must be defined`);
   }

--- a/packages/pcd/eddsa-pcd/src/EdDSAPCD.ts
+++ b/packages/pcd/eddsa-pcd/src/EdDSAPCD.ts
@@ -108,9 +108,9 @@ let eddsa: Eddsa;
  * of the `circomlibjs` package has been properly initialized.
  * It only initializes them once.
  */
-async function ensureInitialized() {
+async function ensureInitialized(): Promise<void> {
   if (!initializedPromise) {
-    initializedPromise = (async () => {
+    initializedPromise = (async (): Promise<void> => {
       eddsa = await buildEddsa();
     })();
   }

--- a/packages/pcd/ethereum-group-pcd/test/EthereumGroupPCD.spec.ts
+++ b/packages/pcd/ethereum-group-pcd/test/EthereumGroupPCD.spec.ts
@@ -5,7 +5,7 @@ import {
   SemaphoreIdentityPCDPackage,
   SemaphoreIdentityPCDTypeName
 } from "@pcd/semaphore-identity-pcd";
-import { Poseidon, Tree } from "@personaelabs/spartan-ecdsa";
+import { MerkleProof, Poseidon, Tree } from "@personaelabs/spartan-ecdsa";
 import { Identity } from "@semaphore-protocol/identity";
 import assert from "assert";
 import { ethers } from "ethers";
@@ -26,7 +26,11 @@ async function groupProof(
   identity: SemaphoreIdentityPCD,
   wallet: ethers.Wallet,
   groupType: GroupType = GroupType.PUBLICKEY
-) {
+): Promise<{
+  signatureOfIdentityCommitment: string;
+  msgHash: Buffer;
+  merkleProof: MerkleProof;
+}> {
   const signatureOfIdentityCommitment = await wallet.signMessage(
     identity.claim.identity.commitment.toString()
   );
@@ -88,7 +92,9 @@ async function groupProof(
   };
 }
 
-async function happyPathEthGroupPCD(groupType: GroupType) {
+async function happyPathEthGroupPCD(
+  groupType: GroupType
+): Promise<EthereumGroupPCD> {
   const identity = await SemaphoreIdentityPCDPackage.prove({
     identity: new Identity()
   });

--- a/packages/pcd/rln-pcd/src/RLNPCD.ts
+++ b/packages/pcd/rln-pcd/src/RLNPCD.ts
@@ -114,7 +114,7 @@ export class RLNPCD implements PCD<RLNPCDClaim, RLNPCDProof> {
   }
 }
 
-function checkClaimProofMatching(claim: RLNPCDClaim, proof: RLNPCDProof) {
+function checkClaimProofMatching(claim: RLNPCDClaim, proof: RLNPCDProof): void {
   const claimExternalNullifier = RLN._genNullifier(
     claim.epoch,
     claim.rlnIdentifier
@@ -127,7 +127,7 @@ function checkClaimProofMatching(claim: RLNPCDClaim, proof: RLNPCDProof) {
   }
 }
 
-export async function init(args: RLNPCDInitArgs) {
+export async function init(args: RLNPCDInitArgs): Promise<void> {
   initArgs = args;
 }
 
@@ -175,7 +175,7 @@ export async function verify(pcd: RLNPCD): Promise<boolean> {
   return await RLN.verifySNARKProof(verificationKeyJSON, fullProof.snarkProof);
 }
 
-function getRLNInstance(rlnIdentifier: bigint, identity?: Identity) {
+function getRLNInstance(rlnIdentifier: bigint, identity?: Identity): RLN {
   if (!initArgs) {
     throw new Error("cannot make proof: init has not been called yet");
   }

--- a/packages/pcd/semaphore-group-pcd/src/SerializedSemaphoreGroup.ts
+++ b/packages/pcd/semaphore-group-pcd/src/SerializedSemaphoreGroup.ts
@@ -23,7 +23,7 @@ export function serializeSemaphoreGroup(
 
 export function deserializeSemaphoreGroup(
   serializedGroup: SerializedSemaphoreGroup
-) {
+): Group {
   const group = new Group(
     BigInt(serializedGroup.id),
     serializedGroup.depth,

--- a/packages/pcd/webauthn-pcd/test/WebAuthnPCD.spec.ts
+++ b/packages/pcd/webauthn-pcd/test/WebAuthnPCD.spec.ts
@@ -14,7 +14,13 @@ const args: WebAuthnPCDArgs = {
 };
 
 jest.mock("@simplewebauthn/browser", () => ({
-  startRegistration: async () => ({
+  startRegistration: async (): Promise<{
+    id: string;
+    rawId: string;
+    response: { clientDataJSON: string; attestationObject: string };
+    clientExtensionResults: object;
+    type: string;
+  }> => ({
     id: "my-credential",
     rawId: "my-credential",
     response: {
@@ -24,7 +30,13 @@ jest.mock("@simplewebauthn/browser", () => ({
     clientExtensionResults: {},
     type: "public-key"
   }),
-  startAuthentication: async () => ({
+  startAuthentication: async (): Promise<{
+    id: string;
+    rawId: string;
+    response: { clientDataJSON: string; attestationObject: string };
+    clientExtensionResults: object;
+    type: string;
+  }> => ({
     id: "my-credential",
     rawId: "my-credential",
     response: {
@@ -40,16 +52,16 @@ jest.mock("@simplewebauthn/server", () => ({
   ...jest.requireActual("@simplewebauthn/server"),
   verifyAuthenticationResponse: async ({
     expectedChallenge
-  }: VerifyAuthenticationResponseOpts) => ({
+  }: VerifyAuthenticationResponseOpts): Promise<{ verified: boolean }> => ({
     verified: expectedChallenge === "valid_challenge"
   })
 }));
 
 // Mock out wasm-based utils function
 jest.mock("@pcd/passport-crypto", () => ({
-  arrayBufferToBase64: (arrayBuffer: ArrayBuffer) =>
+  arrayBufferToBase64: (arrayBuffer: ArrayBuffer): string =>
     btoa(String.fromCharCode(...new Uint8Array(arrayBuffer))),
-  base64ToArrayBuffer: (base64String: string) =>
+  base64ToArrayBuffer: (base64String: string): Uint8Array =>
     Uint8Array.from(atob(base64String), (c) => c.charCodeAt(0))
 }));
 

--- a/packages/pcd/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCD.ts
+++ b/packages/pcd/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCD.ts
@@ -161,13 +161,13 @@ export class ZKEdDSAEventTicketPCD
 /**
  * Initialize ZKEdDSAEventTicketPCDPackage.
  */
-export async function init(args: ZKEdDSAEventTicketPCDInitArgs) {
+export async function init(args: ZKEdDSAEventTicketPCDInitArgs): Promise<void> {
   savedInitArgs = args;
 }
 
 async function ensureDepsInitialized(): Promise<void> {
   if (!depsInitializedPromise) {
-    depsInitializedPromise = (async () => {
+    depsInitializedPromise = (async (): Promise<void> => {
       // TODO: This object is expensive to build, and duplicates some work,
       // including buiding curves which aren't cached and thus have to be
       // re-built by groth16.  We need this object only for eddsa.F.toObject
@@ -432,7 +432,7 @@ export function getProveDisplayOptions(): ProveDisplayOptions<ZKEdDSAEventTicket
       ticket: {
         argumentType: ArgumentTypeName.PCD,
         description: "Generate a proof for the selected ticket",
-        validate(value, params) {
+        validate(value, params): boolean {
           if (value.type !== EdDSATicketPCDTypeName || !value.claim) {
             return false;
           }

--- a/packages/pcd/zk-eddsa-frog-pcd/src/ZKEdDSAFrogPCD.ts
+++ b/packages/pcd/zk-eddsa-frog-pcd/src/ZKEdDSAFrogPCD.ts
@@ -119,7 +119,7 @@ export function getProveDisplayOptions(): ProveDisplayOptions<ZKEdDSAFrogPCDArgs
       frog: {
         argumentType: ArgumentTypeName.PCD,
         description: "Generate a proof for the selected frog",
-        validate(value, _) {
+        validate(value, _): boolean {
           if (value.type !== EdDSAFrogPCDTypeName || !value.claim) {
             return false;
           }
@@ -155,9 +155,9 @@ let eddsa: Eddsa;
  * of the `circomlibjs` package has been properly initialized.
  * It only initializes them once.
  */
-async function ensureEddsaInitialized() {
+async function ensureEddsaInitialized(): Promise<void> {
   if (!initializedPromise) {
-    initializedPromise = (async () => {
+    initializedPromise = (async (): Promise<void> => {
       eddsa = await buildEddsa();
     })();
   }

--- a/packages/tools/artifacts/src/spinner.js
+++ b/packages/tools/artifacts/src/spinner.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import ora from "ora";
 
 export default class Spinner {

--- a/packages/tools/artifacts/src/utils.js
+++ b/packages/tools/artifacts/src/utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { S3Client } from "@aws-sdk/client-s3";
 import { exec } from "child_process";
 import Conf from "conf";

--- a/packages/tools/eslint-config-custom/index.js
+++ b/packages/tools/eslint-config-custom/index.js
@@ -44,7 +44,8 @@ module.exports = {
     ],
     "@typescript-eslint/no-require-imports": "error",
     "import/no-unresolved": "off",
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "@typescript-eslint/explicit-function-return-type": "error"
   },
   settings: {
     "import/resolver": {

--- a/packages/ui/eddsa-frog-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/eddsa-frog-pcd-ui/src/CardBody.tsx
@@ -21,7 +21,7 @@ export const EdDSAFrogPCDUI: PCDUI<EdDSAFrogPCD> = {
   getHeader: Header
 };
 
-function Header({ pcd }: { pcd: EdDSAFrogPCD }) {
+function Header({ pcd }: { pcd: EdDSAFrogPCD }): JSX.Element {
   const frogData = useMemo(() => getEdDSAFrogData(pcd), [pcd]);
   if (!frogData) {
     return <>Frog</>;
@@ -56,7 +56,7 @@ function Header({ pcd }: { pcd: EdDSAFrogPCD }) {
   );
 }
 
-function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
+function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }): JSX.Element {
   const frogData = useMemo(() => getEdDSAFrogData(pcd), [pcd]);
   const [showMore, setShowMore] = useState(false);
   const [showPCD, setShowPCD] = useState(false);
@@ -71,7 +71,9 @@ function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
 
   return showPCD ? (
     <Container>
-      <LinkButton onClick={() => setShowPCD(false)}>View as frog</LinkButton>
+      <LinkButton onClick={(): void => setShowPCD(false)}>
+        View as frog
+      </LinkButton>
       <FrogQR pcd={pcd} />
       <CopyFrogPCD pcd={pcd} />
     </Container>
@@ -79,7 +81,7 @@ function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
     <Container>
       <LinkButton
         style={{ textAlign: "center" }}
-        onClick={() => setShowPCD(true)}
+        onClick={(): void => setShowPCD(true)}
       >
         View as proof&#x2011;carrying data
       </LinkButton>
@@ -107,7 +109,7 @@ function EdDSAFrogCardBody({ pcd }: { pcd: EdDSAFrogPCD }) {
         />
         <FrogAttribute label="BTY" title="Beauty" value={frogData.beauty} />
       </FrogInfo>
-      <LinkButton onClick={() => setShowMore(!showMore)}>
+      <LinkButton onClick={(): void => setShowMore(!showMore)}>
         {showMore ? "Collapse" : "See more"}
       </LinkButton>
       {showMore && (
@@ -139,7 +141,7 @@ function FrogAttribute({
   label: string;
   title: string;
   value: string | number | undefined;
-}) {
+}): JSX.Element {
   return (
     <Attribute>
       <AttrTitle title={title}>{label}</AttrTitle>
@@ -150,7 +152,7 @@ function FrogAttribute({
   );
 }
 
-function attrColor(value: string | number | undefined) {
+function attrColor(value: string | number | undefined): string | undefined {
   if (typeof value === "number") {
     if (value <= 3) {
       return "#a95940";
@@ -161,14 +163,16 @@ function attrColor(value: string | number | undefined) {
   }
 }
 
-function formatAttrValue(value: string | number | undefined) {
+function formatAttrValue(
+  value: string | number | undefined
+): string | undefined {
   if (typeof value === "number") {
     return String(value).padStart(2, "0");
   }
   return value;
 }
 
-function temperamentValue(temperament: Temperament) {
+function temperamentValue(temperament: Temperament): string {
   switch (temperament) {
     case Temperament.UNKNOWN:
       return "???";
@@ -179,11 +183,11 @@ function temperamentValue(temperament: Temperament) {
   }
 }
 
-function biomeValue(biome: Biome) {
+function biomeValue(biome: Biome): string {
   return _.startCase(Biome[biome]);
 }
 
-function FrogQR({ pcd }: { pcd: EdDSAFrogPCD }) {
+function FrogQR({ pcd }: { pcd: EdDSAFrogPCD }): JSX.Element {
   const [hex, setHex] = useState("");
   const generate = useCallback(async () => {
     const serialized = await EdDSAFrogPCDPackage.serialize(pcd);
@@ -196,7 +200,7 @@ function FrogQR({ pcd }: { pcd: EdDSAFrogPCD }) {
   return <HexContainer>{hex}</HexContainer>;
 }
 
-function CopyFrogPCD({ pcd }: { pcd: EdDSAFrogPCD }) {
+function CopyFrogPCD({ pcd }: { pcd: EdDSAFrogPCD }): JSX.Element {
   const [copied, setCopied] = useState(false);
   const onClick = useCallback(async () => {
     const serialized = await EdDSAFrogPCDPackage.serialize(pcd);

--- a/packages/ui/eddsa-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/eddsa-pcd-ui/src/CardBody.tsx
@@ -15,7 +15,7 @@ export const EdDSAPCDUI: PCDUI<EdDSAPCD> = {
 /**
  * This component renders the body of a 'Card' that Zupass uses to display PCDs to the user.
  */
-function EdDSACardBody({ pcd }: { pcd: EdDSAPCD }) {
+function EdDSACardBody({ pcd }: { pcd: EdDSAPCD }): JSX.Element {
   return (
     <Container>
       <p>This PCD represents an EdDSA signature of some bigint values</p>

--- a/packages/ui/eddsa-ticket-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/eddsa-ticket-pcd-ui/src/CardBody.tsx
@@ -5,7 +5,13 @@ import {
   getEdDSATicketData
 } from "@pcd/eddsa-ticket-pcd";
 import { ZUCONNECT_23_DAY_PASS_PRODUCT_ID } from "@pcd/passport-interface";
-import { Spacer, ToggleSwitch, css, styled } from "@pcd/passport-ui";
+import {
+  FlattenSimpleInterpolation,
+  Spacer,
+  ToggleSwitch,
+  css,
+  styled
+} from "@pcd/passport-ui";
 import { PCDUI } from "@pcd/pcd-types";
 import { SemaphoreIdentityPCD } from "@pcd/semaphore-identity-pcd";
 import { useCallback, useState } from "react";
@@ -41,7 +47,7 @@ function EdDSATicketPCDCardBody({
   idBasedVerifyURL
 }: {
   pcd: EdDSATicketPCD;
-} & EdDSATicketPCDCardProps) {
+} & EdDSATicketPCDCardProps): JSX.Element {
   const hasImage = pcd.claim.ticket.imageUrl !== undefined;
 
   const ticketData = getEdDSATicketData(pcd);
@@ -91,12 +97,12 @@ function EdDSATicketPCDCardBody({
   );
 }
 
-function TicketImage({ pcd }: { pcd: EdDSATicketPCD }) {
+function TicketImage({ pcd }: { pcd: EdDSATicketPCD }): JSX.Element {
   const { imageUrl, imageAltText } = pcd.claim.ticket;
   return <img src={imageUrl} alt={imageAltText} />;
 }
 
-function getHeader({ pcd }: { pcd: EdDSATicketPCD }) {
+function getHeader({ pcd }: { pcd: EdDSATicketPCD }): JSX.Element {
   let header;
   if (
     pcd.claim.ticket.ticketCategory === TicketCategory.ZuConnect &&
@@ -111,7 +117,7 @@ function getHeader({ pcd }: { pcd: EdDSATicketPCD }) {
 }
 
 const Container = styled.span<{ padding: boolean }>`
-  ${({ padding }) =>
+  ${({ padding }): FlattenSimpleInterpolation =>
     padding
       ? css`
           padding: 16px;
@@ -134,7 +140,7 @@ const Uppercase = styled.span`
 `;
 
 const RedactedText = styled.div<{ redacted: boolean }>`
-  ${({ redacted }) =>
+  ${({ redacted }): FlattenSimpleInterpolation =>
     redacted
       ? css`
           color: transparent;

--- a/packages/ui/eddsa-ticket-pcd-ui/src/TicketQR.tsx
+++ b/packages/ui/eddsa-ticket-pcd-ui/src/TicketQR.tsx
@@ -36,7 +36,10 @@ export function TicketQR({
   identityPCD,
   verifyURL,
   idBasedVerifyURL
-}: { pcd: EdDSATicketPCD; zk: boolean } & EdDSATicketPCDCardProps) {
+}: {
+  pcd: EdDSATicketPCD;
+  zk: boolean;
+} & EdDSATicketPCDCardProps): JSX.Element {
   const generate = useCallback(async () => {
     if (idBasedVerifyURL && !zk) {
       // For ID-based verification, we encode the ID with a timestamp to

--- a/packages/ui/email-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/email-pcd-ui/src/CardBody.tsx
@@ -6,7 +6,7 @@ export const EmailPCDUI: PCDUI<EmailPCD> = {
   renderCardBody: EmailCardBody
 };
 
-function EmailCardBody({ pcd }: { pcd: EmailPCD }) {
+function EmailCardBody({ pcd }: { pcd: EmailPCD }): JSX.Element {
   const emailAddress = getEmailAddress(pcd);
 
   return (

--- a/packages/ui/ethereum-group-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/ethereum-group-pcd-ui/src/CardBody.tsx
@@ -15,7 +15,11 @@ export const EthereumGroupPCDUI: PCDUI<EthereumGroupPCD> = {
   renderCardBody: EthereumGroupCardBody
 };
 
-export function EthereumGroupCardBody({ pcd }: { pcd: EthereumGroupPCD }) {
+export function EthereumGroupCardBody({
+  pcd
+}: {
+  pcd: EthereumGroupPCD;
+}): JSX.Element {
   const [identityCommitment, setIdentityCommitment] =
     useState("<deserializing>");
 

--- a/packages/ui/ethereum-ownership-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/ethereum-ownership-pcd-ui/src/CardBody.tsx
@@ -15,7 +15,11 @@ export const EthereumOwnershipPCDUI: PCDUI<EthereumOwnershipPCD> = {
   renderCardBody: EthereumOwnershipCardBody
 };
 
-function EthereumOwnershipCardBody({ pcd }: { pcd: EthereumOwnershipPCD }) {
+function EthereumOwnershipCardBody({
+  pcd
+}: {
+  pcd: EthereumOwnershipPCD;
+}): JSX.Element {
   const [identityCommitment, setIdentityCommitment] =
     useState("<deserializing>");
 

--- a/packages/ui/halo-nonce-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/halo-nonce-pcd-ui/src/CardBody.tsx
@@ -15,7 +15,11 @@ const base = new Airtable({
     "pat5y56owllLzfmW4.18658c109003682514513254c6f464f52022562acbb3af33d7fd95f05eebb6f2"
 }).base("appJcTn3eQUXKQEKT");
 
-function useAirtableData(pubkeyHex: string) {
+function useAirtableData(pubkeyHex: string): {
+  headerText: string;
+  imageUrl: string | undefined;
+  loadedAirtable: boolean;
+} {
   const [loadedAirtable, setLoadedAirtable] = useState(false);
   const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
   const [headerText, setHeaderText] = useState<string>("NFC STAMP");
@@ -57,12 +61,12 @@ function useAirtableData(pubkeyHex: string) {
   return { headerText, imageUrl, loadedAirtable };
 }
 
-function Header({ pcd }: { pcd: HaLoNoncePCD }) {
+function Header({ pcd }: { pcd: HaLoNoncePCD }): JSX.Element {
   const { headerText } = useAirtableData(pcd.claim.pubkeyHex);
   return <>{headerText}</>;
 }
 
-function HaLoNonceCardBody({ pcd }: { pcd: HaLoNoncePCD }) {
+function HaLoNonceCardBody({ pcd }: { pcd: HaLoNoncePCD }): JSX.Element {
   const { loadedAirtable, imageUrl } = useAirtableData(pcd.claim.pubkeyHex);
 
   if (!loadedAirtable) {

--- a/packages/ui/rsa-image-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/rsa-image-pcd-ui/src/CardBody.tsx
@@ -6,7 +6,7 @@ export const RSAImagePCDUI: PCDUI<RSAImagePCD> = {
   renderCardBody: RSAImageCardBody
 };
 
-export function RSAImageCardBody({ pcd }: { pcd: RSAImagePCD }) {
+export function RSAImageCardBody({ pcd }: { pcd: RSAImagePCD }): JSX.Element {
   const imageData = JSON.parse(pcd.proof.rsaPCD.claim.message);
 
   return (

--- a/packages/ui/rsa-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/rsa-pcd-ui/src/CardBody.tsx
@@ -12,7 +12,7 @@ export const RSAPCDUI: PCDUI<RSAPCD> = {
   renderCardBody: RSACardBody
 };
 
-export function RSACardBody({ pcd }: { pcd: RSAPCD }) {
+export function RSACardBody({ pcd }: { pcd: RSAPCD }): JSX.Element {
   return (
     <Container>
       <p>This PCD represents an RSA signature of some text</p>

--- a/packages/ui/rsa-ticket-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/rsa-ticket-pcd-ui/src/CardBody.tsx
@@ -17,7 +17,7 @@ export const RSATicketPCDUI: PCDUI<RSATicketPCD> = {
   renderCardBody: RSATicketCardBody
 };
 
-function RSATicketCardBody({ pcd }: { pcd: RSATicketPCD }) {
+function RSATicketCardBody({ pcd }: { pcd: RSATicketPCD }): JSX.Element {
   const ticketData = getTicketData(pcd);
 
   return (
@@ -32,7 +32,7 @@ function RSATicketCardBody({ pcd }: { pcd: RSATicketPCD }) {
   );
 }
 
-function TicketQR({ pcd }: { pcd: RSATicketPCD }) {
+function TicketQR({ pcd }: { pcd: RSATicketPCD }): JSX.Element {
   const generate = useCallback(async () => {
     const serialized = await RSATicketPCDPackage.serialize(pcd);
     const serializedPCD = JSON.stringify(serialized);

--- a/packages/ui/semaphore-group-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/semaphore-group-pcd-ui/src/CardBody.tsx
@@ -12,7 +12,11 @@ export const SemaphoreGroupPCDUI: PCDUI<SemaphoreGroupPCD> = {
   renderCardBody: SemaphoreGroupCardBody
 };
 
-function SemaphoreGroupCardBody({ pcd }: { pcd: SemaphoreGroupPCD }) {
+function SemaphoreGroupCardBody({
+  pcd
+}: {
+  pcd: SemaphoreGroupPCD;
+}): JSX.Element {
   return (
     <Container>
       <p>

--- a/packages/ui/semaphore-identity-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/semaphore-identity-pcd-ui/src/CardBody.tsx
@@ -6,7 +6,11 @@ export const SemaphoreIdentityPCDUI: PCDUI<SemaphoreIdentityPCD> = {
   renderCardBody: SemaphoreIdentityCardBody
 };
 
-function SemaphoreIdentityCardBody({ pcd }: { pcd: SemaphoreIdentityPCD }) {
+function SemaphoreIdentityCardBody({
+  pcd
+}: {
+  pcd: SemaphoreIdentityPCD;
+}): JSX.Element {
   return (
     <Container>
       <p>

--- a/packages/ui/semaphore-signature-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/semaphore-signature-pcd-ui/src/CardBody.tsx
@@ -13,7 +13,11 @@ export const SemaphoreSignaturePCDUI: PCDUI<SemaphoreSignaturePCD> = {
   renderCardBody: SemaphoreSignatureCardBody
 };
 
-function SemaphoreSignatureCardBody({ pcd }: { pcd: SemaphoreSignaturePCD }) {
+function SemaphoreSignatureCardBody({
+  pcd
+}: {
+  pcd: SemaphoreSignaturePCD;
+}): JSX.Element {
   return (
     <Container>
       <p>

--- a/packages/ui/webauthn-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/webauthn-pcd-ui/src/CardBody.tsx
@@ -12,7 +12,7 @@ export const WebAuthnPCDUI: PCDUI<WebAuthnPCD> = {
   renderCardBody: WebAuthnCardBody
 };
 
-function WebAuthnCardBody({ pcd }: { pcd: WebAuthnPCD }) {
+function WebAuthnCardBody({ pcd }: { pcd: WebAuthnPCD }): JSX.Element {
   return (
     <Container>
       <p>

--- a/packages/ui/zk-eddsa-event-ticket-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/zk-eddsa-event-ticket-pcd-ui/src/CardBody.tsx
@@ -12,7 +12,11 @@ export const ZKEdDSAEventTicketPCDUI: PCDUI<ZKEdDSAEventTicketPCD> = {
   renderCardBody: ZKEdDSAEventTicketCardBody
 };
 
-function ZKEdDSAEventTicketCardBody({ pcd }: { pcd: ZKEdDSAEventTicketPCD }) {
+function ZKEdDSAEventTicketCardBody({
+  pcd
+}: {
+  pcd: ZKEdDSAEventTicketPCD;
+}): JSX.Element {
   return (
     <Container>
       <p>

--- a/packages/ui/zk-eddsa-frog-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/zk-eddsa-frog-pcd-ui/src/CardBody.tsx
@@ -12,7 +12,7 @@ export const ZkEdDSAFrogPCDUI: PCDUI<ZKEdDSAFrogPCD> = {
   renderCardBody: ZKEdDSAFrogCardBody
 };
 
-function ZKEdDSAFrogCardBody({ pcd }: { pcd: ZKEdDSAFrogPCD }) {
+function ZKEdDSAFrogCardBody({ pcd }: { pcd: ZKEdDSAFrogPCD }): JSX.Element {
   return (
     <Container>
       <p>

--- a/templates/package/templates/src/index.ts.hbs
+++ b/templates/package/templates/src/index.ts.hbs
@@ -1,3 +1,3 @@
-export default function () {
+export default function (): void {
   // Package typescript goes here
 }


### PR DESCRIPTION
Closes #553 (unless we want to add more rules?)

In retrospect, it might have made sense to loosen the `explicit-function-return-type` rule by allowing anonymous function expressions to not specify return types. This is because front-end code makes heavy use of small, throw-away functions whose return values either don't matter, or are trivially inferred from their `return` statements.

Having said that, linting now passes with the strictest version of the rule in place, and we're free to relax it if we want to.

[https://typescript-eslint.io/linting/configs#strict](https://typescript-eslint.io/linting/configs#strict) might be worth considering if we want to tighten rules up further.