### PR TITLE
Semaphore groups for Pretix pipelines

### DIFF
--- a/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
@@ -1546,7 +1546,33 @@ export class GenericIssuanceService {
         ],
         pretixAPIKey: testPretixAPIKey,
         pretixOrgUrl: testPretixOrgUrl,
-        manualTickets: []
+        manualTickets: [],
+        semaphoreGroups: [
+          {
+            name: "Progcrypto Attendees",
+            groupId: "25d6d4d8-725f-41f2-8b53-7cd5bfacba16",
+            membershipTickets: [
+              {
+                eventId: "3dd02915-7a7e-412c-b792-046c9d654b75",
+                productId: "80d821f7-34a0-4d2f-9351-046b45694a74"
+              }
+            ]
+          },
+          {
+            name: "Progcrypto Organizers",
+            groupId: "a5754136-c942-4038-bbbe-c80a299f9288",
+            membershipTickets: [
+              {
+                eventId: "3dd02915-7a7e-412c-b792-046c9d654b75",
+                productId: "5f80443f-d767-4f6d-88fe-62eb927ae520"
+              },
+              {
+                eventId: "3dd02915-7a7e-412c-b792-046c9d654b75",
+                productId: "80d821f7-34a0-4d2f-9351-046b45694a74"
+              }
+            ]
+          }
+        ]
       },
       type: PipelineType.Pretix
     };

--- a/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/genericIssuanceService.ts
@@ -1551,7 +1551,7 @@ export class GenericIssuanceService {
           {
             name: "Progcrypto Attendees",
             groupId: "25d6d4d8-725f-41f2-8b53-7cd5bfacba16",
-            membershipTickets: [
+            memberCriteria: [
               {
                 eventId: "3dd02915-7a7e-412c-b792-046c9d654b75",
                 productId: "80d821f7-34a0-4d2f-9351-046b45694a74"
@@ -1561,7 +1561,7 @@ export class GenericIssuanceService {
           {
             name: "Progcrypto Organizers",
             groupId: "a5754136-c942-4038-bbbe-c80a299f9288",
-            membershipTickets: [
+            memberCriteria: [
               {
                 eventId: "3dd02915-7a7e-412c-b792-046c9d654b75",
                 productId: "5f80443f-d767-4f6d-88fe-62eb927ae520"

--- a/apps/passport-server/src/services/generic-issuance/pipelines/instantiatePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/instantiatePipeline.ts
@@ -73,7 +73,8 @@ export function instantiatePipeline(
         zupassPublicKey,
         cacheService,
         checkinDB,
-        consumerDB
+        consumerDB,
+        semaphoreHistoryDB
       );
     } else if (isCSVPipelineDefinition(definition)) {
       pipeline = new CSVPipeline(

--- a/apps/passport-server/test/genericIssuance.spec.ts
+++ b/apps/passport-server/test/genericIssuance.spec.ts
@@ -403,6 +403,13 @@ describe("Generic Issuance", function () {
   );
   expectToExist(ethLatAmBouncerProduct);
 
+  const ethLatAmSemaphoreGroupIds = {
+    all: randomUUID(),
+    bouncers: randomUUID(),
+    attendees: randomUUID(),
+    attendeesAndBouncers: randomUUID()
+  };
+
   const ethLatAmPipeline: PretixPipelineDefinition = {
     ownerUserId: ethLatAmGIUserID,
     timeCreated: new Date().toISOString(),
@@ -441,6 +448,54 @@ describe("Generic Issuance", function () {
           productId: ethLatAmBouncerProduct.genericIssuanceId,
           attendeeEmail: EthLatAmManualBouncerEmail,
           attendeeName: "Manual Bouncer"
+        }
+      ],
+      semaphoreGroups: [
+        {
+          // All attendees, irrespective of product type
+          name: "All EthLatAm Attendees",
+          groupId: ethLatAmSemaphoreGroupIds.all,
+          membershipTickets: [{ eventId: ethLatAmEventId }]
+        },
+        {
+          // Holders of bouncer-tier tickets
+          name: "EthLatAm Bouncers",
+          groupId: ethLatAmSemaphoreGroupIds.bouncers,
+          membershipTickets: [
+            {
+              eventId: ethLatAmEventId,
+              productId: ethLatAmBouncerProduct.genericIssuanceId
+            }
+          ]
+        },
+        {
+          // Holders of attendee-tier tickets
+          name: "EthLatAm Attendees",
+          groupId: ethLatAmSemaphoreGroupIds.attendees,
+          membershipTickets: [
+            {
+              eventId: ethLatAmEventId,
+              productId: ethLatAmAttendeeProduct.genericIssuanceId
+            }
+          ]
+        },
+        {
+          // Both holders of bouncer-tier tickets and attendee-tier tickets.
+          // In this case, this group will have the same membership as the
+          // "all" group, but if there were more tiers then this demonstrates
+          // how it would be possible to create arbitrary groupings.
+          name: "EthLatAm Bouncers and Attendees",
+          groupId: ethLatAmSemaphoreGroupIds.attendeesAndBouncers,
+          membershipTickets: [
+            {
+              eventId: ethLatAmEventId,
+              productId: ethLatAmBouncerProduct.genericIssuanceId
+            },
+            {
+              eventId: ethLatAmEventId,
+              productId: ethLatAmAttendeeProduct.genericIssuanceId
+            }
+          ]
         }
       ],
       pretixAPIKey: ethLatAmPretixOrganizer.token,
@@ -1440,6 +1495,79 @@ t2,i1`,
       ]);
 
       await checkPipelineInfoEndpoint(giBackend, pipeline);
+    }
+  );
+
+  step(
+    "Pretix pipeline Semaphore groups contain correct members",
+    async function () {
+      expectToExist(giService);
+      const pipelines = await giService.getAllPipelines();
+      expectToExist(pipelines);
+      expectLength(pipelines, 3);
+      const ethLatAmPipeline = pipelines.find(PretixPipeline.is);
+      expectToExist(ethLatAmPipeline);
+
+      await ethLatAmPipeline.load();
+
+      const semaphoreGroupAll = await requestGenericIssuanceSemaphoreGroup(
+        process.env.PASSPORT_SERVER_URL as string,
+        ethLatAmPipeline.id,
+        ethLatAmSemaphoreGroupIds.all
+      );
+      expectTrue(semaphoreGroupAll.success);
+      expectLength(semaphoreGroupAll.value.members, 4);
+      expect(semaphoreGroupAll.value.members).to.deep.include.members([
+        EthLatAmBouncerIdentity.commitment.toString(),
+        EthLatAmAttendeeIdentity.commitment.toString(),
+        EthLatAmManualAttendeeIdentity.commitment.toString(),
+        EthLatAmManualBouncerIdentity.commitment.toString()
+      ]);
+
+      const semaphoreGroupBouncers = await requestGenericIssuanceSemaphoreGroup(
+        process.env.PASSPORT_SERVER_URL as string,
+        ethLatAmPipeline.id,
+        ethLatAmSemaphoreGroupIds.bouncers
+      );
+
+      expectTrue(semaphoreGroupBouncers.success);
+      expectLength(semaphoreGroupBouncers.value.members, 2);
+      expect(semaphoreGroupBouncers.value.members).to.deep.include.members([
+        EthLatAmBouncerIdentity.commitment.toString(),
+        EthLatAmManualBouncerIdentity.commitment.toString()
+      ]);
+
+      const semaphoreGroupAttendees =
+        await requestGenericIssuanceSemaphoreGroup(
+          process.env.PASSPORT_SERVER_URL as string,
+          ethLatAmPipeline.id,
+          ethLatAmSemaphoreGroupIds.attendees
+        );
+
+      expectTrue(semaphoreGroupAttendees.success);
+      expectLength(semaphoreGroupAttendees.value.members, 2);
+      expect(semaphoreGroupAttendees.value.members).to.deep.include.members([
+        EthLatAmAttendeeIdentity.commitment.toString(),
+        EthLatAmManualAttendeeIdentity.commitment.toString()
+      ]);
+
+      const semaphoreGroupAttendeesAndBouncers =
+        await requestGenericIssuanceSemaphoreGroup(
+          process.env.PASSPORT_SERVER_URL as string,
+          ethLatAmPipeline.id,
+          ethLatAmSemaphoreGroupIds.attendeesAndBouncers
+        );
+
+      expectTrue(semaphoreGroupAttendeesAndBouncers.success);
+      expectLength(semaphoreGroupAttendeesAndBouncers.value.members, 4);
+      expect(
+        semaphoreGroupAttendeesAndBouncers.value.members
+      ).to.deep.include.members([
+        EthLatAmBouncerIdentity.commitment.toString(),
+        EthLatAmAttendeeIdentity.commitment.toString(),
+        EthLatAmManualAttendeeIdentity.commitment.toString(),
+        EthLatAmManualBouncerIdentity.commitment.toString()
+      ]);
     }
   );
 

--- a/apps/passport-server/test/genericIssuance.spec.ts
+++ b/apps/passport-server/test/genericIssuance.spec.ts
@@ -455,13 +455,13 @@ describe("Generic Issuance", function () {
           // All attendees, irrespective of product type
           name: "All EthLatAm Attendees",
           groupId: ethLatAmSemaphoreGroupIds.all,
-          membershipTickets: [{ eventId: ethLatAmEventId }]
+          memberCriteria: [{ eventId: ethLatAmEventId }]
         },
         {
           // Holders of bouncer-tier tickets
           name: "EthLatAm Bouncers",
           groupId: ethLatAmSemaphoreGroupIds.bouncers,
-          membershipTickets: [
+          memberCriteria: [
             {
               eventId: ethLatAmEventId,
               productId: ethLatAmBouncerProduct.genericIssuanceId
@@ -472,7 +472,7 @@ describe("Generic Issuance", function () {
           // Holders of attendee-tier tickets
           name: "EthLatAm Attendees",
           groupId: ethLatAmSemaphoreGroupIds.attendees,
-          membershipTickets: [
+          memberCriteria: [
             {
               eventId: ethLatAmEventId,
               productId: ethLatAmAttendeeProduct.genericIssuanceId
@@ -486,7 +486,7 @@ describe("Generic Issuance", function () {
           // how it would be possible to create arbitrary groupings.
           name: "EthLatAm Bouncers and Attendees",
           groupId: ethLatAmSemaphoreGroupIds.attendeesAndBouncers,
-          membershipTickets: [
+          memberCriteria: [
             {
               eventId: ethLatAmEventId,
               productId: ethLatAmBouncerProduct.genericIssuanceId

--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -385,7 +385,8 @@ const PretixPipelineOptionsSchema = BasePipelineOptionsSchema.extend({
   pretixOrgUrl: z.string(),
   events: z.array(PretixEventConfigSchema),
   feedOptions: FeedIssuanceOptionsSchema,
-  manualTickets: ManualTicketListSchema
+  manualTickets: ManualTicketListSchema,
+  semaphoreGroups: SemaphoreGroupListSchema
 }).refine((val) => {
   // Validate that the manual tickets have event and product IDs that match the
   // event configuration.


### PR DESCRIPTION
Extends #1549 with support for Pretix pipelines.

The actual code for an additional pipeline is pretty minimal - most of this PR is tests and config for the local demo pipeline.