### PR TITLE
Simplify adding a subscription with a deep-link

### DIFF
--- a/apps/generic-issuance-client/src/pages/Pipeline.tsx
+++ b/apps/generic-issuance-client/src/pages/Pipeline.tsx
@@ -181,6 +181,16 @@ export default function Pipeline(): ReactNode {
                       {info.feeds?.map((feed) => (
                         <li key={feed.url}>
                           <b>{feed.name}</b> - <a href={feed.url}>{feed.url}</a>{" "}
+                          -{" "}
+                          <a
+                            href={`${
+                              process.env.PASSPORT_CLIENT_URL
+                            }/#/add-subscription?url=${encodeURIComponent(
+                              feed.url
+                            )}`}
+                          >
+                            Subscription link
+                          </a>
                         </li>
                       ))}
                     </ol>

--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -160,30 +160,31 @@ export function AddSubscriptionScreen(): JSX.Element {
             </p>
           </MismatchedEmailWarning>
         )}
-        {url.length === 0 && (
-          <>
-            <Spacer h={16} />
-            <div>Enter a URL to a feed provider:</div>
-            <Spacer h={8} />
-            <BigInput
-              autoCorrect="off"
-              autoCapitalize="off"
-              disabled={fetching}
-              value={providerUrl}
-              onChange={(e): void => {
-                setProviderUrl(e.target.value);
-              }}
-            />
-            <Spacer h={16} />
-            <Button
-              disabled={fetching || alreadyFetched}
-              onClick={onFetchFeedsClick}
-            >
-              <Spinner show={fetching} text="Get possible subscriptions" />
-            </Button>
-            <Spacer h={16} />
-          </>
-        )}
+        {fetchError ||
+          (url.length === 0 && (
+            <>
+              <Spacer h={16} />
+              <div>Enter a URL to a feed provider:</div>
+              <Spacer h={8} />
+              <BigInput
+                autoCorrect="off"
+                autoCapitalize="off"
+                disabled={fetching}
+                value={providerUrl}
+                onChange={(e): void => {
+                  setProviderUrl(e.target.value);
+                }}
+              />
+              <Spacer h={16} />
+              <Button
+                disabled={fetching || alreadyFetched}
+                onClick={onFetchFeedsClick}
+              >
+                <Spinner show={fetching} text="Get possible subscriptions" />
+              </Button>
+              <Spacer h={16} />
+            </>
+          ))}
         <Spacer h={8} />
         {fetchError && <SubscriptionErrors>{fetchError}</SubscriptionErrors>}
         <div>

--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -122,7 +122,6 @@ export function AddSubscriptionScreen(): JSX.Element {
 
   useEffect(() => {
     const url = query?.get("url") ?? "";
-    console.log({ url, onFetchFeedsClick });
     // If a URL was specified in the query string, automatically fetch feeds for it
     if (url.length > 0 && !fetchError && !fetchedProviderUrl) {
       onFetchFeedsClick();

--- a/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
@@ -93,8 +93,10 @@ export function LoginScreen(): JSX.Element {
     pendingViewFrogCryptoRequest
   ]);
 
+  const suggestedEmail = query?.get("email");
+
   const self = useSelf();
-  const [email, setEmail] = useState("");
+  const [email, setEmail] = useState(suggestedEmail ?? "");
 
   const onGenPass = useCallback(
     function (e: FormEvent<HTMLFormElement>) {


### PR DESCRIPTION
Closes #1474 

This makes the following changes:

If you hit `http://<zupass-client>/#/add-subscription` with a `url=?` parameter, this will be fetched on page load. If it's a valid feed listing URL, the available feeds will be shown with a one-click subscribe option.

If there is an `email=?` parameter, this is taken as a "suggested email". If this does not equal the current user's email address, they will be warned that the feed might not be intended to be used with that email, and they should either contact the issuer or sign up for another Zupass account with the email the feed issuer expects:

<img width="428" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/bed9838e-f3fb-43d5-8bad-80058d5b1c0b">


If the user is not logged in, then they will be taken to a login form with the suggested email pre-filled. On completing login/registration, they will be taken to the "add subscription" flow as described above.