### PR TITLE
Save all PCDs after deleting folder contents

### DIFF
--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -1139,6 +1139,7 @@ async function removeAllPCDsInFolder(
     state.pcds.folders
   );
   pcds.removeAllPCDsInFolder(folder);
+  await savePCDs(pcds);
   update({ pcds });
   window.scrollTo({ top: 0 });
 }


### PR DESCRIPTION
Although the sync system will sync changes made to the application state, this can take some time to complete. If the user reloads the page before it has completed, then changes can be lost. To avoid this, we manually update local storage, which will then get synced to remote storage after the reload.

I wonder if we could do this automatically when the relevant state changes?