### PR TITLE
Cache issuance in Lemonade and Pretix pipelines

### DIFF
--- a/apps/passport-server/src/services.ts
+++ b/apps/passport-server/src/services.ts
@@ -91,7 +91,8 @@ export async function startServices(
     apis.lemonadeAPI,
     apis.genericPretixAPI,
     pagerDutyService,
-    discordService
+    discordService,
+    persistentCacheService
   );
 
   const services: GlobalServices = {

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -36,6 +36,7 @@ import {
   PipelineAtom
 } from "../../../database/queries/pipelineAtomDB";
 import { logger } from "../../../util/logger";
+import { PersistentCacheService } from "../../persistentCacheService";
 import { setError, traced } from "../../telemetryService";
 import {
   CheckinCapability,
@@ -93,6 +94,7 @@ export class LemonadePipeline implements BasePipeline {
    */
   private db: IPipelineAtomDB<LemonadeAtom>;
   private api: ILemonadeAPI;
+  private cacheService: PersistentCacheService;
 
   public get id(): string {
     return this.definition.id;
@@ -111,7 +113,8 @@ export class LemonadePipeline implements BasePipeline {
     definition: LemonadePipelineDefinition,
     db: IPipelineAtomDB,
     api: ILemonadeAPI,
-    zupassPublicKey: EdDSAPublicKey
+    zupassPublicKey: EdDSAPublicKey,
+    cacheService: PersistentCacheService
   ) {
     this.eddsaPrivateKey = eddsaPrivateKey;
     this.definition = definition;
@@ -142,6 +145,7 @@ export class LemonadePipeline implements BasePipeline {
       } satisfies CheckinCapability
     ] as unknown as BasePipelineCapability[];
     this.pendingCheckIns = new Map();
+    this.cacheService = cacheService;
   }
 
   public async stop(): Promise<void> {
@@ -423,11 +427,8 @@ export class LemonadePipeline implements BasePipeline {
       span?.setAttribute("email", email);
       span?.setAttribute("semaphore_id", emailPCD.claim.semaphoreId);
 
-      // TODO: cache this intelligently
       const tickets = await Promise.all(
-        ticketDatas.map((t) =>
-          this.ticketDataToTicketPCD(t, this.eddsaPrivateKey)
-        )
+        ticketDatas.map((t) => this.getOrGenerateTicket(t))
       );
 
       span?.setAttribute("pcds_issued", tickets.length);
@@ -444,6 +445,82 @@ export class LemonadePipeline implements BasePipeline {
         ]
       };
     });
+  }
+
+  private async getOrGenerateTicket(
+    ticketData: ITicketData
+  ): Promise<EdDSATicketPCD> {
+    return traced(LOG_NAME, "getOrGenerateTicket", async (span) => {
+      span?.setAttribute("ticket_id", ticketData.ticketId);
+      span?.setAttribute("ticket_email", ticketData.attendeeEmail);
+      span?.setAttribute("ticket_name", ticketData.attendeeName);
+
+      const cachedTicket = await this.getCachedTicket(ticketData);
+
+      if (cachedTicket) {
+        return cachedTicket;
+      }
+
+      logger(`${LOG_TAG} cache miss for ticket id ${ticketData.ticketId}`);
+
+      const generatedTicket = await this.ticketDataToTicketPCD(
+        ticketData,
+        this.eddsaPrivateKey
+      );
+
+      try {
+        this.cacheTicket(generatedTicket);
+      } catch (e) {
+        logger(
+          `${LOG_TAG} error caching ticket ${ticketData.ticketId} ` +
+            `${ticketData.attendeeEmail} for ${ticketData.eventId} (${ticketData.eventName})`
+        );
+      }
+
+      return generatedTicket;
+    });
+  }
+
+  private static async getTicketCacheKey(
+    ticketData: ITicketData
+  ): Promise<string> {
+    const ticketCopy: Partial<ITicketData> = { ...ticketData };
+    // the reason we remove `timestampSigned` from the cache key
+    // is that it changes every time we instantiate `ITicketData`
+    // for a particular devconnect ticket, rendering the caching
+    // ineffective.
+    delete ticketCopy.timestampSigned;
+    const hash = await getHash(JSON.stringify(ticketCopy));
+    return hash;
+  }
+
+  private async cacheTicket(ticket: EdDSATicketPCD): Promise<void> {
+    const key = await LemonadePipeline.getTicketCacheKey(ticket.claim.ticket);
+    const serialized = await EdDSATicketPCDPackage.serialize(ticket);
+    this.cacheService.setValue(key, JSON.stringify(serialized));
+  }
+
+  private async getCachedTicket(
+    ticketData: ITicketData
+  ): Promise<EdDSATicketPCD | undefined> {
+    const key = await LemonadePipeline.getTicketCacheKey(ticketData);
+    const serializedTicket = await this.cacheService.getValue(key);
+    if (!serializedTicket) {
+      logger(`${LOG_TAG} cache miss for ticket id ${ticketData.ticketId}`);
+      return undefined;
+    }
+    logger(`${LOG_TAG} cache hit for ticket id ${ticketData.ticketId}`);
+    const parsedTicket = JSON.parse(serializedTicket.cache_value);
+
+    try {
+      const deserializedTicket = await EdDSATicketPCDPackage.deserialize(
+        parsedTicket.pcd
+      );
+      return deserializedTicket;
+    } catch (e) {
+      logger(`${LOG_TAG} failed to parse cached ticket ${key}`, e);
+      return undefined;
+    }
   }
 
   private async ticketDataToTicketPCD(

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -43,6 +43,7 @@ import {
 } from "../../../database/queries/pipelineAtomDB";
 import { mostRecentCheckinEvent } from "../../../util/devconnectTicket";
 import { logger } from "../../../util/logger";
+import { PersistentCacheService } from "../../persistentCacheService";
 import { setError, traced } from "../../telemetryService";
 import {
   CheckinCapability,
@@ -78,6 +79,7 @@ export class PretixPipeline implements BasePipeline {
   private eddsaPrivateKey: string;
   private definition: PretixPipelineDefinition;
   private zupassPublicKey: EdDSAPublicKey;
+  private cacheService: PersistentCacheService;
 
   // Pending check-ins are check-ins which have either completed (and have
   // succeeded) or are in-progress, but which are not yet reflected in the data
@@ -112,7 +114,8 @@ export class PretixPipeline implements BasePipeline {
     definition: PretixPipelineDefinition,
     db: IPipelineAtomDB,
     api: IGenericPretixAPI,
-    zupassPublicKey: EdDSAPublicKey
+    zupassPublicKey: EdDSAPublicKey,
+    cacheService: PersistentCacheService
   ) {
     this.eddsaPrivateKey = eddsaPrivateKey;
     this.definition = definition;
@@ -142,6 +145,7 @@ export class PretixPipeline implements BasePipeline {
       } satisfies CheckinCapability
     ] as unknown as BasePipelineCapability[];
     this.pendingCheckIns = new Map();
+    this.cacheService = cacheService;
   }
 
   public async stop(): Promise<void> {
@@ -645,11 +649,8 @@ export class PretixPipeline implements BasePipeline {
         this.atomToTicketData(t, credential.claim.identityCommitment)
       );
 
-      // TODO: cache this intelligently
       const tickets = await Promise.all(
-        ticketDatas.map((t) =>
-          this.ticketDataToTicketPCD(t, this.eddsaPrivateKey)
-        )
+        ticketDatas.map((t) => this.getOrGenerateTicket(t))
       );
 
       span?.setAttribute("pcds_issued", tickets.length);
@@ -694,6 +695,82 @@ export class PretixPipeline implements BasePipeline {
       isRevoked: false,
       ticketCategory: TicketCategory.Generic
     };
+  }
+
+  private async getOrGenerateTicket(
+    ticketData: ITicketData
+  ): Promise<EdDSATicketPCD> {
+    return traced(LOG_NAME, "getOrGenerateTicket", async (span) => {
+      span?.setAttribute("ticket_id", ticketData.ticketId);
+      span?.setAttribute("ticket_email", ticketData.attendeeEmail);
+      span?.setAttribute("ticket_name", ticketData.attendeeName);
+
+      const cachedTicket = await this.getCachedTicket(ticketData);
+
+      if (cachedTicket) {
+        return cachedTicket;
+      }
+
+      logger(`${LOG_TAG} cache miss for ticket id ${ticketData.ticketId}`);
+
+      const generatedTicket = await this.ticketDataToTicketPCD(
+        ticketData,
+        this.eddsaPrivateKey
+      );
+
+      try {
+        this.cacheTicket(generatedTicket);
+      } catch (e) {
+        logger(
+          `${LOG_TAG} error caching ticket ${ticketData.ticketId} ` +
+            `${ticketData.attendeeEmail} for ${ticketData.eventId} (${ticketData.eventName})`
+        );
+      }
+
+      return generatedTicket;
+    });
+  }
+
+  private static async getTicketCacheKey(
+    ticketData: ITicketData
+  ): Promise<string> {
+    const ticketCopy: Partial<ITicketData> = { ...ticketData };
+    // the reason we remove `timestampSigned` from the cache key
+    // is that it changes every time we instantiate `ITicketData`
+    // for a particular devconnect ticket, rendering the caching
+    // ineffective.
+    delete ticketCopy.timestampSigned;
+    const hash = await getHash(JSON.stringify(ticketCopy));
+    return hash;
+  }
+
+  private async cacheTicket(ticket: EdDSATicketPCD): Promise<void> {
+    const key = await PretixPipeline.getTicketCacheKey(ticket.claim.ticket);
+    const serialized = await EdDSATicketPCDPackage.serialize(ticket);
+    this.cacheService.setValue(key, JSON.stringify(serialized));
+  }
+
+  private async getCachedTicket(
+    ticketData: ITicketData
+  ): Promise<EdDSATicketPCD | undefined> {
+    const key = await PretixPipeline.getTicketCacheKey(ticketData);
+    const serializedTicket = await this.cacheService.getValue(key);
+    if (!serializedTicket) {
+      logger(`${LOG_TAG} cache miss for ticket id ${ticketData.ticketId}`);
+      return undefined;
+    }
+    logger(`${LOG_TAG} cache hit for ticket id ${ticketData.ticketId}`);
+    const parsedTicket = JSON.parse(serializedTicket.cache_value);
+
+    try {
+      const deserializedTicket = await EdDSATicketPCDPackage.deserialize(
+        parsedTicket.pcd
+      );
+      return deserializedTicket;
+    } catch (e) {
+      logger(`${LOG_TAG} failed to parse cached ticket ${key}`, e);
+      return undefined;
+    }
   }
 
   private async ticketDataToTicketPCD(

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -778,7 +778,9 @@ export class PretixPipeline implements BasePipeline {
     }
 
     try {
-      logger(`${LOG_TAG} cache hit for ticket id ${ticketData.ticketId} on pipeline ${this.id}`);
+      logger(
+        `${LOG_TAG} cache hit for ticket id ${ticketData.ticketId} on pipeline ${this.id}`
+      );
       const parsedTicket = JSON.parse(serializedTicket.cache_value);
       const deserializedTicket = await EdDSATicketPCDPackage.deserialize(
         parsedTicket.pcd

--- a/apps/passport-server/src/services/generic-issuance/pipelines/instantiatePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/instantiatePipeline.ts
@@ -3,6 +3,7 @@ import { PipelineDefinition } from "@pcd/passport-interface";
 import { ILemonadeAPI } from "../../../apis/lemonade/lemonadeAPI";
 import { IGenericPretixAPI } from "../../../apis/pretix/genericPretixAPI";
 import { IPipelineAtomDB } from "../../../database/queries/pipelineAtomDB";
+import { PersistentCacheService } from "../../persistentCacheService";
 import { traced } from "../../telemetryService";
 import { tracePipeline } from "../honeycombQueries";
 import { CSVPipeline } from "./CSVPipeline";
@@ -31,7 +32,8 @@ export function instantiatePipeline(
     genericPretixAPI: IGenericPretixAPI;
   },
   zupassPublicKey: EdDSAPublicKey,
-  rsaPrivateKey: string
+  rsaPrivateKey: string,
+  cacheService: PersistentCacheService
 ): Promise<Pipeline> {
   return traced("instantiatePipeline", "instantiatePipeline", async () => {
     tracePipeline(definition);
@@ -42,7 +44,8 @@ export function instantiatePipeline(
         definition,
         db,
         apis.lemonadeAPI,
-        zupassPublicKey
+        zupassPublicKey,
+        cacheService
       );
     } else if (isPretixPipelineDefinition(definition)) {
       return new PretixPipeline(
@@ -50,7 +53,8 @@ export function instantiatePipeline(
         definition,
         db,
         apis.genericPretixAPI,
-        zupassPublicKey
+        zupassPublicKey,
+        cacheService
       );
     } else if (isCSVPipelineDefinition(definition)) {
       return new CSVPipeline(


### PR DESCRIPTION
Direct copy of the issuance caching mechanism from the original issuance service, with the exception that the signing key is also included in the cache key. This is to cover the (unlikely but possible in future) scenario in which two pipelines issue identical tickets but with different signing keys.

There is substantial code duplication between the two pipelines, and if we create additional pipelines which also issue tickets then we may want to refactor this into a `TicketIssuer` class which takes in `ITicketData` from the pipeline and handles all of the `EdDSATicketPCD` proving, and caching of the result.