### PR TITLE
add UI that loads and displays pipeline info (which includes its feed URLS) to the generic issuance frontend

### DIFF
--- a/apps/generic-issuance-client/src/pages/Pipeline.tsx
+++ b/apps/generic-issuance-client/src/pages/Pipeline.tsx
@@ -1,8 +1,10 @@
 import {
   PipelineDefinition,
+  PipelineInfoResponseValue,
   requestGenericIssuanceDeletePipeline,
   requestGenericIssuanceGetPipeline,
-  requestGenericIssuanceUpsertPipeline
+  requestGenericIssuanceUpsertPipeline,
+  requestPipelineInfo
 } from "@pcd/passport-interface";
 import { useStytchUser } from "@stytch/react";
 import { ReactNode, useEffect, useState } from "react";
@@ -22,6 +24,8 @@ export default function Pipeline(): ReactNode {
   const [textareaValue, setTextareaValue] = useState("");
   const [queryLoading, setQueryLoading] = useState(true);
   const [saveLoading, setSaveLoading] = useState(false);
+  const [info, setInfo] = useState<PipelineInfoResponseValue | undefined>();
+
   const [error, setError] = useState("");
 
   async function savePipeline(): Promise<void> {
@@ -60,6 +64,7 @@ export default function Pipeline(): ReactNode {
         ZUPASS_SERVER_URL,
         id
       );
+
       if (res.success) {
         setSavedPipeline(res.value);
         setTextareaValue(format(res.value));
@@ -70,8 +75,18 @@ export default function Pipeline(): ReactNode {
         );
         setSavedPipeline(undefined);
       }
+
+      const infoRes = await requestPipelineInfo(ZUPASS_SERVER_URL, id);
+      if (infoRes.success) {
+        setError("");
+        setInfo(infoRes.value);
+      } else {
+        setError(`couldn't load pipeline info`);
+      }
+
       setQueryLoading(false);
     }
+
     fetchPipeline();
   }, [id]);
 
@@ -108,6 +123,15 @@ export default function Pipeline(): ReactNode {
           <p>
             <button onClick={deletePipeline}>Delete pipeline</button>
           </p>
+        </>
+      )}
+      {info && (
+        <>
+          {info.feeds.map((f) => (
+            <div>
+              feed {f.name} - <a href={f.url}>{f.url}</a>{" "}
+            </div>
+          ))}
         </>
       )}
       {error && (


### PR DESCRIPTION
<img width="798" alt="Screenshot 2024-02-01 at 6 36 41 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/11c2a489-69e5-410a-831f-789d02c7b715">

note for @robknight and @rrrliu as we continue to develop this - posting screenshots of these pipeline management pages is actually slightly dangerous in that they include sensitive information like API keys. let's be careful to not leak stuff like that in code or screenshots on github or elsewhere.