### PR TITLE
Manually-configured tickets

### DIFF
--- a/apps/generic-issuance-client/src/pages/SamplePipelines.ts
+++ b/apps/generic-issuance-client/src/pages/SamplePipelines.ts
@@ -28,7 +28,8 @@ export const SAMPLE_LEMONADE_PIPELINE = JSON.stringify(
       oauthServerUrl: "",
       backendUrl: "",
       events: [],
-      feedOptions: DEFAULT_FEED_OPTIONS
+      feedOptions: DEFAULT_FEED_OPTIONS,
+      manualTickets: []
     }
   } satisfies Partial<LemonadePipelineDefinition>,
   null,

--- a/apps/generic-issuance-client/src/pages/create-pipeline/pipeline-builders/PretixPipelineBuilder.tsx
+++ b/apps/generic-issuance-client/src/pages/create-pipeline/pipeline-builders/PretixPipelineBuilder.tsx
@@ -210,7 +210,8 @@ export default function PretixPipelineBuilder(
                           {}
                       )
                     }
-                  ]
+                  ],
+                  manualTickets: []
                 }
               };
               return props.onCreate(JSON.stringify(pipeline));

--- a/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
@@ -1312,6 +1312,7 @@ export class GenericIssuanceService {
             ]
           }
         ],
+        manualTickets: [],
         pretixAPIKey: testPretixAPIKey,
         pretixOrgUrl: testPretixOrgUrl
       },
@@ -1411,7 +1412,8 @@ export class GenericIssuanceService {
         oauthAudience: testLemonadeOAuthAudience,
         oauthClientId: testLemonadeOAuthClientId,
         oauthClientSecret: testLemonadeOAuthClientSecret,
-        oauthServerUrl: testLemonadeOAuthServerUrl
+        oauthServerUrl: testLemonadeOAuthServerUrl,
+        manualTickets: []
       },
       type: PipelineType.Lemonade
     };

--- a/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
@@ -1312,9 +1312,9 @@ export class GenericIssuanceService {
             ]
           }
         ],
-        manualTickets: [],
         pretixAPIKey: testPretixAPIKey,
-        pretixOrgUrl: testPretixOrgUrl
+        pretixOrgUrl: testPretixOrgUrl,
+        manualTickets: []
       },
       type: PipelineType.Pretix
     };

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -424,6 +424,11 @@ export class LemonadePipeline implements BasePipeline {
     };
   }
 
+  /**
+   * Retrieves all tickets for a single email address, including both tickets
+   * from the Lemonade backend and manually-specified tickets from the Pipeline
+   * definition.
+   */
   private async getTicketsForEmail(
     email: string,
     identityCommitment: string

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -355,7 +355,7 @@ export class LemonadePipeline implements BasePipeline {
       this.pendingCheckIns.forEach((value, key) => {
         if (
           value.status === CheckinStatus.Success &&
-          value.timestamp < loadStart.getTime()
+          value.timestamp <= loadStart.getTime()
         ) {
           this.pendingCheckIns.delete(key);
         }

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -675,6 +675,11 @@ export class PretixPipeline implements BasePipeline {
     };
   }
 
+  /**
+   * Retrieves all tickets for a single email address, including both tickets
+   * from the Pretix backend and manually-specified tickets from the Pipeline
+   * definition.
+   */
   private async getTicketsForEmail(
     email: string,
     identityCommitment: string

--- a/apps/passport-server/test/genericIssuance.spec.ts
+++ b/apps/passport-server/test/genericIssuance.spec.ts
@@ -827,8 +827,8 @@ t2,i1`,
       const manualBouncerChecksInBouncer = await requestCheckInPipelineTicket(
         pipeline.checkinCapability.getCheckinUrl(),
         ZUPASS_EDDSA_PRIVATE_KEY,
-        EdgeCityManualBouncerEmail,
-        EdgeCityManualBouncerIdentity,
+        EthLatAmManualBouncerEmail,
+        EthLatAmManualBouncerIdentity,
         bouncerTicket
       );
       expect(manualBouncerChecksInBouncer.value).to.deep.eq({

--- a/apps/passport-server/test/lemonade/LemonadeDataMocker.ts
+++ b/apps/passport-server/test/lemonade/LemonadeDataMocker.ts
@@ -249,4 +249,17 @@ export class LemonadeDataMocker {
     // Un-checked-in users are represented by a checkin date of `null`
     account.setCheckin(eventId, userId, null);
   }
+
+  /**
+   * Checks all tickets out, useful for resetting check-in status.
+   */
+  public checkOutAll(): void {
+    for (const account of this.accounts.values()) {
+      for (const [eventId, eventTickets] of account.getTickets().entries()) {
+        for (const ticket of eventTickets.values()) {
+          account.setCheckin(eventId, ticket.user_id, null);
+        }
+      }
+    }
+  }
 }

--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -80,11 +80,11 @@ const ManualTicketSchema = z.object({
   /**
    * The email to assign the ticket to.
    */
-  attendeeEmail: z.string(),
+  attendeeEmail: z.string().email(),
   /**
    * The full name of the attendee.
    */
-  attendeeName: z.string()
+  attendeeName: z.string().min(1)
 });
 
 export type ManualTicket = z.infer<typeof ManualTicketSchema>;

--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -278,6 +278,27 @@ const PretixPipelineOptionsSchema = BasePipelineOptionsSchema.extend({
   events: z.array(PretixEventConfigSchema),
   feedOptions: FeedIssuanceOptionsSchema,
   manualTickets: z.array(ManualTicketSchema).optional().default([])
+}).refine((val) => {
+  // Validate that the manual tickets have event and product IDs that match the
+  // event configuration.
+  const events = new Map(val.events.map((ev) => [ev.genericIssuanceId, ev]));
+  for (const manualTicket of val.manualTickets) {
+    // Check that the event exists
+    const manualTicketEvent = events.get(manualTicket.eventId);
+    if (!manualTicketEvent) {
+      return false;
+    }
+    // Check that the event has a product with the product ID on the ticket
+    if (
+      !manualTicketEvent.products.find(
+        (product) => product.genericIssuanceId === manualTicket.productId
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 });
 
 export type PretixPipelineOptions = z.infer<typeof PretixPipelineOptionsSchema>;


### PR DESCRIPTION
Closes [OXP-28](https://linear.app/0xparc-pcd/issue/0XP-28)

Manually-configured tickets can be added to both Lemonade and Pretix pipelines, by adding the following section to the Pipeline definition options:
```json
{
  "manualTickets": [
    {
      "id": "b3bb20f5-7aed-4963-baaf-a8c6010739b0",
      "eventId": "4a2e7e30-8f4e-462a-a13b-6c69c14e9ea9",
      "productId": "977e5b25-be0a-4058-8eea-9e5922b9eb3d",
      "attendeeEmail": "manual@example.com",
      "attendeeName": "Manual Test"
    }
  ]
}
```

The ID is a UUID which the admin user will need to generate. The event ID and product ID *must* match an event ID/product ID pair in the pipeline definition, and will fail to validate if they do not.

If the product ID is a superuser product, then holders of these tickets can perform check-ins. However, manually-configured tickets can not themselves be checked in (a later PR will add support for this).