### PR TITLE
Remove all PCDs in folder

### DIFF
--- a/apps/passport-client/components/screens/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen.tsx
@@ -108,8 +108,6 @@ export function HomeScreenImpl(): JSX.Element {
     document.body.scrollTop = document.documentElement.scrollTop = 0;
   }, []);
 
-  if (self == null) return null;
-
   const onRemoveAllClick = useCallback(() => {
     if (
       window.confirm(
@@ -119,6 +117,8 @@ export function HomeScreenImpl(): JSX.Element {
       dispatch({ type: "remove-all-pcds-in-folder", folder: browsingFolder });
     }
   }, [browsingFolder, dispatch]);
+
+  if (self == null) return null;
 
   return (
     <>

--- a/apps/passport-client/components/screens/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen.tsx
@@ -15,6 +15,7 @@ import React, {
 import { useNavigate, useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 import {
+  useDispatch,
   useFolders,
   usePCDCollection,
   usePCDsInFolder,
@@ -22,7 +23,7 @@ import {
 } from "../../src/appHooks";
 import { useSyncE2EEStorage } from "../../src/useSyncE2EEStorage";
 import { isFrogCryptoFolder } from "../../src/util";
-import { Placeholder, Spacer } from "../core";
+import { Button, Placeholder, Spacer } from "../core";
 import { MaybeModal } from "../modals/Modal";
 import { AppContainer } from "../shared/AppContainer";
 import { AppHeader } from "../shared/AppHeader";
@@ -42,6 +43,7 @@ export function HomeScreenImpl(): JSX.Element {
   useSyncE2EEStorage();
   const self = useSelf();
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   const pcdCollection = usePCDCollection();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -108,6 +110,16 @@ export function HomeScreenImpl(): JSX.Element {
 
   if (self == null) return null;
 
+  const onRemoveAllClick = useCallback(() => {
+    if (
+      window.confirm(
+        "Are you sure you want to remove all PCDs in this folder? They will be permanently deleted!"
+      )
+    ) {
+      dispatch({ type: "remove-all-pcds-in-folder", folder: browsingFolder });
+    }
+  }, [browsingFolder, dispatch]);
+
   return (
     <>
       <MaybeModal />
@@ -159,6 +171,20 @@ export function HomeScreenImpl(): JSX.Element {
                 <PCDCardList pcds={pcdsInFolder} />
               ) : (
                 <NoPcdsContainer>This folder has no PCDs</NoPcdsContainer>
+              )}
+              {pcdsInFolder.length > 0 && !isRoot && (
+                <>
+                  <Spacer h={16} />
+                  <RemoveAllContainer>
+                    <Button
+                      style="danger"
+                      size="small"
+                      onClick={onRemoveAllClick}
+                    >
+                      Remove all
+                    </Button>
+                  </RemoveAllContainer>
+                </>
               )}
             </>
           )}
@@ -297,4 +323,11 @@ const FolderEntryContainer = styled.div`
   &:hover {
     background: var(--primary-lite);
   }
+`;
+
+const RemoveAllContainer = styled.div`
+  padding: 0px 16px 16px 16px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
 `;

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -101,6 +101,7 @@ export type Action =
   | { type: "password-change-on-other-tab" }
   | { type: "add-pcds"; pcds: SerializedPCD[]; upsert?: boolean }
   | { type: "remove-pcd"; id: string }
+  | { type: "remove-all-pcds-in-folder"; folder: string }
   | { type: "sync" }
   | { type: "resolve-subscription-error"; subscriptionId: string }
   | {
@@ -200,6 +201,8 @@ export async function dispatch(
       return addPCDs(state, update, action.pcds, action.upsert);
     case "remove-pcd":
       return removePCD(state, update, action.id);
+    case "remove-all-pcds-in-folder":
+      return removeAllPCDsInFolder(state, update, action.folder);
     case "participant-invalid":
       return userInvalid(update);
     case "sync":
@@ -1122,4 +1125,20 @@ async function mergeImport(
       }
     });
   }
+}
+
+async function removeAllPCDsInFolder(
+  state: AppState,
+  update: ZuUpdate,
+  folder: string
+): Promise<void> {
+  const packages = await getPackages();
+  const pcds = new PCDCollection(
+    packages,
+    state.pcds.getAll(),
+    state.pcds.folders
+  );
+  pcds.removeAllPCDsInFolder(folder);
+  update({ pcds });
+  window.scrollTo({ top: 0 });
 }


### PR DESCRIPTION
Closes #1513 

<img width="436" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/69627e29-595c-4257-a1c6-d2f3b2e93a40">

Adds a button to remove all PCDs in a folder. Does not appear in the root folder. Does not navigate you away from the folder after clearing it - showing the user the empty folder seems like a reasonable way of confirming that the PCDs were removed, and it's easy to navigate up to higher-level folders from there.