### PR TITLE
Fetch email PCD as part of account setup

### DIFF
--- a/apps/passport-client/src/defaultSubscriptions.ts
+++ b/apps/passport-client/src/defaultSubscriptions.ts
@@ -5,7 +5,7 @@ import {
 } from "@pcd/passport-interface";
 import { appConfig } from "../src/appConfig";
 
-const ZUPASS_FEED_URL = `${appConfig.zupassServer}/feeds`;
+export const ZUPASS_FEED_URL = `${appConfig.zupassServer}/feeds`;
 const ZUPASS_FEED_PROVIDER_NAME = "Zupass";
 const ZUPASS_SERVER_FEEDS = new Set(Object.keys(zupassDefaultSubscriptions));
 
@@ -22,6 +22,14 @@ function getDefaultFeedURLs(): string[] {
   return res;
 }
 
+export function addZupassProvider(
+  subscriptions: FeedSubscriptionManager
+): void {
+  if (!subscriptions.hasProvider(ZUPASS_FEED_URL)) {
+    subscriptions.addProvider(ZUPASS_FEED_URL, ZUPASS_FEED_PROVIDER_NAME);
+  }
+}
+
 export function isDefaultSubscription(sub: Subscription): boolean {
   return (
     (sub.providerUrl === ZUPASS_FEED_URL &&
@@ -33,9 +41,7 @@ export function isDefaultSubscription(sub: Subscription): boolean {
 export async function addDefaultSubscriptions(
   subscriptions: FeedSubscriptionManager
 ): Promise<void> {
-  if (!subscriptions.hasProvider(ZUPASS_FEED_URL)) {
-    subscriptions.addProvider(ZUPASS_FEED_URL, ZUPASS_FEED_PROVIDER_NAME);
-  }
+  addZupassProvider(subscriptions);
 
   for (const id in zupassDefaultSubscriptions) {
     subscriptions.subscribe(

--- a/packages/lib/passport-interface/src/CredentialManager.ts
+++ b/packages/lib/passport-interface/src/CredentialManager.ts
@@ -77,10 +77,17 @@ export class CredentialManager implements CredentialManagerAPI {
   public async prepareCredentials(reqs: CredentialRequest[]): Promise<void> {
     for (const req of reqs) {
       if (!this.getCachedCredential(req.pcdType)) {
-        this.setCachedCredential(
-          req.pcdType,
-          await this.generateCredential(req)
-        );
+        try {
+          this.setCachedCredential(
+            req.pcdType,
+            await this.generateCredential(req)
+          );
+        } catch (e) {
+          // It can be possible for credential generation to fail if the user
+          // does not have the right kind of PCD. Because we are only
+          // pre-generating credentials here, we don't need to take any action
+          // if a single credential fails to generate.
+        }
       }
     }
   }


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-168

Because the email PCD is a requirement for some default subscriptions to work, we need to ensure that the user has an email PCD at an earlier stage of login for first use. This PR causes the email PCD to be fetched as part of account setup.

I have been testing this locally by adding a manual ticket for a new email in Podbox, then signing into Zupass locally using that email, and observing that the tickets for the Podbox feed appear after first login/registration without requiring a refresh or any other interaction.