### PR TITLE
PCD Performance test harness

### DIFF
--- a/packages/pcd/zk-eddsa-event-ticket-pcd/test/ZKEdDSAEventTicketPCD.spec.ts
+++ b/packages/pcd/zk-eddsa-event-ticket-pcd/test/ZKEdDSAEventTicketPCD.spec.ts
@@ -5,6 +5,7 @@ import { v4 as uuid } from "uuid";
 
 import {
   EdDSATicketPCDPackage,
+  EdDSATicketPCDTypeName,
   ITicketData,
   TicketCategory
 } from "@pcd/eddsa-ticket-pcd";
@@ -24,8 +25,7 @@ import {
   ZKEdDSAEventTicketPCD,
   ZKEdDSAEventTicketPCDArgs,
   ZKEdDSAEventTicketPCDClaim,
-  ZKEdDSAEventTicketPCDPackage,
-  ZKEdDSAEventTicketPCDTypeName
+  ZKEdDSAEventTicketPCDPackage
 } from "../src";
 
 import "mocha";
@@ -222,7 +222,7 @@ describe("ZKEdDSAEventTicketPCD should work", function () {
       ticket: {
         value: serializedTicketPCD,
         argumentType: ArgumentTypeName.PCD,
-        pcdType: ZKEdDSAEventTicketPCDTypeName
+        pcdType: EdDSATicketPCDTypeName
       },
       identity: {
         value: serializedIdentityPCD,

--- a/packages/tools/perftest/.eslintrc.js
+++ b/packages/tools/perftest/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ["@pcd/eslint-config-custom"],
+  root: true,
+};

--- a/packages/tools/perftest/.gitignore
+++ b/packages/tools/perftest/.gitignore
@@ -1,0 +1,4 @@
+*.js
+*.ts.map
+!.eslintrc.js
+dist

--- a/packages/tools/perftest/CHANGELOG.md
+++ b/packages/tools/perftest/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @pcd/perftest
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial changeset.

--- a/packages/tools/perftest/LICENSE
+++ b/packages/tools/perftest/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 0xPARC Foundation <https://0xparc.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/tools/perftest/README.md
+++ b/packages/tools/perftest/README.md
@@ -1,0 +1,33 @@
+<p align="center">
+    <h1 align="center">
+        @pcd/artifacts
+    </h1>
+</p>
+
+<p align="center">
+    <a href="https://github.com/proofcarryingdata">
+        <img src="https://img.shields.io/badge/project-PCD-blue.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/blob/main/packages/tools/perftest/LICENSE">
+        <img alt="License" src="https://img.shields.io/badge/license-MIT-green.svg?style=flat-square">
+    </a>
+    <a href="https://www.npmjs.com/package/@pcd/perftest">
+        <img alt="NPM version" src="https://img.shields.io/npm/v/@pcd/perftest?style=flat-square" />
+    </a>
+    <a href="https://npmjs.org/package/@pcd/perftest">
+        <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/perftest.svg?style=flat-square" />
+    </a>
+</p>
+
+| Command line tool for testing PCD package performance |
+| ----------------------------------------------------- |
+
+To run:
+
+    yarn start timer <pcd-package> <operation> [iteration-count]
+
+For example:
+
+    yarn start timer demo demo
+    yarn start timer all all
+    yarn start timer eddsa-ticket-pcd prove

--- a/packages/tools/perftest/README.md
+++ b/packages/tools/perftest/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <h1 align="center">
-        @pcd/artifacts
+        @pcd/perftest
     </h1>
 </p>
 
@@ -28,6 +28,6 @@ To run:
 
 For example:
 
-    yarn start timer demo demo
     yarn start timer all all
+    yarn start timer demo prove
     yarn start timer eddsa-ticket-pcd prove

--- a/packages/tools/perftest/package.json
+++ b/packages/tools/perftest/package.json
@@ -16,6 +16,7 @@
     "@pcd/eddsa-ticket-pcd": "^0.5.0",
     "@pcd/pcd-types": "^0.10.0",
     "@pcd/semaphore-identity-pcd": "^0.10.0",
+    "@pcd/semaphore-signature-pcd": "^0.10.0",
     "@pcd/util": "^0.4.0",
     "@pcd/zk-eddsa-event-ticket-pcd": "^0.4.0",
     "@semaphore-protocol/identity": "^3.14.0"

--- a/packages/tools/perftest/package.json
+++ b/packages/tools/perftest/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "commander": "^11.0.0",
     "conf": "^11.0.2",
+    "log-symbols": "^4.1.0",
     "uuid": "^9.0.0",
     "@pcd/eddsa-ticket-pcd": "^0.5.0",
     "@pcd/pcd-types": "^0.10.0",

--- a/packages/tools/perftest/package.json
+++ b/packages/tools/perftest/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@pcd/perftest",
+  "private": true,
+  "version": "0.0.1",
+  "license": "MIT",
+  "scripts": {
+    "start": "yarn ts-node src/index.ts",
+    "lint": "eslint \"**/*.ts{,x}\"",
+    "clean": "rm -rf dist node_modules *.tsbuildinfo"
+  },
+  "dependencies": {
+    "commander": "^11.0.0",
+    "conf": "^11.0.2",
+    "uuid": "^9.0.0",
+    "@pcd/eddsa-ticket-pcd": "^0.5.0",
+    "@pcd/pcd-types": "^0.10.0",
+    "@pcd/semaphore-identity-pcd": "^0.10.0",
+    "@pcd/util": "^0.4.0",
+    "@pcd/zk-eddsa-event-ticket-pcd": "^0.4.0",
+    "@semaphore-protocol/identity": "^3.14.0"
+  },
+  "devDependencies": {
+    "ts-node": "*",
+    "@pcd/eslint-config-custom": "*",
+    "@pcd/tsconfig": "*",
+    "eslint": "^7.32.0",
+    "typescript": "^5.3.3"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  }
+}

--- a/packages/tools/perftest/src/cases/EdDSATicketTimer.ts
+++ b/packages/tools/perftest/src/cases/EdDSATicketTimer.ts
@@ -1,0 +1,91 @@
+import {
+  EdDSATicketPCD,
+  EdDSATicketPCDArgs,
+  EdDSATicketPCDPackage,
+  ITicketData,
+  TicketCategory
+} from "@pcd/eddsa-ticket-pcd";
+import { ArgumentTypeName } from "@pcd/pcd-types";
+import { v4 as uuid } from "uuid";
+import { TimerCase } from "../types";
+
+// Key borrowed from https://github.com/iden3/circomlibjs/blob/4f094c5be05c1f0210924a3ab204d8fd8da69f49/test/eddsa.js#L103
+export const prvKey: string =
+  "0001020304050607080900010203040506070809000102030405060708090001";
+
+export const ticketData: ITicketData = {
+  // the fields below are not signed and are used for display purposes
+
+  attendeeName: "test name",
+  attendeeEmail: "user@test.com",
+  eventName: "event",
+  ticketName: "ticket",
+  checkerEmail: "checker@test.com",
+
+  // the fields below are signed using the server's private eddsa key
+
+  ticketId: uuid(),
+  eventId: uuid(),
+  productId: uuid(),
+  timestampConsumed: Date.now(),
+  timestampSigned: Date.now(),
+  attendeeSemaphoreId: "12345",
+  isConsumed: false,
+  isRevoked: false,
+  ticketCategory: TicketCategory.Devconnect
+};
+
+export const proveArgs: EdDSATicketPCDArgs = {
+  ticket: {
+    value: ticketData,
+    argumentType: ArgumentTypeName.Object
+  },
+  privateKey: {
+    value: prvKey,
+    argumentType: ArgumentTypeName.String
+  },
+  id: {
+    value: undefined,
+    argumentType: ArgumentTypeName.String
+  }
+};
+
+export class EdDSATicketProveCase extends TimerCase {
+  constructor() {
+    super("eddsa-ticket-pcd.prove");
+  }
+
+  async init(): Promise<void> {
+    await EdDSATicketPCDPackage.init?.({});
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  async setup(): Promise<void> {}
+
+  async op(): Promise<void> {
+    await EdDSATicketPCDPackage.prove(proveArgs);
+  }
+}
+
+export class EdDSATicketVerifyCase extends TimerCase {
+  pcd?: EdDSATicketPCD;
+
+  constructor() {
+    super("eddsa-ticket-pcd.verify");
+  }
+
+  async init(): Promise<void> {
+    await EdDSATicketPCDPackage.init?.({});
+  }
+
+  async setup(): Promise<void> {
+    this.pcd = await EdDSATicketPCDPackage.prove(proveArgs);
+  }
+
+  async op(): Promise<void> {
+    if (!this.pcd) {
+      throw new Error("Missing PCD.  Skipped setup?");
+    }
+    await EdDSATicketPCDPackage.verify(this.pcd);
+  }
+}

--- a/packages/tools/perftest/src/cases/EdDSATicketTimer.ts
+++ b/packages/tools/perftest/src/cases/EdDSATicketTimer.ts
@@ -10,7 +10,7 @@ import { v4 as uuid } from "uuid";
 import { TimerCase } from "../types";
 
 // Key borrowed from https://github.com/iden3/circomlibjs/blob/4f094c5be05c1f0210924a3ab204d8fd8da69f49/test/eddsa.js#L103
-export const prvKey: string =
+export const prvKey =
   "0001020304050607080900010203040506070809000102030405060708090001";
 
 export const ticketData: ITicketData = {

--- a/packages/tools/perftest/src/cases/SemaphoreSignatureTimer.ts
+++ b/packages/tools/perftest/src/cases/SemaphoreSignatureTimer.ts
@@ -1,0 +1,85 @@
+import { ArgumentTypeName } from "@pcd/pcd-types";
+import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
+import {
+  SemaphoreSignaturePCD,
+  SemaphoreSignaturePCDArgs,
+  SemaphoreSignaturePCDPackage
+} from "@pcd/semaphore-signature-pcd";
+import { Identity } from "@semaphore-protocol/identity";
+import * as path from "path";
+import { TimerCase } from "../types";
+
+const zkeyFilePath = path.join(
+  __dirname,
+  `../../../../pcd/semaphore-signature-pcd/artifacts/16.zkey`
+);
+const wasmFilePath = path.join(
+  __dirname,
+  `../../../../pcd/semaphore-signature-pcd/artifacts/16.wasm`
+);
+
+async function setupProveArgs(): Promise<SemaphoreSignaturePCDArgs> {
+  const identity = new Identity();
+  const identityPCD = await SemaphoreIdentityPCDPackage.serialize(
+    await SemaphoreIdentityPCDPackage.prove({ identity })
+  );
+
+  return {
+    identity: {
+      argumentType: ArgumentTypeName.PCD,
+      pcdType: SemaphoreIdentityPCDPackage.name,
+      value: identityPCD
+    },
+    signedMessage: {
+      argumentType: ArgumentTypeName.String,
+      value: "Test message"
+    }
+  };
+}
+
+export class SemaphoreSignatureProveCase extends TimerCase {
+  proveArgs?: SemaphoreSignaturePCDArgs;
+
+  constructor() {
+    super("semaphore-signature-pcd.prove");
+  }
+
+  async init(): Promise<void> {
+    await SemaphoreSignaturePCDPackage.init?.({ zkeyFilePath, wasmFilePath });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  async setup(): Promise<void> {
+    this.proveArgs = await setupProveArgs();
+  }
+
+  async op(): Promise<void> {
+    if (!this.proveArgs) {
+      throw new Error("Missing proveArgs.  Skipped setup?");
+    }
+    await SemaphoreSignaturePCDPackage.prove(this.proveArgs);
+  }
+}
+
+export class SemaphoreSignatureVerifyCase extends TimerCase {
+  pcd?: SemaphoreSignaturePCD;
+
+  constructor() {
+    super("semaphore-signature-pcd.verify");
+  }
+
+  async init(): Promise<void> {
+    await SemaphoreSignaturePCDPackage.init?.({ zkeyFilePath, wasmFilePath });
+  }
+
+  async setup(): Promise<void> {
+    this.pcd = await SemaphoreSignaturePCDPackage.prove(await setupProveArgs());
+  }
+
+  async op(): Promise<void> {
+    if (!this.pcd) {
+      throw new Error("Missing PCD.  Skipped setup?");
+    }
+    await SemaphoreSignaturePCDPackage.verify(this.pcd);
+  }
+}

--- a/packages/tools/perftest/src/cases/ZKEdDSAEventTicketTimer.ts
+++ b/packages/tools/perftest/src/cases/ZKEdDSAEventTicketTimer.ts
@@ -1,0 +1,183 @@
+import {
+  EdDSATicketPCDPackage,
+  EdDSATicketPCDTypeName,
+  ITicketData,
+  TicketCategory
+} from "@pcd/eddsa-ticket-pcd";
+import { ArgumentTypeName } from "@pcd/pcd-types";
+import {
+  SemaphoreIdentityPCDPackage,
+  SemaphoreIdentityPCDTypeName
+} from "@pcd/semaphore-identity-pcd";
+import {
+  EdDSATicketFieldsToReveal,
+  ZKEdDSAEventTicketPCD,
+  ZKEdDSAEventTicketPCDArgs,
+  ZKEdDSAEventTicketPCDPackage
+} from "@pcd/zk-eddsa-event-ticket-pcd";
+import { Identity } from "@semaphore-protocol/identity";
+import * as path from "path";
+import { v4 as uuid } from "uuid";
+import { TimerCase } from "../types";
+
+const zkeyFilePath = path.join(
+  __dirname,
+  `../../../../pcd/zk-eddsa-event-ticket-pcd/artifacts/circuit.zkey`
+);
+const wasmFilePath = path.join(
+  __dirname,
+  `../../../../pcd/zk-eddsa-event-ticket-pcd/artifacts/circuit.wasm`
+);
+
+async function setupProveArgs(): Promise<ZKEdDSAEventTicketPCDArgs> {
+  const identity = new Identity(
+    '["329061722381819402313027227353491409557029289040211387019699013780657641967", "99353161014976810914716773124042455250852206298527174581112949561812190422"]'
+  );
+
+  // Key borrowed from https://github.com/iden3/circomlibjs/blob/4f094c5be05c1f0210924a3ab204d8fd8da69f49/test/eddsa.js#L103
+  const prvKey =
+    "0001020304050607080900010203040506070809000102030405060708090001";
+
+  const WATERMARK = BigInt(6);
+  const EXTERNAL_NULLIFIER = BigInt(42);
+
+  const ticketData: ITicketData = {
+    // the fields below are not signed and are used for display purposes
+
+    attendeeName: "test name",
+    attendeeEmail: "user@test.com",
+    eventName: "event",
+    ticketName: "ticket",
+    checkerEmail: "checker@test.com",
+
+    // the fields below are signed using the server's private eddsa key
+
+    ticketId: "b38501b0-cf66-4416-a4ef-631a9a9b32c4",
+    eventId: "4332f16c-8444-4261-94b9-a0ba8ca917e2",
+    productId: "c94002fb-2c41-480b-842d-fa826fb517e5",
+    timestampConsumed: 0,
+    timestampSigned: 1693028498280,
+    attendeeSemaphoreId: identity.getCommitment().toString(),
+    isConsumed: false,
+    isRevoked: false,
+    ticketCategory: TicketCategory.Devconnect
+  };
+
+  const fieldsToReveal: EdDSATicketFieldsToReveal = {
+    revealEventId: true,
+    revealProductId: true
+  };
+
+  const validEventIdsContainingTicket: string[] = [
+    uuid(),
+    ticketData.eventId,
+    uuid(),
+    uuid()
+  ];
+
+  const identityPCD = await SemaphoreIdentityPCDPackage.prove({
+    identity: identity
+  });
+
+  const serializedIdentityPCD =
+    await SemaphoreIdentityPCDPackage.serialize(identityPCD);
+
+  const ticketPCD = await EdDSATicketPCDPackage.prove({
+    ticket: {
+      value: ticketData,
+      argumentType: ArgumentTypeName.Object
+    },
+    privateKey: {
+      value: prvKey,
+      argumentType: ArgumentTypeName.String
+    },
+    id: {
+      value: undefined,
+      argumentType: ArgumentTypeName.String
+    }
+  });
+
+  const serializedTicketPCD = await EdDSATicketPCDPackage.serialize(ticketPCD);
+
+  return {
+    ticket: {
+      value: serializedTicketPCD,
+      argumentType: ArgumentTypeName.PCD,
+      pcdType: EdDSATicketPCDTypeName
+    },
+    identity: {
+      value: serializedIdentityPCD,
+      argumentType: ArgumentTypeName.PCD,
+      pcdType: SemaphoreIdentityPCDTypeName
+    },
+    fieldsToReveal: {
+      value: fieldsToReveal,
+      argumentType: ArgumentTypeName.ToggleList
+    },
+    validEventIds: {
+      value: validEventIdsContainingTicket,
+      argumentType: ArgumentTypeName.StringArray
+    },
+    externalNullifier: {
+      value: EXTERNAL_NULLIFIER.toString(),
+      argumentType: ArgumentTypeName.BigInt
+    },
+    watermark: {
+      value: WATERMARK.toString(),
+      argumentType: ArgumentTypeName.BigInt
+    }
+  };
+}
+
+export class ZKEdDSAEventTicketProveCase extends TimerCase {
+  proveArgs?: ZKEdDSAEventTicketPCDArgs;
+
+  constructor() {
+    super("zk-eddsa-event-ticket-pcd.prove");
+  }
+
+  async init(): Promise<void> {
+    await ZKEdDSAEventTicketPCDPackage.init?.({
+      zkeyFilePath,
+      wasmFilePath
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  async setup(): Promise<void> {
+    this.proveArgs = await setupProveArgs();
+  }
+
+  async op(): Promise<void> {
+    if (!this.proveArgs) {
+      throw new Error("Missing proveArgs.  Skipped setup?");
+    }
+    await ZKEdDSAEventTicketPCDPackage.prove(this.proveArgs);
+  }
+}
+
+export class ZKEdDSAEventTicketVerifyCase extends TimerCase {
+  pcd?: ZKEdDSAEventTicketPCD;
+
+  constructor() {
+    super("zk-eddsa-event-ticket-pcd.verify");
+  }
+
+  async init(): Promise<void> {
+    await ZKEdDSAEventTicketPCDPackage.init?.({
+      zkeyFilePath,
+      wasmFilePath
+    });
+  }
+
+  async setup(): Promise<void> {
+    this.pcd = await ZKEdDSAEventTicketPCDPackage.prove(await setupProveArgs());
+  }
+
+  async op(): Promise<void> {
+    if (!this.pcd) {
+      throw new Error("Missing PCD.  Skipped setup?");
+    }
+    await ZKEdDSAEventTicketPCDPackage.verify(this.pcd);
+  }
+}

--- a/packages/tools/perftest/src/index.ts
+++ b/packages/tools/perftest/src/index.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import { program } from "commander";
+import logSymbols from "log-symbols";
+import "./timer";
+
+program
+  .name("pcd-perftest")
+  .description("Command line tool for testing PCD performance.")
+  .version("0.0.1", "-v, --version", "Show PCD pertest CLI version.")
+  .configureOutput({
+    outputError: (message) => {
+      console.info(`\n ${logSymbols.error}`, message);
+    }
+  });
+
+program.parse(process.argv);

--- a/packages/tools/perftest/src/index.ts
+++ b/packages/tools/perftest/src/index.ts
@@ -7,7 +7,7 @@ import "./timer";
 program
   .name("pcd-perftest")
   .description("Command line tool for testing PCD performance.")
-  .version("0.0.1", "-v, --version", "Show PCD pertest CLI version.")
+  .version("0.0.1", "-v, --version", "Show PCD perftest CLI version.")
   .configureOutput({
     outputError: (message) => {
       console.info(`\n ${logSymbols.error}`, message);

--- a/packages/tools/perftest/src/timer.ts
+++ b/packages/tools/perftest/src/timer.ts
@@ -90,14 +90,12 @@ program
       pcdOperation: string,
       iterationCount: number
     ) => {
-      console.log("ART_DBG: action()");
       const testCases: (() => TimerCase)[] = [];
 
       // Single package, or all packages
       let packageNames = [pcdPackage];
       if (pcdPackage === "all") {
         packageNames = Object.keys(TIME_TEST_CONFIGS);
-        console.log("ART_DBG", packageNames);
       }
 
       for (const curPackageName of packageNames) {

--- a/packages/tools/perftest/src/timer.ts
+++ b/packages/tools/perftest/src/timer.ts
@@ -1,0 +1,113 @@
+import { EdDSATicketPCDPackage } from "@pcd/eddsa-ticket-pcd";
+import { ZKEdDSAEventTicketPCDPackage } from "@pcd/zk-eddsa-event-ticket-pcd";
+import { program } from "commander";
+import logSymbols from "log-symbols";
+import {
+  EdDSATicketProveCase,
+  EdDSATicketVerifyCase
+} from "./cases/EdDSATicketTimer";
+import {
+  ZKEdDSAEventTicketProveCase,
+  ZKEdDSAEventTicketVerifyCase
+} from "./cases/ZKEdDSAEventTicketTimer";
+import { DemoCase, TimerCase } from "./types";
+
+const TIME_TEST_CONFIGS: Record<string, Record<string, () => TimerCase>> = {
+  demo: {
+    demo: () => new DemoCase()
+  },
+  [EdDSATicketPCDPackage.name]: {
+    prove: () => new EdDSATicketProveCase(),
+    verify: () => new EdDSATicketVerifyCase()
+  },
+  [ZKEdDSAEventTicketPCDPackage.name]: {
+    prove: () => new ZKEdDSAEventTicketProveCase(),
+    verify: () => new ZKEdDSAEventTicketVerifyCase()
+  }
+};
+
+async function timeOp(
+  opName: string,
+  iterationCount: number,
+  op: () => Promise<void>
+): Promise<void> {
+  const startMS = performance.now();
+  for (let i = 0; i < iterationCount; i++) {
+    await op();
+  }
+  const endMS = performance.now();
+  console.info(
+    `${logSymbols.success}`,
+    `${opName}${iterationCount > 1 ? ` (average of ${iterationCount})` : ""}: ${
+      (endMS - startMS) / iterationCount
+    }ms`
+  );
+}
+
+async function timerDriver(
+  caseMaker: () => TimerCase,
+  iterationCount: number
+): Promise<void> {
+  const timerCase = caseMaker();
+  console.info(`Running timing test of ${timerCase.name}...`);
+  await timeOp("init", 1, () => timerCase.init());
+  await timeOp("setup", 1, () => timerCase.setup());
+  await timeOp("first op", 1, () => timerCase.op());
+  await timeOp("second op", 1, () => timerCase.op());
+  await timeOp("repeat op", iterationCount, () => timerCase.op());
+}
+
+program
+  .command("timer")
+  .description("Time a set of operations for a PCD packge")
+  .argument("<pcd-package>", "Supported PCD package.")
+  .argument("<operation>", "PCD operation (prove, verify).")
+  .argument("[count]", "Count of iterations for averaging.", 10)
+  .action(
+    async (
+      packageName: string,
+      pcdOperation: string,
+      iterationCount: number
+    ) => {
+      const testCases: (() => TimerCase)[] = [];
+      if (packageName !== "all") {
+        const testPackage = TIME_TEST_CONFIGS[packageName];
+        if (!testPackage) {
+          console.error(
+            `${logSymbols.error}`,
+            `No test config for package ${packageName}`
+          );
+          process.exit(1);
+        }
+        const testCase = testPackage[pcdOperation];
+        if (!testCase) {
+          console.error(
+            `${logSymbols.error}`,
+            `No test config for operation ${packageName}.${pcdOperation}`
+          );
+          process.exit(1);
+        }
+        testCases.push(testCase);
+      } else {
+        for (const testPackage of Object.values(TIME_TEST_CONFIGS)) {
+          for (const testCase of Object.values(testPackage)) {
+            testCases.push(testCase);
+          }
+        }
+      }
+
+      try {
+        for (const testCase of testCases) {
+          await timerDriver(testCase, iterationCount);
+        }
+      } catch (error) {
+        console.error(`${logSymbols.error}`, `${error}`);
+        process.exit(1);
+      }
+
+      // This shouldn't be necessary, but otherwise the program doesn't exit
+      // after ZKEdDSAEventTicketPCD test cases.  Probably some zombie async
+      // code which I don't have time to hunt down right now.
+      process.exit(0);
+    }
+  );

--- a/packages/tools/perftest/src/types.ts
+++ b/packages/tools/perftest/src/types.ts
@@ -1,0 +1,31 @@
+import { sleep } from "@pcd/util";
+import logSymbols from "log-symbols";
+
+export abstract class TimerCase {
+  name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  abstract init(): Promise<void>;
+  abstract setup(): Promise<void>;
+  abstract op(): Promise<void>;
+}
+
+export class DemoCase extends TimerCase {
+  constructor() {
+    super("demo");
+  }
+  async init(): Promise<void> {
+    await sleep(1000);
+    console.info(`${logSymbols.success}`, "init()");
+  }
+  async setup(): Promise<void> {
+    await sleep(1000);
+    console.info(`${logSymbols.success}`, "setup()");
+  }
+  async op(): Promise<void> {
+    await sleep(100);
+    console.info(`${logSymbols.success}`, "op()");
+  }
+}

--- a/packages/tools/perftest/tsconfig.json
+++ b/packages/tools/perftest/tsconfig.json
@@ -30,7 +30,13 @@
       "path": "../../lib/pcd-types"
     },
     {
+      "path": "../../pcd/semaphore-identity-pcd"
+    },
+    {
       "path": "../../lib/util"
+    },
+    {
+      "path": "../../pcd/zk-eddsa-event-ticket-pcd"
     }
   ]
 }

--- a/packages/tools/perftest/tsconfig.json
+++ b/packages/tools/perftest/tsconfig.json
@@ -33,6 +33,9 @@
       "path": "../../pcd/semaphore-identity-pcd"
     },
     {
+      "path": "../../pcd/semaphore-signature-pcd"
+    },
+    {
       "path": "../../lib/util"
     },
     {

--- a/packages/tools/perftest/tsconfig.json
+++ b/packages/tools/perftest/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "extends": "@pcd/tsconfig/ts-library.json",
+  "compilerOptions": {
+    "lib": [
+      "dom"
+    ],
+    "outDir": "dist",
+    "declarationDir": "dist/types",
+    // Include all source files, including tests
+    "rootDir": "."
+  },
+  // Some artifact-including packages need to import a JSON file
+  "include": [
+    "src",
+    "test",
+    "artifacts/*.json"
+  ],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules"
+  ],
+  // DO NOT MODIFY MANUALLY BEYOND THIS POINT
+  // References are automatically maintained by `yarn fix-references`
+  "references": [
+    {
+      "path": "../../pcd/eddsa-ticket-pcd"
+    },
+    {
+      "path": "../../lib/pcd-types"
+    },
+    {
+      "path": "../../lib/util"
+    }
+  ]
+}

--- a/packages/tools/perftest/typedoc.json
+++ b/packages/tools/perftest/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["src/index.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16097,7 +16097,7 @@ ts-node-dev@^2.0.0:
     ts-node "^10.4.0"
     tsconfig "^7.0.0"
 
-ts-node@7.0.1, ts-node@^10.4.0, ts-node@^10.9.2:
+ts-node@*, ts-node@7.0.1, ts-node@^10.4.0, ts-node@^10.9.2:
   version "10.9.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==


### PR DESCRIPTION
Adds a command-line tool for rough local perf testing of PCD operations, by running them repeatedly and averaging.  It has cases built for eddsa-ticket-pcd and zk-eddsa-event-ticket-pcd and room to easily add more.  My intent is to use this to verify any changes to cryptographic libraries don't regress our performance too badly, starting with a retroactive test of #1493 (see comment on that PR).

Can be run like this:

    cd zupass/packages/tools/perftest
    yarn start timer all all

Here's a snippet of example output from testing #1493:

```
Running timing test of zk-eddsa-event-ticket-pcd.prove...
✔ init: 0.15695810317993164ms
✔ setup: 44.70187520980835ms
✔ first op: 1298.1974577903748ms
✔ second op: 519.0421657562256ms
✔ repeat op (average of 10): 514.5606165885926ms
Running timing test of zk-eddsa-event-ticket-pcd.verify...
✔ init: 0.07541704177856445ms
✔ setup: 566.9950408935547ms
✔ first op: 9.173666000366211ms
✔ second op: 7.883166313171387ms
✔ repeat op (average of 10): 8.090016603469849ms
```

I'm sure the TypeScript is a mess, and I'm open to feedback for learning purposes.  Seems to work well enough for what it is, though.