### PR TITLE
Verify signer of email PCD credentials during check-in

### DIFF
--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -519,6 +519,18 @@ export class LemonadePipeline implements BasePipeline {
         payload.emailPCD.pcd
       );
 
+      if (
+        !isEqualEdDSAPublicKey(
+          checkerEmailPCD.proof.eddsaPCD.claim.publicKey,
+          this.zupassPublicKey
+        )
+      ) {
+        logger(
+          `${LOG_TAG} Email ${checkerEmailPCD.claim.emailAddress} not signed by Zupass`
+        );
+        return { canCheckIn: false, error: { name: "InvalidSignature" } };
+      }
+
       checkerTickets = await this.db.loadByEmail(
         this.id,
         checkerEmailPCD.claim.emailAddress
@@ -593,6 +605,18 @@ export class LemonadePipeline implements BasePipeline {
       const checkerEmailPCD = await EmailPCDPackage.deserialize(
         payload.emailPCD.pcd
       );
+
+      if (
+        !isEqualEdDSAPublicKey(
+          checkerEmailPCD.proof.eddsaPCD.claim.publicKey,
+          this.zupassPublicKey
+        )
+      ) {
+        logger(
+          `${LOG_TAG} Email ${checkerEmailPCD.claim.emailAddress} not signed by Zupass`
+        );
+        return { checkedIn: false, error: { name: "InvalidSignature" } };
+      }
 
       checkerTickets = await this.db.loadByEmail(
         this.id,

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -742,6 +742,18 @@ export class PretixPipeline implements BasePipeline {
         payload.emailPCD.pcd
       );
 
+      if (
+        !isEqualEdDSAPublicKey(
+          checkerEmailPCD.proof.eddsaPCD.claim.publicKey,
+          this.zupassPublicKey
+        )
+      ) {
+        logger(
+          `${LOG_TAG} Email ${checkerEmailPCD.claim.emailAddress} not signed by Zupass`
+        );
+        return { canCheckIn: false, error: { name: "InvalidSignature" } };
+      }
+
       checkerTickets = await this.db.loadByEmail(
         this.id,
         checkerEmailPCD.claim.emailAddress
@@ -825,6 +837,18 @@ export class PretixPipeline implements BasePipeline {
       const checkerEmailPCD = await EmailPCDPackage.deserialize(
         payload.emailPCD.pcd
       );
+
+      if (
+        !isEqualEdDSAPublicKey(
+          checkerEmailPCD.proof.eddsaPCD.claim.publicKey,
+          this.zupassPublicKey
+        )
+      ) {
+        logger(
+          `${LOG_TAG} Email ${checkerEmailPCD.claim.emailAddress} not signed by Zupass`
+        );
+        return { checkedIn: false, error: { name: "InvalidSignature" } };
+      }
 
       checkerTickets = await this.db.loadByEmail(
         this.id,


### PR DESCRIPTION
This was missed during the initial check-in implementation, but is a nasty security bug.