### PR TITLE
Check-in for manual tickets

### DIFF
--- a/apps/passport-server/migrations/68_generic_issuance_checkins.sql
+++ b/apps/passport-server/migrations/68_generic_issuance_checkins.sql
@@ -1,0 +1,7 @@
+CREATE TABLE generic_issuance_checkins (
+  pipeline_id UUID NOT NULL,
+  ticket_id UUID NOT NULL,
+  checkin_timestamp TIMESTAMPTZ NOT NULL,
+  -- Ticket IDs should be globally unique
+  PRIMARY KEY(ticket_id)
+);

--- a/apps/passport-server/src/database/queries/pipelineCheckinDB.ts
+++ b/apps/passport-server/src/database/queries/pipelineCheckinDB.ts
@@ -12,7 +12,7 @@ export interface IPipelineCheckinDB {
   // Add a check-in record for a ticket ID
   checkIn(pipelineId: string, ticketId: string, timestamp: Date): Promise<void>;
   // Delete check-in for a ticket ID
-  checkOut(pipelineId: string, ticketId: string): Promise<number>;
+  deleteCheckIn(pipelineId: string, ticketId: string): Promise<number>;
 }
 
 /**
@@ -90,7 +90,10 @@ export class PipelineCheckinDB implements IPipelineCheckinDB {
    * Delete a check-in. Returns the number of affected rows, which should be
    * exactly 1 if the ticket was previously checked in.
    */
-  public async checkOut(pipelineId: string, ticketId: string): Promise<number> {
+  public async deleteCheckIn(
+    pipelineId: string,
+    ticketId: string
+  ): Promise<number> {
     const result = await sqlQuery(
       this.db,
       `

--- a/apps/passport-server/src/database/queries/pipelineCheckinDB.ts
+++ b/apps/passport-server/src/database/queries/pipelineCheckinDB.ts
@@ -13,6 +13,11 @@ export interface IPipelineCheckinDB {
   checkOut(pipelineId: string, ticketId: string): Promise<number>;
 }
 
+/**
+ * Manages the database of check-ins, currently only used for "manual tickets"
+ * which are created via Pipeline configuration rather than imported from a
+ * back-end system.
+ */
 export class PipelineCheckinDB implements IPipelineCheckinDB {
   private db: Pool;
 
@@ -78,6 +83,9 @@ export class PipelineCheckinDB implements IPipelineCheckinDB {
   }
 }
 
+/**
+ * A record of a check-in.
+ */
 export interface PipelineCheckin {
   ticketId: string;
   timestamp: Date;

--- a/apps/passport-server/src/database/queries/pipelineCheckinDB.ts
+++ b/apps/passport-server/src/database/queries/pipelineCheckinDB.ts
@@ -7,6 +7,8 @@ export interface IPipelineCheckinDB {
     pipelineId: string,
     ticketId: string
   ): Promise<PipelineCheckin | undefined>;
+  // Fetch all check-ins for a pipeline
+  getByPipelineId(pipelineId: string): Promise<PipelineCheckin[]>;
   // Add a check-in record for a ticket ID
   checkIn(pipelineId: string, ticketId: string, timestamp: Date): Promise<void>;
   // Delete check-in for a ticket ID
@@ -46,6 +48,24 @@ export class PipelineCheckinDB implements IPipelineCheckinDB {
         timestamp: result.rows[0].checkin_timestamp
       };
     }
+  }
+
+  /**
+   * Retrieve all check-ins for a pipeline.
+   */
+  public async getByPipelineId(pipelineId: string): Promise<PipelineCheckin[]> {
+    const result = await sqlQuery(
+      this.db,
+      `SELECT * FROM generic_issuance_checkins WHERE pipeline_id = $1`,
+      [pipelineId]
+    );
+
+    return result.rows.map((row) => {
+      return {
+        ticketId: row.ticket_id,
+        timestamp: row.checkin_timestamp
+      } satisfies PipelineCheckin;
+    });
   }
 
   /**

--- a/apps/passport-server/src/database/queries/pipelineCheckinDB.ts
+++ b/apps/passport-server/src/database/queries/pipelineCheckinDB.ts
@@ -1,0 +1,84 @@
+import { Pool } from "postgres-pool";
+import { sqlQuery } from "../sqlQuery";
+
+export interface IPipelineCheckinDB {
+  // Fetch a check-in record
+  getByTicketId(
+    pipelineId: string,
+    ticketId: string
+  ): Promise<PipelineCheckin | undefined>;
+  // Add a check-in record for a ticket ID
+  checkIn(pipelineId: string, ticketId: string, timestamp: Date): Promise<void>;
+  // Delete check-in for a ticket ID
+  checkOut(pipelineId: string, ticketId: string): Promise<number>;
+}
+
+export class PipelineCheckinDB implements IPipelineCheckinDB {
+  private db: Pool;
+
+  public constructor(db: Pool) {
+    this.db = db;
+  }
+
+  /**
+   * Retrieve a check-in for a single ticket.
+   */
+  public async getByTicketId(
+    pipelineId: string,
+    ticketId: string
+  ): Promise<PipelineCheckin | undefined> {
+    const result = await sqlQuery(
+      this.db,
+      `SELECT * FROM generic_issuance_checkins WHERE pipeline_id = $1 AND ticket_id = $2`,
+      [pipelineId, ticketId]
+    );
+
+    if (result.rowCount === 0) {
+      return undefined;
+    } else {
+      return {
+        ticketId: result.rows[0].ticket_id,
+        timestamp: result.rows[0].checkin_timestamp
+      };
+    }
+  }
+
+  /**
+   * Check a ticket in. Because the insert does not handle conflicts, this will
+   * throw an error if the ticket is already checked in.
+   */
+  public async checkIn(
+    pipelineId: string,
+    ticketId: string,
+    timestamp: Date
+  ): Promise<void> {
+    await sqlQuery(
+      this.db,
+      `
+    INSERT INTO generic_issuance_checkins (pipeline_id, ticket_id, checkin_timestamp) VALUES($1, $2, $3)
+    `,
+      [pipelineId, ticketId, timestamp]
+    );
+  }
+
+  /**
+   * Delete a check-in. Returns the number of affected rows, which should be
+   * exactly 1 if the ticket was previously checked in.
+   */
+  public async checkOut(pipelineId: string, ticketId: string): Promise<number> {
+    const result = await sqlQuery(
+      this.db,
+      `
+    DELETE FROM generic_issuance_checkins WHERE pipeline_id = $1 AND ticket_id = $2
+    `,
+      [pipelineId, ticketId]
+    );
+
+    return result.rowCount;
+  }
+}
+
+export interface PipelineCheckin {
+  ticketId: string;
+  timestamp: Date;
+}

--- a/apps/passport-server/src/database/queries/pipelineCheckinDB.ts
+++ b/apps/passport-server/src/database/queries/pipelineCheckinDB.ts
@@ -1,6 +1,12 @@
 import { Pool } from "postgres-pool";
 import { sqlQuery } from "../sqlQuery";
 
+/**
+ * Stores check-in records for "manual tickets". These are tickets which are
+ * not fetched from remote back-end systems and are therefore not remotely
+ * checked-in. Instead, they are specified in the pipeline configuration and
+ * are checked in by updating records in the DB.
+ */
 export interface IPipelineCheckinDB {
   // Fetch a check-in record
   getByTicketId(

--- a/apps/passport-server/src/routing/routes/genericIssuanceRoutes.ts
+++ b/apps/passport-server/src/routing/routes/genericIssuanceRoutes.ts
@@ -245,10 +245,11 @@ export function initGenericIssuanceRoutes(
       traceUser(user);
 
       const reqBody = req.body as GenericIssuanceUpsertPipelineRequest;
-      const result = await genericIssuanceService.upsertPipelineDefinition(
-        user,
-        reqBody.pipeline
-      );
+      const { definition: result } =
+        await genericIssuanceService.upsertPipelineDefinition(
+          user,
+          reqBody.pipeline
+        );
       res.json(result satisfies GenericIssuanceUpsertPipelineResponseValue);
     }
   );

--- a/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
@@ -35,6 +35,10 @@ import { ILemonadeAPI } from "../../apis/lemonade/lemonadeAPI";
 import { IGenericPretixAPI } from "../../apis/pretix/genericPretixAPI";
 import { IPipelineAtomDB } from "../../database/queries/pipelineAtomDB";
 import {
+  IPipelineCheckinDB,
+  PipelineCheckinDB
+} from "../../database/queries/pipelineCheckinDB";
+import {
   IPipelineDefinitionDB,
   PipelineDefinitionDB
 } from "../../database/queries/pipelineDefinitionDB";
@@ -106,6 +110,7 @@ export class GenericIssuanceService {
   private userDB: IPipelineUserDB;
   private definitionDB: IPipelineDefinitionDB;
   private atomDB: IPipelineAtomDB;
+  private checkinDB: IPipelineCheckinDB;
 
   private lemonadeAPI: ILemonadeAPI;
   private genericPretixAPI: IGenericPretixAPI;
@@ -143,6 +148,7 @@ export class GenericIssuanceService {
     this.userDB = new PipelineUserDB(context.dbPool);
     this.definitionDB = new PipelineDefinitionDB(context.dbPool);
     this.atomDB = atomDB;
+    this.checkinDB = new PipelineCheckinDB(context.dbPool);
     this.lemonadeAPI = lemonadeAPI;
     this.genericPretixAPI = pretixAPI;
     this.eddsaPrivateKey = eddsaPrivateKey;

--- a/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
@@ -1312,6 +1312,7 @@ export class GenericIssuanceService {
             ]
           }
         ],
+        manualTickets: [],
         pretixAPIKey: testPretixAPIKey,
         pretixOrgUrl: testPretixOrgUrl,
         manualTickets: []

--- a/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
@@ -233,7 +233,8 @@ export class GenericIssuanceService {
               },
               this.zupassPublicKey,
               this.rsaPrivateKey,
-              this.cacheService
+              this.cacheService,
+              this.checkinDB
             );
           } catch (e) {
             this.rollbarService?.reportError(e);
@@ -1120,7 +1121,8 @@ export class GenericIssuanceService {
         },
         this.zupassPublicKey,
         this.rsaPrivateKey,
-        this.cacheService
+        this.cacheService,
+        this.checkinDB
       );
 
       await this.performPipelineLoad(pipelineSlot);

--- a/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
@@ -1312,7 +1312,6 @@ export class GenericIssuanceService {
             ]
           }
         ],
-        manualTickets: [],
         pretixAPIKey: testPretixAPIKey,
         pretixOrgUrl: testPretixOrgUrl,
         manualTickets: []

--- a/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
@@ -911,7 +911,10 @@ export class GenericIssuanceService {
   public async upsertPipelineDefinition(
     user: PipelineUser,
     newDefinition: PipelineDefinition
-  ): Promise<PipelineDefinition> {
+  ): Promise<{
+    definition: PipelineDefinition;
+    restartPromise: Promise<void>;
+  }> {
     return traced(SERVICE_NAME, "upsertPipelineDefinition", async (span) => {
       logger(
         SERVICE_NAME,
@@ -999,8 +1002,8 @@ export class GenericIssuanceService {
       );
       await this.atomDB.clear(validatedNewDefinition.id);
       // purposely not awaited
-      this.restartPipeline(validatedNewDefinition.id);
-      return validatedNewDefinition;
+      const restartPromise = this.restartPipeline(validatedNewDefinition.id);
+      return { definition: validatedNewDefinition, restartPromise };
     });
   }
 

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
@@ -234,6 +234,10 @@ export class CSVPipeline implements BasePipeline {
     });
   }
 
+  public async start(): Promise<void> {
+    logger(LOG_TAG, `starting csv pipeline`);
+  }
+
   public async stop(): Promise<void> {
     logger(LOG_TAG, `stopping csv pipeline`);
   }

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -1008,7 +1008,7 @@ export class LemonadePipeline implements BasePipeline {
 
       if (canCheckInResult === true) {
         if (ticketAtom.checkinDate instanceof Date) {
-          span?.setAttribute("precheck_error", "AlreadyCheckedIn");
+          span?.setAttribute("checkin_error", "AlreadyCheckedIn");
           return {
             checkedIn: false,
             error: {

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -1224,22 +1224,15 @@ export class LemonadePipeline implements BasePipeline {
 
       const pendingCheckin = this.pendingCheckIns.get(ticketAtom.id);
       if (pendingCheckin) {
-        if (
-          pendingCheckin.status === CheckinStatus.Pending ||
-          pendingCheckin.status === CheckinStatus.Success
-        ) {
-          span?.setAttribute("checkin_error", "AlreadyCheckedIn");
-          return {
-            checkedIn: false,
-            error: {
-              name: "AlreadyCheckedIn",
-              checkinTimestamp: new Date(
-                pendingCheckin.timestamp
-              ).toISOString(),
-              checker: LEMONADE_CHECKER
-            }
-          };
-        }
+        span?.setAttribute("checkin_error", "AlreadyCheckedIn");
+        return {
+          checkedIn: false,
+          error: {
+            name: "AlreadyCheckedIn",
+            checkinTimestamp: new Date(pendingCheckin.timestamp).toISOString(),
+            checker: LEMONADE_CHECKER
+          }
+        };
       }
 
       this.pendingCheckIns.set(ticketAtom.id, {

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -414,10 +414,10 @@ export class LemonadePipeline implements BasePipeline {
     });
   }
 
-  private manualTicketToTicketData(
+  private async manualTicketToTicketData(
     manualTicket: ManualTicket,
     sempahoreId: string
-  ): ITicketData {
+  ): Promise<ITicketData> {
     const event = this.definition.options.events.find(
       (event) => event.genericIssuanceEventId === manualTicket.eventId
     );
@@ -440,6 +440,12 @@ export class LemonadePipeline implements BasePipeline {
         `Manual ticket specifies non-existent product ID ${manualTicket.productId} on pipeline ${this.id}`
       );
     }
+
+    const checkIn = await this.checkinDb.getByTicketId(
+      this.id,
+      manualTicket.id
+    );
+
     return {
       ticketId: manualTicket.id,
       eventId: manualTicket.eventId,
@@ -447,10 +453,10 @@ export class LemonadePipeline implements BasePipeline {
       attendeeEmail: manualTicket.attendeeEmail,
       attendeeName: manualTicket.attendeeName,
       attendeeSemaphoreId: sempahoreId,
-      isConsumed: false,
+      isConsumed: checkIn ? true : false,
       isRevoked: false,
       timestampSigned: Date.now(),
-      timestampConsumed: 0,
+      timestampConsumed: checkIn ? checkIn.timestamp.getTime() : 0,
       ticketCategory: TicketCategory.Generic,
       eventName: event.name,
       ticketName: product.name,
@@ -489,9 +495,11 @@ export class LemonadePipeline implements BasePipeline {
     const manualTickets = this.getManualTicketsForEmail(email);
     // Convert manual tickets to ticket data and add to array
     ticketDatas.push(
-      ...manualTickets.map((manualTicket) =>
-        this.manualTicketToTicketData(manualTicket, identityCommitment)
-      )
+      ...(await Promise.all(
+        manualTickets.map((manualTicket) =>
+          this.manualTicketToTicketData(manualTicket, identityCommitment)
+        )
+      ))
     );
 
     // Turn ticket data into PCDs

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -154,6 +154,10 @@ export class LemonadePipeline implements BasePipeline {
     this.checkinDb = checkinDb;
   }
 
+  public async start(): Promise<void> {
+    await this.cleanUpManualCheckins();
+  }
+
   public async stop(): Promise<void> {
     logger(LOG_TAG, `stopping LemonadePipeline with id ${this.id}`);
     // TODO: what to actually do for a stopped pipeline?
@@ -382,6 +386,31 @@ export class LemonadePipeline implements BasePipeline {
         errorMessage: undefined,
         success: true
       } satisfies PipelineLoadSummary;
+    });
+  }
+
+  /**
+   * If manual tickets are removed after being checked in, they can leave
+   * orphaned check-in data behind. This method cleans those up.
+   */
+  private async cleanUpManualCheckins(): Promise<void> {
+    return traced(LOG_NAME, "cleanUpManualCheckins", async (span) => {
+      const ticketIds = new Set(
+        this.definition.options.manualTickets.map(
+          (manualTicket) => manualTicket.id
+        )
+      );
+      const checkIns = await this.checkinDb.getByPipelineId(this.id);
+      for (const checkIn of checkIns) {
+        if (!ticketIds.has(checkIn.ticketId)) {
+          logger(
+            `${LOG_TAG} Deleting orphaned check-in for ${checkIn.ticketId} on pipeline ${this.id}`
+          );
+          span?.setAttribute("deleted_checkin_ticket_id", checkIn.ticketId);
+
+          this.checkinDb.deleteCheckIn(this.id, checkIn.ticketId);
+        }
+      }
     });
   }
 

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -59,7 +59,7 @@ import { BasePipeline, Pipeline } from "./types";
 const LOG_NAME = "LemonadePipeline";
 const LOG_TAG = `[${LOG_NAME}]`;
 
-const LEMONADE_CHECKER = "Lemonade";
+export const LEMONADE_CHECKER = "Lemonade";
 
 export function isLemonadePipelineDefinition(
   d: PipelineDefinition

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -413,35 +413,8 @@ export class LemonadePipeline implements BasePipeline {
     manualTicket: ManualTicket,
     sempahoreId: string
   ): Promise<ITicketData> {
-    const event = this.definition.options.events.find(
-      (event) => event.genericIssuanceEventId === manualTicket.eventId
-    );
-
-    /**
-     * This should never happen, due to validation of the pipeline definition
-     * during parsing. See {@link LemonadePipelineOptionsSchema}.
-     */
-    if (!event) {
-      throw new Error(
-        `Manual ticket specifies non-existent event ID ${manualTicket.eventId} on pipeline ${this.id}`
-      );
-    }
-    const product = event.ticketTypes.find(
-      (product) => product.genericIssuanceProductId === manualTicket.productId
-    );
-    // As above, this should be prevented by pipeline definition validation
-    if (!product) {
-      throw new Error(
-        `Manual ticket specifies non-existent product ID ${manualTicket.productId} on pipeline ${this.id}`
-      );
-    }
-
-    /**
-     * TODO:
-     * refactor the above into simpler "get event", "get product" methods that throw if the thing isn't found
-     * replace their usage here, and also use them in the pre-check response
-     * port all of this to the Pretix pipeline
-     */
+    const event = this.getEventById(manualTicket.eventId);
+    const product = this.getTicketTypeById(event, manualTicket.productId);
 
     const checkIn = await this.checkinDb.getByTicketId(
       this.id,

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -1373,22 +1373,15 @@ export class PretixPipeline implements BasePipeline {
       const pretixEventId = this.atomToPretixEventId(ticketAtom);
       const pendingCheckin = this.pendingCheckIns.get(ticketAtom.id);
       if (pendingCheckin) {
-        if (
-          pendingCheckin.status === CheckinStatus.Pending ||
-          pendingCheckin.status === CheckinStatus.Success
-        ) {
-          span?.setAttribute("checkin_error", "AlreadyCheckedIn");
-          return {
-            checkedIn: false,
-            error: {
-              name: "AlreadyCheckedIn",
-              checkinTimestamp: new Date(
-                pendingCheckin.timestamp
-              ).toISOString(),
-              checker: PRETIX_CHECKER
-            }
-          };
-        }
+        span?.setAttribute("checkin_error", "AlreadyCheckedIn");
+        return {
+          checkedIn: false,
+          error: {
+            name: "AlreadyCheckedIn",
+            checkinTimestamp: new Date(pendingCheckin.timestamp).toISOString(),
+            checker: PRETIX_CHECKER
+          }
+        };
       }
 
       try {

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -155,6 +155,8 @@ export class PretixPipeline implements BasePipeline {
   }
 
   public async start(): Promise<void> {
+    // On startup, the pipeline definition may have changed, and manual tickets
+    // may have been deleted. If so, clean up any check-ins for those tickets.
     await this.cleanUpManualCheckins();
   }
 
@@ -978,7 +980,7 @@ export class PretixPipeline implements BasePipeline {
    * Returns true if the user has the permission to check the ticket in, or an
    * error if not.
    */
-  private async canCheckIn(
+  private async canCheckInForEvent(
     eventId: string,
     checkerEmail: string
   ): Promise<true | GenericIssuanceCheckInError> {
@@ -1018,6 +1020,77 @@ export class PretixPipeline implements BasePipeline {
     }
 
     return { name: "NotSuperuser" };
+  }
+
+  private async canCheckInPretixTicket(
+    ticketAtom: PretixAtom
+  ): Promise<true | GenericIssuanceCheckInError> {
+    return traced(LOG_NAME, "canCheckInPretixTicket", async (span) => {
+      // Is the ticket already checked in?
+      // Only check if ticket is already checked in here, to avoid leaking
+      // information about ticket check-in status to unpermitted users.
+      if (ticketAtom.timestampConsumed instanceof Date) {
+        span?.setAttribute("precheck_error", "AlreadyCheckedIn");
+        return {
+          name: "AlreadyCheckedIn",
+          checkinTimestamp: ticketAtom.timestampConsumed.toISOString(),
+          checker: PRETIX_CHECKER
+        };
+      }
+
+      // Is there a pending check-in for the ticket?
+      // If so, return as though this has succeeded.
+      const pendingCheckin = this.pendingCheckIns.get(ticketAtom.id);
+      if (pendingCheckin) {
+        span?.setAttribute("precheck_error", "AlreadyCheckedIn");
+        return {
+          name: "AlreadyCheckedIn",
+          checkinTimestamp: new Date(pendingCheckin.timestamp).toISOString(),
+          checker: PRETIX_CHECKER
+        };
+      }
+
+      return true;
+    });
+  }
+
+  /**
+   * Verifies that a manual ticket can be checked in. The only reason for this
+   * to be disallowed is if the ticket has already been checked in, or if there
+   * is a pending check-in.
+   */
+  private async canCheckInManualTicket(
+    manualTicket: ManualTicket
+  ): Promise<true | GenericIssuanceCheckInError> {
+    return traced(LOG_NAME, "canCheckInManualTicket", async (span) => {
+      // Is the ticket already checked in?
+      const checkIn = await this.checkinDb.getByTicketId(
+        this.id,
+        manualTicket.id
+      );
+
+      if (checkIn) {
+        span?.setAttribute("precheck_error", "AlreadyCheckedIn");
+        return {
+          name: "AlreadyCheckedIn",
+          checkinTimestamp: checkIn.timestamp.toISOString(),
+          checker: PRETIX_CHECKER
+        };
+      }
+
+      // Is there a pending check-in for the ticket?
+      const pendingCheckin = this.pendingCheckIns.get(manualTicket.id);
+      if (pendingCheckin) {
+        span?.setAttribute("precheck_error", "AlreadyCheckedIn");
+        return {
+          name: "AlreadyCheckedIn",
+          checkinTimestamp: new Date(pendingCheckin.timestamp).toISOString(),
+          checker: PRETIX_CHECKER
+        };
+      }
+
+      return true;
+    });
   }
 
   /**
@@ -1076,59 +1149,80 @@ export class PretixPipeline implements BasePipeline {
           return { canCheckIn: false, error: { name: "InvalidSignature" } };
         }
 
-        // Check permissions
-        const canCheckInResult = await this.canCheckIn(eventId, checkerEmail);
+        try {
+          // Verify that checker can check in tickets for the specified event
+          const canCheckInResult = await this.canCheckInForEvent(
+            eventId,
+            checkerEmail
+          );
 
-        if (canCheckInResult === true) {
+          if (canCheckInResult !== true) {
+            span?.setAttribute("precheck_error", canCheckInResult.name);
+            return { canCheckIn: false, error: canCheckInResult };
+          }
+
+          // First see if we have an atom which matches the ticket ID
           const ticketAtom = await this.db.loadById(this.id, ticketId);
-          if (!ticketAtom) {
-            span?.setAttribute("precheck_error", "InvalidTicket");
-            return { canCheckIn: false, error: { name: "InvalidTicket" } };
-          }
-          // Only check if ticket is already checked in here, to avoid leaking
-          // information about ticket check-in status to unpermitted users.
-          if (ticketAtom.isConsumed) {
-            span?.setAttribute("precheck_error", "AlreadyCheckedIn");
-            return {
-              canCheckIn: false,
-              error: {
-                name: "AlreadyCheckedIn",
-                checkinTimestamp: ticketAtom.timestampConsumed?.toISOString(),
-                checker: PRETIX_CHECKER // Pretix does not store a "checker" so use a constant
-              }
-            };
-          }
-
-          let pendingCheckin;
-          if ((pendingCheckin = this.pendingCheckIns.get(ticketAtom.id))) {
-            if (
-              pendingCheckin.status === CheckinStatus.Pending ||
-              pendingCheckin.status === CheckinStatus.Success
-            ) {
-              span?.setAttribute("precheck_error", "AlreadyCheckedIn");
+          if (ticketAtom && ticketAtom.eventId === eventId) {
+            const canCheckInTicketResult =
+              await this.canCheckInPretixTicket(ticketAtom);
+            if (canCheckInTicketResult !== true) {
               return {
                 canCheckIn: false,
-                error: {
-                  name: "AlreadyCheckedIn",
-                  checkinTimestamp: new Date(
-                    pendingCheckin.timestamp
-                  ).toISOString(),
-                  checker: PRETIX_CHECKER
-                }
+                error: canCheckInTicketResult
+              };
+            } else {
+              return {
+                canCheckIn: true,
+                eventName: this.atomToEventName(ticketAtom),
+                ticketName: this.atomToTicketName(ticketAtom),
+                attendeeEmail: ticketAtom.email as string,
+                attendeeName: ticketAtom.name
               };
             }
+          } else {
+            // No Pretix atom found, try looking for a manual ticket
+            const manualTicket = this.getManualTicketById(ticketId);
+            if (manualTicket && manualTicket.eventId === eventId) {
+              // Manual ticket found
+              const canCheckInTicketResult =
+                await this.canCheckInManualTicket(manualTicket);
+              if (canCheckInTicketResult !== true) {
+                return {
+                  canCheckIn: false,
+                  error: canCheckInTicketResult
+                };
+              } else {
+                const eventConfig = this.getEventById(manualTicket.eventId);
+                const ticketType = this.getProductById(
+                  eventConfig,
+                  manualTicket.productId
+                );
+                return {
+                  canCheckIn: true,
+                  eventName: eventConfig.name,
+                  ticketName: ticketType.name,
+                  attendeeEmail: manualTicket.attendeeEmail,
+                  attendeeName: manualTicket.attendeeName
+                };
+              }
+            }
           }
-          return {
-            canCheckIn: true,
-            eventName: this.atomToEventName(ticketAtom),
-            ticketName: this.atomToTicketName(ticketAtom),
-            attendeeEmail: ticketAtom.email as string,
-            attendeeName: ticketAtom.name
-          };
-        } else {
-          span?.setAttribute("precheck_error", canCheckInResult.name);
-          return { canCheckIn: false, error: canCheckInResult };
+        } catch (e) {
+          logger(
+            `${LOG_TAG} Error when finding ticket ${ticketId} for checkin by ${checkerEmail} on pipeline ${this.id}`,
+            e
+          );
+          setError(e);
+          span?.setAttribute("checkin_error", "InvalidTicket");
+          return { canCheckIn: false, error: { name: "InvalidTicket" } };
         }
+        // Didn't find any matching ticket
+        logger(
+          `${LOG_TAG} Could not find ticket ${ticketId} for event ${eventId} for checkin requested by ${checkerEmail} on pipeline ${this.id}`
+        );
+        span?.setAttribute("checkin_error", "InvalidTicket");
+        return { canCheckIn: false, error: { name: "InvalidTicket" } };
       }
     );
   }
@@ -1187,7 +1281,10 @@ export class PretixPipeline implements BasePipeline {
         span?.setAttribute("checkin_error", "InvalidSignature");
         return { checkedIn: false, error: { name: "InvalidSignature" } };
       }
-      const canCheckInResult = await this.canCheckIn(eventId, checkerEmail);
+      const canCheckInResult = await this.canCheckInForEvent(
+        eventId,
+        checkerEmail
+      );
       if (canCheckInResult !== true) {
         return { checkedIn: false, error: canCheckInResult };
       }
@@ -1213,6 +1310,9 @@ export class PretixPipeline implements BasePipeline {
     });
   }
 
+  /**
+   * Checks a manual ticket into the DB.
+   */
   private async checkInManualTicket(
     manualTicket: ManualTicket,
     checkerEmail: string
@@ -1220,22 +1320,15 @@ export class PretixPipeline implements BasePipeline {
     return traced(LOG_NAME, "checkInManualTicket", async (span) => {
       const pendingCheckin = this.pendingCheckIns.get(manualTicket.id);
       if (pendingCheckin) {
-        if (
-          pendingCheckin.status === CheckinStatus.Pending ||
-          pendingCheckin.status === CheckinStatus.Success
-        ) {
-          span?.setAttribute("checkin_error", "AlreadyCheckedIn");
-          return {
-            checkedIn: false,
-            error: {
-              name: "AlreadyCheckedIn",
-              checkinTimestamp: new Date(
-                pendingCheckin.timestamp
-              ).toISOString(),
-              checker: PRETIX_CHECKER
-            }
-          };
-        }
+        span?.setAttribute("checkin_error", "AlreadyCheckedIn");
+        return {
+          checkedIn: false,
+          error: {
+            name: "AlreadyCheckedIn",
+            checkinTimestamp: new Date(pendingCheckin.timestamp).toISOString(),
+            checker: PRETIX_CHECKER
+          }
+        };
       }
 
       try {
@@ -1252,6 +1345,8 @@ export class PretixPipeline implements BasePipeline {
         this.pendingCheckIns.delete(manualTicket.id);
 
         if (e instanceof DatabaseError) {
+          // We may have received a DatabaseError due to an insertion conflict
+          // Detect this conflict by looking for an existing check-in.
           const existingCheckin = await this.checkinDb.getByTicketId(
             this.id,
             manualTicket.id
@@ -1275,6 +1370,9 @@ export class PretixPipeline implements BasePipeline {
     });
   }
 
+  /**
+   * Check in a ticket to the Pretix back-end.
+   */
   private async checkInPretixTicket(
     ticketAtom: PretixAtom,
     checkerEmail: string
@@ -1402,56 +1500,29 @@ export class PretixPipeline implements BasePipeline {
     return correspondingEventConfig.externalId;
   }
 
-  private atomToPretixProductId(ticketAtom: PretixAtom): string {
-    const correspondingEventConfig = this.definition.options.events.find(
-      (e) => e.genericIssuanceId === ticketAtom.eventId
+  private getEventById(eventId: string): PretixEventConfig {
+    const eventConfig = this.definition.options.events.find(
+      (ev) => ev.genericIssuanceId === eventId
     );
-
-    if (!correspondingEventConfig) {
-      throw new Error("no matching event id");
+    if (!eventConfig) {
+      throw new Error(`Could not find event ${eventId} on pipeline ${this.id}`);
     }
-
-    const correspondingProductConfig = correspondingEventConfig.products.find(
-      (p) => p.genericIssuanceId === ticketAtom.productId
-    );
-
-    if (!correspondingProductConfig) {
-      throw new Error("no matching product id");
-    }
-
-    return correspondingProductConfig.externalId;
+    return eventConfig;
   }
 
-  private eddsaTicketToPretixEventId(ticket: EdDSATicketPCD): string {
-    const correspondingEventConfig = this.definition.options.events.find(
-      (e) => e.genericIssuanceId === ticket.claim.ticket.eventId
+  private getProductById(
+    event: PretixEventConfig,
+    productId: string
+  ): PretixProductConfig {
+    const productConfig = event.products.find(
+      (product) => product.genericIssuanceId === productId
     );
-
-    if (!correspondingEventConfig) {
-      throw new Error("no matching event id");
+    if (!productConfig) {
+      throw new Error(
+        `Could not find product ${productId} for event ${event.genericIssuanceId} on pipeline ${this.id}`
+      );
     }
-
-    return correspondingEventConfig.externalId;
-  }
-
-  private eddsaTicketToPretixProductId(ticket: EdDSATicketPCD): string {
-    const correspondingEventConfig = this.definition.options.events.find(
-      (e) => e.genericIssuanceId === ticket.claim.ticket.eventId
-    );
-
-    if (!correspondingEventConfig) {
-      throw new Error("no matching event id");
-    }
-
-    const correspondingProductConfig = correspondingEventConfig.products.find(
-      (p) => p.genericIssuanceId === ticket.claim.ticket.productId
-    );
-
-    if (!correspondingProductConfig) {
-      throw new Error("no matching product id");
-    }
-
-    return correspondingProductConfig.externalId;
+    return productConfig;
   }
 
   public static is(p: Pipeline): p is PretixPipeline {

--- a/apps/passport-server/src/services/generic-issuance/pipelines/instantiatePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/instantiatePipeline.ts
@@ -3,6 +3,7 @@ import { PipelineDefinition } from "@pcd/passport-interface";
 import { ILemonadeAPI } from "../../../apis/lemonade/lemonadeAPI";
 import { IGenericPretixAPI } from "../../../apis/pretix/genericPretixAPI";
 import { IPipelineAtomDB } from "../../../database/queries/pipelineAtomDB";
+import { IPipelineCheckinDB } from "../../../database/queries/pipelineCheckinDB";
 import { PersistentCacheService } from "../../persistentCacheService";
 import { traced } from "../../telemetryService";
 import { tracePipeline } from "../honeycombQueries";
@@ -33,7 +34,8 @@ export function instantiatePipeline(
   },
   zupassPublicKey: EdDSAPublicKey,
   rsaPrivateKey: string,
-  cacheService: PersistentCacheService
+  cacheService: PersistentCacheService,
+  checkinDb: IPipelineCheckinDB
 ): Promise<Pipeline> {
   return traced("instantiatePipeline", "instantiatePipeline", async () => {
     tracePipeline(definition);
@@ -45,7 +47,8 @@ export function instantiatePipeline(
         db,
         apis.lemonadeAPI,
         zupassPublicKey,
-        cacheService
+        cacheService,
+        checkinDb
       );
     } else if (isPretixPipelineDefinition(definition)) {
       return new PretixPipeline(

--- a/apps/passport-server/src/services/generic-issuance/pipelines/instantiatePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/instantiatePipeline.ts
@@ -40,8 +40,10 @@ export function instantiatePipeline(
   return traced("instantiatePipeline", "instantiatePipeline", async () => {
     tracePipeline(definition);
 
+    let pipeline: Pipeline | undefined = undefined;
+
     if (isLemonadePipelineDefinition(definition)) {
-      return new LemonadePipeline(
+      pipeline = new LemonadePipeline(
         eddsaPrivateKey,
         definition,
         db,
@@ -51,7 +53,7 @@ export function instantiatePipeline(
         checkinDb
       );
     } else if (isPretixPipelineDefinition(definition)) {
-      return new PretixPipeline(
+      pipeline = new PretixPipeline(
         eddsaPrivateKey,
         definition,
         db,
@@ -61,13 +63,18 @@ export function instantiatePipeline(
         checkinDb
       );
     } else if (isCSVPipelineDefinition(definition)) {
-      return new CSVPipeline(
+      pipeline = new CSVPipeline(
         eddsaPrivateKey,
         definition,
         db,
         zupassPublicKey,
         rsaPrivateKey
       );
+    }
+
+    if (pipeline) {
+      await pipeline.start();
+      return pipeline;
     }
 
     throw new Error(

--- a/apps/passport-server/src/services/generic-issuance/pipelines/instantiatePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/instantiatePipeline.ts
@@ -57,7 +57,8 @@ export function instantiatePipeline(
         db,
         apis.genericPretixAPI,
         zupassPublicKey,
-        cacheService
+        cacheService,
+        checkinDb
       );
     } else if (isCSVPipelineDefinition(definition)) {
       return new CSVPipeline(

--- a/apps/passport-server/src/services/generic-issuance/pipelines/types.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/types.ts
@@ -17,6 +17,7 @@ export interface BasePipeline {
   type: PipelineType;
   capabilities: readonly BasePipelineCapability[];
   load(): Promise<PipelineLoadSummary>;
+  start(): Promise<void>;
   stop(): Promise<void>;
 }
 

--- a/apps/passport-server/test/genericIssuance.spec.ts
+++ b/apps/passport-server/test/genericIssuance.spec.ts
@@ -686,6 +686,27 @@ t2,i1`,
         checkedIn: true
       });
 
+      {
+        const ManualAttendeeTickets = await requestTicketsFromPipeline(
+          edgeCityDenverPipeline.issuanceCapability.options.feedFolder,
+          edgeCityDenverTicketFeedUrl,
+          edgeCityDenverPipeline.issuanceCapability.options.feedId,
+          ZUPASS_EDDSA_PRIVATE_KEY,
+          EdgeCityManualAttendeeEmail,
+          EdgeCityManualAttendeeIdentity
+        );
+        expectLength(ManualAttendeeTickets, 1);
+        const ManualAttendeeTicket = ManualAttendeeTickets[0];
+        expectIsEdDSATicketPCD(ManualAttendeeTicket);
+        expect(ManualAttendeeTicket.claim.ticket.attendeeEmail).to.eq(
+          EdgeCityManualAttendeeEmail
+        );
+        expect(ManualAttendeeTicket.claim.ticket.isConsumed).to.eq(true);
+        expect(ManualAttendeeTicket.claim.ticket.timestampConsumed).to.eq(
+          Date.now()
+        );
+      }
+
       const manualBouncerChecksInManualAttendeeAgain =
         await requestCheckInPipelineTicket(
           edgeCityDenverPipeline.checkinCapability.getCheckinUrl(),
@@ -873,6 +894,27 @@ t2,i1`,
       expect(manualBouncerChecksInManualAttendee.value).to.deep.eq({
         checkedIn: true
       });
+
+      {
+        const ManualAttendeeTickets = await requestTicketsFromPipeline(
+          pipeline.issuanceCapability.options.feedFolder,
+          ethLatAmTicketFeedUrl,
+          pipeline.issuanceCapability.options.feedId,
+          ZUPASS_EDDSA_PRIVATE_KEY,
+          EthLatAmManualAttendeeEmail,
+          EthLatAmManualAttendeeIdentity
+        );
+        expectLength(ManualAttendeeTickets, 1);
+        const ManualAttendeeTicket = ManualAttendeeTickets[0];
+        expectIsEdDSATicketPCD(ManualAttendeeTicket);
+        expect(ManualAttendeeTicket.claim.ticket.attendeeEmail).to.eq(
+          EthLatAmManualAttendeeEmail
+        );
+        expect(ManualAttendeeTicket.claim.ticket.isConsumed).to.eq(true);
+        expect(ManualAttendeeTicket.claim.ticket.timestampConsumed).to.eq(
+          Date.now()
+        );
+      }
 
       const manualBouncerChecksInManualAttendeeAgain =
         await requestCheckInPipelineTicket(

--- a/apps/passport-server/test/genericIssuance.spec.ts
+++ b/apps/passport-server/test/genericIssuance.spec.ts
@@ -667,14 +667,15 @@ t2,i1`,
         EdgeCityManualBouncerEmail
       );
 
-      const manualBouncerChecksInBouncer = await requestCheckInPipelineTicket(
-        edgeCityDenverPipeline.checkinCapability.getCheckinUrl(),
-        ZUPASS_EDDSA_PRIVATE_KEY,
-        EdgeCityManualBouncerEmail,
-        EdgeCityManualBouncerIdentity,
-        BouncerTicket
-      );
-      expect(manualBouncerChecksInBouncer.value).to.deep.eq({
+      const manualBouncerChecksInManualAttendee =
+        await requestCheckInPipelineTicket(
+          edgeCityDenverPipeline.checkinCapability.getCheckinUrl(),
+          ZUPASS_EDDSA_PRIVATE_KEY,
+          EdgeCityManualBouncerEmail,
+          EdgeCityManualBouncerIdentity,
+          ManualAttendeeTicket
+        );
+      expect(manualBouncerChecksInManualAttendee.value).to.deep.eq({
         checkedIn: true
       });
 
@@ -834,10 +835,6 @@ t2,i1`,
       expect(manualBouncerChecksInBouncer.value).to.deep.eq({
         checkedIn: true
       });
-
-      // TODO test checking in manual attendee/bouncer
-      // Currently not supported as these are not present in the Lemonade
-      // backend, will be implemented with the pipeline as the check-in backend
 
       await checkPipelineInfoEndpoint(giBackend, pipeline);
     }

--- a/apps/passport-server/test/genericIssuance.spec.ts
+++ b/apps/passport-server/test/genericIssuance.spec.ts
@@ -368,6 +368,7 @@ describe("Generic Issuance", function () {
           attendeeName: "Manual Bouncer"
         }
       ],
+      manualTickets: [],
       pretixAPIKey: ethLatAmPretixOrganizer.token,
       pretixOrgUrl: ethLatAmPretixOrganizer.orgUrl
     },

--- a/apps/passport-server/test/genericIssuance.spec.ts
+++ b/apps/passport-server/test/genericIssuance.spec.ts
@@ -368,7 +368,6 @@ describe("Generic Issuance", function () {
           attendeeName: "Manual Bouncer"
         }
       ],
-      manualTickets: [],
       pretixAPIKey: ethLatAmPretixOrganizer.token,
       pretixOrgUrl: ethLatAmPretixOrganizer.orgUrl
     },

--- a/apps/passport-server/test/lemonade/LemonadeDataMocker.ts
+++ b/apps/passport-server/test/lemonade/LemonadeDataMocker.ts
@@ -140,7 +140,8 @@ class LemonadeAccount {
   public setCheckin(
     eventId: string,
     userId: string,
-    checkinDate: Date | null
+    checkinDate: Date | null,
+    force = false
   ): void {
     if (!this.events.has(eventId)) {
       throw new Error(`Can't check in user to non-existent event ${eventId}`);
@@ -164,11 +165,11 @@ class LemonadeAccount {
     }
 
     // If the ticket exists and has already been checked in
-    if (ticket.checkin_date && checkinDate) {
+    if (ticket.checkin_date && checkinDate && !force) {
       throw new Error(`User ${userId} is already checked in to ${eventId}`);
     }
 
-    if (!ticket.checkin_date && !checkinDate) {
+    if (!ticket.checkin_date && !checkinDate && !force) {
       throw new Error(`User ${userId} is already checked out from ${eventId}`);
     }
 
@@ -257,7 +258,7 @@ export class LemonadeDataMocker {
     for (const account of this.accounts.values()) {
       for (const [eventId, eventTickets] of account.getTickets().entries()) {
         for (const ticket of eventTickets.values()) {
-          account.setCheckin(eventId, ticket.user_id, null);
+          account.setCheckin(eventId, ticket.user_id, null, true);
         }
       }
     }


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-39

Allows manually-specified tickets to be checked in.

This is achieved by adding a database table in which check-ins are recorded. On check-in, the pipeline determines if the ticket to be checked in is a remote ticket (from Pretix or Lemonade) or a manual ticket. If the former, it calls the remote API to check the ticket in, and if the latter it persists the check-in to the DB.