### PR TITLE
Use dispatch when resolving feed error

### DIFF
--- a/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
@@ -125,7 +125,7 @@ const SearchButton = ({
               dispatch({
                 type: "sync-subscription",
                 subscriptionId: id,
-                onSucess: () => {
+                onSuccess: () => {
                   // nb: sync-subscription swallows http errors and always resolve as success
                   const error = subManager.getError(id);
                   if (error?.type === SubscriptionErrorType.FetchError) {

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -129,7 +129,7 @@ export type Action =
   | {
       type: "sync-subscription";
       subscriptionId: string;
-      onSucess?: () => void;
+      onSuccess?: () => void;
       onError?: (e: Error) => void;
     }
   | {
@@ -238,7 +238,7 @@ export async function dispatch(
         state,
         update,
         action.subscriptionId,
-        action.onSucess,
+        action.onSuccess,
         action.onError
       );
     case "merge-import":


### PR DESCRIPTION
Closes #1357

Previously, the "resolve feed error" UI would only check to see if a feed is now responding successfully, and would not process any of the actions received from the feed. Now it dispatches to a different code path, which will process any actions received from the feed.