### PR TITLE
Enforce ID uniqueness (within pipeline) on manual tickets

### DIFF
--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -94,7 +94,8 @@ const ManualTicketListSchema = z
   .refine(
     (manualTickets) =>
       manualTickets.length ===
-      new Set(manualTickets.map((manualTicket) => manualTicket.id)).size
+      new Set(manualTickets.map((manualTicket) => manualTicket.id)).size,
+    { message: "Ticket IDs must be unique" }
   );
 
 export type ManualTicket = z.infer<typeof ManualTicketSchema>;

--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -87,6 +87,16 @@ const ManualTicketSchema = z.object({
   attendeeName: z.string().min(1)
 });
 
+const ManualTicketListSchema = z
+  .array(ManualTicketSchema)
+  .optional()
+  .default([])
+  .refine(
+    (manualTickets) =>
+      manualTickets.length ===
+      new Set(manualTickets.map((manualTicket) => manualTicket.id)).size
+  );
+
 export type ManualTicket = z.infer<typeof ManualTicketSchema>;
 
 const LemonadePipelineTicketTypeConfigSchema = z.object({
@@ -165,7 +175,7 @@ const LemonadePipelineOptionsSchema = BasePipelineOptionsSchema.extend({
   events: z.array(LemonadePipelineEventConfigSchema),
   superuserEmails: z.array(z.string()).optional(),
   feedOptions: FeedIssuanceOptionsSchema,
-  manualTickets: z.array(ManualTicketSchema).optional()
+  manualTickets: ManualTicketListSchema
 }).refine((val) => {
   // Validate that the manual tickets have event and product IDs that match the
   // event configuration.
@@ -277,7 +287,7 @@ const PretixPipelineOptionsSchema = BasePipelineOptionsSchema.extend({
   pretixOrgUrl: z.string(),
   events: z.array(PretixEventConfigSchema),
   feedOptions: FeedIssuanceOptionsSchema,
-  manualTickets: z.array(ManualTicketSchema).optional()
+  manualTickets: ManualTicketListSchema
 }).refine((val) => {
   // Validate that the manual tickets have event and product IDs that match the
   // event configuration.

--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -90,11 +90,13 @@ const ManualTicketSchema = z.object({
 const ManualTicketListSchema = z
   .array(ManualTicketSchema)
   .optional()
-  .default([])
   .refine(
     (manualTickets) =>
+      // If manualTickets is undefined then that's OK
+      manualTickets === undefined ||
+      // Otherwise make sure each one has a unique ID
       manualTickets.length ===
-      new Set(manualTickets.map((manualTicket) => manualTicket.id)).size,
+        new Set(manualTickets.map((manualTicket) => manualTicket.id)).size,
     { message: "Ticket IDs must be unique" }
   );
 


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-117/manualtickets-qr-always-shows-the-first-qr-code