### PR TITLE
Remove duplicate call to rate-limited function in account reset flow

### DIFF
--- a/apps/passport-server/src/services.ts
+++ b/apps/passport-server/src/services.ts
@@ -40,7 +40,7 @@ export async function startServices(
   const kudosbotService = await startKudosbotService(context, rollbarService);
   const provingService = await startProvingService(rollbarService);
   const emailService = startEmailService(context, apis.emailAPI);
-  const emailTokenService = startEmailTokenService(context, rateLimitService);
+  const emailTokenService = startEmailTokenService(context);
   const semaphoreService = startSemaphoreService(context);
   const zuzaluPretixSyncService = startZuzaluPretixSyncService(
     context,

--- a/apps/passport-server/src/services/emailTokenService.ts
+++ b/apps/passport-server/src/services/emailTokenService.ts
@@ -2,10 +2,8 @@ import {
   fetchEmailToken,
   insertEmailToken
 } from "../database/queries/emailToken";
-import { PCDHTTPError } from "../routing/pcdHttpError";
 import { ApplicationContext } from "../types";
 import { randomEmailToken } from "../util/util";
-import { RateLimitService } from "./rateLimitService";
 
 /**
  * Responsible for generating, storing, and retrieving single-use
@@ -13,29 +11,15 @@ import { RateLimitService } from "./rateLimitService";
  */
 export class EmailTokenService {
   private context: ApplicationContext;
-  private readonly rateLimitService: RateLimitService;
 
-  public constructor(
-    context: ApplicationContext,
-    rateLimitService: RateLimitService
-  ) {
+  public constructor(context: ApplicationContext) {
     this.context = context;
-    this.rateLimitService = rateLimitService;
   }
 
   public async checkTokenCorrect(
     email: string,
     token: string
   ): Promise<boolean> {
-    if (
-      !(await this.rateLimitService.requestRateLimitedAction(
-        "CHECK_EMAIL_TOKEN",
-        email
-      ))
-    ) {
-      throw new PCDHTTPError(401, "Too many attempts. Come back later.");
-    }
-
     const savedToken = await this.getTokenForEmail(email);
     return token === savedToken;
   }
@@ -53,9 +37,8 @@ export class EmailTokenService {
 }
 
 export function startEmailTokenService(
-  context: ApplicationContext,
-  rateLimitService: RateLimitService
+  context: ApplicationContext
 ): EmailTokenService {
-  const emailTokenService = new EmailTokenService(context, rateLimitService);
+  const emailTokenService = new EmailTokenService(context);
   return emailTokenService;
 }


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-156

The account reset flow is rate-limited to 5 account resets per day. The "verify token" API endpoint is limited to 10 requests per hour.

If the user performs 5 sequential account resets, we would expect them to be rate-limited by the account reset limit, and to receive the appropriate error message.

However, the account reset flow was involves calling the `checkTokenCorrect` method on the `EmailTokenService` twice - once in the "verify token" API endpoint, and again from within `handleNewUser`. Because of this, the user will exhaust the bucket for token verification before they exhaust the account reset bucket, and will not see the expected error message.

The intent behind the limit on `checkTokenCorrect` was intended to limit access to the verify token API, and not to limit new user creation. It is probably a mistake that the rate limiting is applied to `checkTokenCorrect`, rather than being applied to the endpoint itself.

This PR removes the rate limit on `EmailTokenService.checkTokenCorrect`, and instead applies one to `handleVerifyToken`. `handleNewUser` now no longer triggers the rate limiter when it calls `checkTokenCorrect`.

This means that each account reset only increments the rate limit for token verification once, and therefore does not exhaust the token verification rate limit before the account reset limit, meaning that the user sees the correct error message when they hit the account reset limit:

![image](https://github.com/proofcarryingdata/zupass/assets/20022/75a5c3c1-da60-493c-9e68-b57745844eaf)
