### PR TITLE
Target ES2020

### DIFF
--- a/apps/anon-message-client/tsconfig.json
+++ b/apps/anon-message-client/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -27,8 +27,8 @@
     "compilerOptions": {
       "module": "commonjs",
       "outDir": "dist",
-      "lib": ["es2019"],
-      "target": "es2019",
+      "lib": ["ES2020"],
+      "target": "ES2020",
       "isolatedModules": false,
       "noEmit": false
     }

--- a/apps/consumer-client/tsconfig.json
+++ b/apps/consumer-client/tsconfig.json
@@ -3,7 +3,7 @@
     "resolveJsonModule": true,
     "downlevelIteration": true,
     "jsx": "react-jsx",
-    "lib": ["ES2015", "DOM"],
+    "lib": ["ES2020", "DOM"],
     "esModuleInterop": true,
     // To allow for mocha and jest to work together:
     // https://stackoverflow.com/a/65568463

--- a/apps/generic-issuance-client/tsconfig.json
+++ b/apps/generic-issuance-client/tsconfig.json
@@ -3,23 +3,15 @@
     "resolveJsonModule": true,
     "downlevelIteration": true,
     "jsx": "react-jsx",
-    "lib": [
-      "ES2015",
-      "DOM"
-    ],
+    "lib": ["ES2020", "DOM"],
     "esModuleInterop": true,
     // To allow for mocha and jest to work together:
     // https://stackoverflow.com/a/65568463
     "skipLibCheck": true,
     "strictNullChecks": true
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ],
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"],
   "references": [
     {
       "path": "../../packages/lib/passport-interface"

--- a/apps/passport-client/src/worker/tsconfig.json
+++ b/apps/passport-client/src/worker/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../tsconfig.json",
   "files": ["service-worker.ts", "../sharedConstants.ts"],
   "compilerOptions": {
-    "lib": ["ES2015", "DOM", "WebWorker"]
+    "lib": ["ES2020", "DOM", "WebWorker"]
   }
 }

--- a/apps/passport-client/tsconfig.json
+++ b/apps/passport-client/tsconfig.json
@@ -4,7 +4,7 @@
     "resolveJsonModule": true,
     "downlevelIteration": true,
     "jsx": "react-jsx",
-    "lib": ["ES2015", "DOM"],
+    "lib": ["ES2020", "DOM"],
     "esModuleInterop": true,
     // To allow for mocha and jest to work together:
     // https://stackoverflow.com/a/65568463

--- a/examples/nextjs/tsconfig.json
+++ b/examples/nextjs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/examples/zupass-feed-server/tsconfig.json
+++ b/examples/zupass-feed-server/tsconfig.json
@@ -17,9 +17,9 @@
     "strict": true,
     "strictNullChecks": true,
     "jsx": "react-jsx",
-    "lib": ["ES2015", "DOM"],
+    "lib": ["ES2020", "DOM"],
     "module": "CommonJS",
-    "target": "es6",
+    "target": "ES2020",
     "resolveJsonModule": true,
     "noImplicitThis": false
   }

--- a/packages/lib/util/package.json
+++ b/packages/lib/util/package.json
@@ -26,6 +26,7 @@
     "clean": "rm -rf dist node_modules *.tsbuildinfo"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "chai": "^4.3.7",
     "js-sha256": "^0.10.1",
     "uuid": "^9.0.0"

--- a/packages/lib/util/src/NumericRepresentation.ts
+++ b/packages/lib/util/src/NumericRepresentation.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import { parse as uuidParse, stringify as uuidStringify } from "uuid";
 
 /**

--- a/packages/lib/util/src/SNARKHelpers.ts
+++ b/packages/lib/util/src/SNARKHelpers.ts
@@ -28,5 +28,5 @@ export function babyJubIsNegativeOne(value: string): boolean {
 export function generateSnarkMessageHash(signal: string): bigint {
   // right shift to fit into a field element, which is 254 bits long
   // shift by 8 ensures we have a 253 bit element
-  return BigInt("0x" + sha256(signal)) >> BigInt(8);
+  return BigInt("0x" + sha256(signal)) >> 8n;
 }

--- a/packages/pcd/eddsa-frog-pcd/test/EdDSAFrogPCD.spec.ts
+++ b/packages/pcd/eddsa-frog-pcd/test/EdDSAFrogPCD.spec.ts
@@ -169,7 +169,7 @@ describe("EdDSA frog should work", function () {
     }
 
     await testVerifyBadClaim((claim) => {
-      claim.message[0] = BigInt(1);
+      claim.message[0] = 1n;
     });
     await testVerifyBadClaim((claim) => {
       claim.publicKey[0] = "123";

--- a/packages/tools/perftest/src/cases/ZKEdDSAEventTicketTimer.ts
+++ b/packages/tools/perftest/src/cases/ZKEdDSAEventTicketTimer.ts
@@ -38,8 +38,8 @@ async function setupProveArgs(): Promise<ZKEdDSAEventTicketPCDArgs> {
   const prvKey =
     "0001020304050607080900010203040506070809000102030405060708090001";
 
-  const WATERMARK = BigInt(6);
-  const EXTERNAL_NULLIFIER = BigInt(42);
+  const WATERMARK = 6n;
+  const EXTERNAL_NULLIFIER = 42n;
 
   const ticketData: ITicketData = {
     // the fields below are not signed and are used for display purposes

--- a/packages/tools/tsconfig/nextjs.json
+++ b/packages/tools/tsconfig/nextjs.json
@@ -3,7 +3,7 @@
   "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/tools/tsconfig/server.json
+++ b/packages/tools/tsconfig/server.json
@@ -3,7 +3,7 @@
   "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
-    "target": "es6",
+    "target": "ES2020",
     "lib": ["esnext", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "strict": true,

--- a/packages/tools/tsconfig/ts-library.json
+++ b/packages/tools/tsconfig/ts-library.json
@@ -10,9 +10,9 @@
     "outDir": "dist",
     "declarationDir": "dist/types",
     "jsx": "react-jsx",
-    "lib": ["ES2015", "DOM"],
+    "lib": ["ES2020", "DOM"],
     "module": "CommonJS",
-    "target": "es6",
+    "target": "ES2020",
     "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Upgrading language version after discussion on Discord.  The primary motivating feature at the moment is bigint literals, so I found a few places in code where they could be used to replace BigInt(N), and applied those changes to ensure it works. 
 The Buffer import change is unrelated to ES2020, but is a followup to the same discussion on Discord.

This seems to work for me locally.  I tested with Consumer Client requesting a Semaphore Signature, which involves a hash calculation which now uses a bigint literal.

I'm not sure how to fully validate the browser compatibility impact of this.  Once this is on staging, an important test will be to try it out in Telegram, which is probably the most limited browser we need to support.