### PR TITLE
Fix build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 if [[ -z $DISABLE_BUILD_CACHE ]]; then
   yarn turbo run build
 else


### PR DESCRIPTION
The `scripts/build.sh` script had an incorrect hashbang at the beginning. The script works in environments with reasonably modern shells, but doesn't work in Github actions, where `sh` is the default shell. The failure case is that build caching is disabled, which is safe, but results in slower CI builds than necessary.

I've also tested this fix by deploying to `ivan-staging` on Render, where it correctly uses the environment variable to disable build caching.