### PR TITLE
Move checkin credential code to passport-interface

### DIFF
--- a/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
@@ -53,10 +53,10 @@ import {
   isFeedIssuanceCapability
 } from "./capabilities/FeedIssuanceCapability";
 import { traceLoadSummary, tracePipeline, traceUser } from "./honeycombQueries";
-import { isCSVPipelineDefinition } from "./pipelines/PretixPipeline";
 import { instantiatePipeline } from "./pipelines/instantiatePipeline";
 import { Pipeline, PipelineUser } from "./pipelines/types";
 import { makePLogErr, makePLogInfo } from "./util";
+import { isCSVPipelineDefinition } from "./pipelines/PretixPipeline";
 
 const SERVICE_NAME = "GENERIC_ISSUANCE";
 const LOG_TAG = `[${SERVICE_NAME}]`;

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -821,6 +821,7 @@ export class PretixPipeline implements BasePipeline {
             checkerEmailPCD.claim.semaphoreId
           );
         } catch (e) {
+          logger(`${LOG_TAG} Failed to verify credential due to error: `, e);
           setError(e, span);
           span?.setAttribute("precheck_error", "InvalidSignature");
           return { canCheckIn: false, error: { name: "InvalidSignature" } };
@@ -938,6 +939,7 @@ export class PretixPipeline implements BasePipeline {
           checkerEmailPCD.claim.semaphoreId
         );
       } catch (e) {
+        logger(`${LOG_TAG} Failed to verify credential due to error: `, e);
         setError(e, span);
         span?.setAttribute("checkin_error", "InvalidSignature");
         return { checkedIn: false, error: { name: "InvalidSignature" } };

--- a/packages/lib/passport-interface/src/CheckinCredential.ts
+++ b/packages/lib/passport-interface/src/CheckinCredential.ts
@@ -1,0 +1,78 @@
+import { EmailPCD, EmailPCDPackage } from "@pcd/email-pcd";
+import { SerializedPCD } from "@pcd/pcd-types";
+import {
+  SemaphoreSignaturePCD,
+  SemaphoreSignaturePCDPackage
+} from "@pcd/semaphore-signature-pcd";
+
+/*
+ * The payload encoded in the message of the SemaphoreSignaturePCD passed
+ * as a credential to the checkin api within the Generic Issuance backend.
+ */
+export interface GenericCheckinCredentialPayload {
+  emailPCD: SerializedPCD<EmailPCD>;
+  ticketIdToCheckIn: string;
+  eventId: string;
+  timestamp: number;
+}
+
+/**
+ * After verification, return the unserialized Email PCD.
+ */
+export interface VerifiedCheckinCredential {
+  emailPCD: EmailPCD;
+  ticketIdToCheckIn: string;
+  eventId: string;
+}
+
+/**
+ * Creates a credential payload for use in the Generic Issuance checkin API.
+ */
+export function createGenericCheckinCredentialPayload(
+  emailPCD: SerializedPCD<EmailPCD>,
+  ticketId: string,
+  eventId: string
+): GenericCheckinCredentialPayload {
+  return {
+    emailPCD: emailPCD,
+    ticketIdToCheckIn: ticketId,
+    eventId,
+    timestamp: Date.now()
+  };
+}
+
+/**
+ * When checking tickets in, the user submits a payload wrapped in a Semaphore
+ * signature.
+ */
+export async function verifyCheckinCredential(
+  credential: SerializedPCD<SemaphoreSignaturePCD>
+): Promise<VerifiedCheckinCredential> {
+  const signaturePCD = await SemaphoreSignaturePCDPackage.deserialize(
+    credential.pcd
+  );
+  const signaturePCDValid =
+    await SemaphoreSignaturePCDPackage.verify(signaturePCD);
+
+  if (!signaturePCDValid) {
+    throw new Error("Invalid signature");
+  }
+
+  const payload: GenericCheckinCredentialPayload = JSON.parse(
+    signaturePCD.claim.signedMessage
+  );
+
+  // TODO in the feed credential verification, we also check the timestamp
+  // Do we need to do this here?
+
+  const emailPCD = await EmailPCDPackage.deserialize(payload.emailPCD.pcd);
+  if (!(await EmailPCDPackage.verify(emailPCD))) {
+    throw new Error("Invalid email PCD");
+  }
+
+  return {
+    emailPCD,
+    ticketIdToCheckIn: payload.ticketIdToCheckIn,
+    eventId: payload.eventId
+  };
+}

--- a/packages/lib/passport-interface/src/FeedCredential.ts
+++ b/packages/lib/passport-interface/src/FeedCredential.ts
@@ -19,19 +19,6 @@ export interface FeedCredentialPayload {
   timestamp: number;
 }
 
-/*
- * The payload encoded in the message of the SemaphoreSignaturePCD passed
- * as a credential to the checkin api within the Generic Issuance backend.
- *
- * TODO: move to a different file.
- */
-export interface GenericCheckinCredentialPayload {
-  emailPCD: SerializedPCD<EmailPCD>;
-  ticketIdToCheckIn: string;
-  eventId: string;
-  timestamp: number;
-}
-
 /**
  * Creates a feed credential payload with timestamp.
  */
@@ -40,24 +27,6 @@ export function createFeedCredentialPayload(
 ): FeedCredentialPayload {
   return {
     pcd: pcd,
-    timestamp: Date.now()
-  };
-}
-
-/**
- * Creates a credential payload for use in the Generic Issuance checkin API.
- *
- * TODO: move to a different file.
- */
-export function createGenericCheckinCredentialPayload(
-  emailPCD: SerializedPCD<EmailPCD>,
-  ticketId: string,
-  eventId: string
-): GenericCheckinCredentialPayload {
-  return {
-    emailPCD: emailPCD,
-    ticketIdToCheckIn: ticketId,
-    eventId,
     timestamp: Date.now()
   };
 }

--- a/packages/lib/passport-interface/src/index.ts
+++ b/packages/lib/passport-interface/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./CheckinCredential";
 export * from "./CredentialManager";
 export * from "./EncryptedStorage";
 export * from "./FeedAPI";


### PR DESCRIPTION
Removes duplicated code between Lemonade and Pretix pipelines by having a single shared function for verifying check-in credentials in `passport-interface`. This code also correctly verifies the email PCD, which was not previously done.

In future we might want to cache these verifications, particularly because at large events there will be many check-ins using the same credentials. However, we should work out if/how we want to do timestamping to prevent unlimited credential reuse.