### PR TITLE
ES2020 for passport-client

### DIFF
--- a/apps/passport-client/tsconfig.json
+++ b/apps/passport-client/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
     "incremental": false,
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "downlevelIteration": true,
     "jsx": "react-jsx",
+    "target": "ES2020",
     "lib": [
       "ES2020",
       "DOM"
@@ -27,12 +29,6 @@
     },
     {
       "path": "../../packages/ui/eddsa-frog-pcd-ui"
-    },
-    {
-      "path": "../../packages/pcd/message-pcd"
-    },
-    {
-      "path": "../../packages/ui/message-pcd-ui"
     },
     {
       "path": "../../packages/pcd/eddsa-pcd"
@@ -66,6 +62,12 @@
     },
     {
       "path": "../../packages/ui/halo-nonce-pcd-ui"
+    },
+    {
+      "path": "../../packages/pcd/message-pcd"
+    },
+    {
+      "path": "../../packages/ui/message-pcd-ui"
     },
     {
       "path": "../../packages/lib/passport-crypto"


### PR DESCRIPTION
@ichub @robknight I need you to vet this for sanity, since I'm not very familiar with our build system.

I ran into an error when adding a bigint literal to some test code in passport-client.  It seems like my switchover to ES2020 didn't affect passport-client because it doesn't have a declared target, so it didn't come up in my search.  It's also apparently not using the base tsconfig files in tools/tsconfig.

The new values for `target` and `moduleResolution` are what I added.  The paths were updated automatically by `yarn fix-references`.

The change here seems to work in my testing, but I have no clue if it's right or would affect compatibility.  In particular, the `moduleResolution` value is something I pattern matched from elsewhere after seeing an error message.  I don't really understand what it means and whether it's the right option for this app.
