### PR TITLE
Missed files from PR #1533

### DIFF
--- a/apps/kudosbot-client/tsconfig.json
+++ b/apps/kudosbot-client/tsconfig.json
@@ -3,7 +3,7 @@
     "resolveJsonModule": true,
     "downlevelIteration": true,
     "jsx": "react-jsx",
-    "lib": ["ES2015", "DOM"],
+    "lib": ["ES2020", "DOM"],
     "esModuleInterop": true,
     // To allow for mocha and jest to work together:
     // https://stackoverflow.com/a/65568463

--- a/examples/cra/tsconfig.json
+++ b/examples/cra/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
When I rebooted my Mac I discovered some unsaved files held onto by VSCode.  I think these changes were part of my bulk changes in #1533 but never got saved.  These changes eliminate some stray references to old JS versions in the repo.

Note that I can't figure out how to build `examples/cra` so this change is only by inspection.  The kudosbot-client builds with the changed config.