### PR TITLE
Post-ECD cleanup

### DIFF
--- a/apps/passport-client/components/screens/EdgeCityScreens/EdgeCityHome.tsx
+++ b/apps/passport-client/components/screens/EdgeCityScreens/EdgeCityHome.tsx
@@ -249,43 +249,37 @@ export function EdgeCityHome(): JSX.Element {
         <div style={{ zIndex: 10 }}>
           <ExperiencesHeader>
             <p>
-              Collect EXP by participating in community experiences. <br />
-              <br />
-              Your EXP earns you a fraction of the {TOTAL_SUPPLY} available
-              $ZUCASH.
+              Thank you for participating. View the community experiences that
+              you have collected below.
             </p>
           </ExperiencesHeader>
-          <CategorySection>
-            <CategoryHeader>
-              <EventTitle>{CONTACT_EVENT_NAME}</EventTitle>
-              <span>{`${
-                (pcdsByEventName[CONTACT_EVENT_NAME] ?? []).length
-              }/${"∞"}`}</span>
-            </CategoryHeader>
+          {!!pcdsByEventName[CONTACT_EVENT_NAME]?.length && (
+            <CategorySection>
+              <CategoryHeader>
+                <EventTitle>{CONTACT_EVENT_NAME}</EventTitle>
+                <span>{`${
+                  (pcdsByEventName[CONTACT_EVENT_NAME] ?? []).length
+                }/${"∞"}`}</span>
+              </CategoryHeader>
 
-            <CategoryDescription>
-              Scan another resident's ticket to collect their contact. Worth 10
-              EXP.
-            </CategoryDescription>
+              <CategoryDescription />
 
-            <ItemContainer>
-              {(pcdsByEventName[CONTACT_EVENT_NAME] ?? []).flatMap((pcd) => (
-                <ItemCard
-                  key={pcd.id}
-                  onClick={(): void => {
-                    setSelectedExperience(pcd);
-                    setSelectedExperienceIsContact(true);
-                    setSelectedExperienceIsStar(false);
-                  }}
-                >
-                  <img src={pcd.claim.ticket?.imageUrl} draggable={false} />
-                </ItemCard>
-              ))}
-              <Link to="/scan">
-                <CTAButton>Collect Contact</CTAButton>
-              </Link>
-            </ItemContainer>
-          </CategorySection>
+              <ItemContainer>
+                {(pcdsByEventName[CONTACT_EVENT_NAME] ?? []).flatMap((pcd) => (
+                  <ItemCard
+                    key={pcd.id}
+                    onClick={(): void => {
+                      setSelectedExperience(pcd);
+                      setSelectedExperienceIsContact(true);
+                      setSelectedExperienceIsStar(false);
+                    }}
+                  >
+                    <img src={pcd.claim.ticket?.imageUrl} draggable={false} />
+                  </ItemCard>
+                ))}
+              </ItemContainer>
+            </CategorySection>
+          )}
           {groupedResult.map(
             ({
               eventName,
@@ -381,7 +375,6 @@ const Container = styled.div`
 `;
 
 const ExperiencesHeader = styled.div`
-  text-align: center;
   margin-bottom: 32px;
   padding-bottom: 16px;
   border-bottom: 1px solid grey;

--- a/apps/passport-client/components/screens/EdgeCityScreens/EdgeCityHome.tsx
+++ b/apps/passport-client/components/screens/EdgeCityScreens/EdgeCityHome.tsx
@@ -22,12 +22,9 @@ import {
 import { RippleLoader } from "../../core/RippleLoader";
 import { AdhocModal } from "../../modals/AdhocModal";
 import { PCDCardList } from "../../shared/PCDCardList";
-import { SuperFunkyFont } from "../FrogScreens/FrogFolder";
 import { BalancesTab } from "./BalancesTab";
 import { ExperienceModal } from "./ExperienceModal";
 import { useZucashConfetti } from "./useZucashConfetti";
-
-const animSpeedMs = 500;
 
 const TABS = [
   {
@@ -79,13 +76,7 @@ const groupedResult: GroupedEvent[] = BADGES_EDGE_CITY.reduce((acc, item) => {
 /**
  * Renders EdgeCity UI.
  */
-export function EdgeCityHome({
-  setBrowsingFolder,
-  confetti
-}: {
-  setBrowsingFolder: (folder?: string, tab?: string) => void;
-  confetti: () => Promise<void>;
-}): JSX.Element {
+export function EdgeCityHome(): JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
   const tab = searchParams.get("tab") ?? "ticket";
   const setTab = useCallback(
@@ -180,10 +171,7 @@ export function EdgeCityHome({
       return acc; // Return the accumulator for the next iteration
     }, {}); // Initial value of the accumulator is an empty object
 
-  const [buttonRef, setButtonRef] = useState<HTMLElement>();
-
   const [ref, setRef] = useState<HTMLElement>();
-  const [btnText, setBtnText] = useState("FrogCrypto");
   const z_confetti = useZucashConfetti(ref);
 
   if (loading) {
@@ -267,49 +255,6 @@ export function EdgeCityHome({
               $ZUCASH.
             </p>
           </ExperiencesHeader>
-          <CategorySection>
-            <CategoryHeader>
-              <EventTitle>FROGCRYPTO</EventTitle>
-              <span></span>
-            </CategoryHeader>
-
-            <CategoryDescription>
-              Collect frogs to earn EXP.
-            </CategoryDescription>
-
-            <FrogCryptoButton
-              ref={(r): void => setButtonRef(r)}
-              onClick={(): void => {
-                buttonRef.classList?.add("big");
-                buttonRef.style.border = "none";
-                buttonRef.style.color = "transparent";
-                document.body.style.overflow = "hidden";
-                setBtnText("");
-                setTimeout(() => {
-                  document.body.style.overflowY = "scroll";
-                  setBrowsingFolder("FrogCrypto");
-                  confetti();
-                }, 400);
-              }}
-            >
-              <div className="wrapper">
-                <div className="expander">
-                  <div className="text">
-                    <SuperFunkyFont
-                      style={{
-                        width: "100%",
-                        display: "flex",
-                        justifyContent: "center",
-                        alignItems: "center"
-                      }}
-                    >
-                      {btnText}
-                    </SuperFunkyFont>
-                  </div>
-                </div>
-              </div>
-            </FrogCryptoButton>
-          </CategorySection>
           <CategorySection>
             <CategoryHeader>
               <EventTitle>{CONTACT_EVENT_NAME}</EventTitle>
@@ -567,64 +512,6 @@ const CTAButton = styled(Button)`
   border: 1px solid white;
   font-size: 0.8em;
   white-space: nowrap;
-`;
-
-const FrogCryptoButton = styled.div`
-  user-select: none;
-  cursor: pointer;
-  width: 100%;
-  height: 50px;
-  max-height: 50px;
-  font-family: PressStart2P;
-  position: relative;
-  z-index: 9998;
-
-  .wrapper {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    height: 100%;
-  }
-
-  .expander {
-    background-color: #206b5e;
-    transition: ${animSpeedMs}ms;
-    position: absolute;
-    top: 0%;
-    left: 0%;
-    width: 100%;
-    height: 100%;
-    border-radius: 4px;
-    border: 1px solid white;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    &:hover {
-      transform: scale(1.05);
-
-      &:active {
-        transform: scale(1.1);
-      }
-    }
-  }
-
-  &.big {
-    .expander {
-      transition: ${animSpeedMs}ms;
-      position: absolute;
-      top: calc(50% - 100vh);
-      left: calc(50% - 100vw);
-      width: 200vw;
-      height: 200vh;
-    }
-  }
 `;
 
 const CategorySection = styled.div`

--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -34,6 +34,7 @@ export function FrogFolder({
     }>
   >;
 }): JSX.Element {
+  // TODO: Add a feature flagging system to prevent having to deploy a code change to change this flag.
   const frogcryptoDisabled = true;
   const fetchTimestamp = useFetchTimestamp();
 

--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -35,22 +35,19 @@ export function FrogFolder({
   >;
 }): JSX.Element {
   // TODO: Add a feature flagging system to prevent having to deploy a code change to change this flag.
-  const frogcryptoDisabled = true;
+  const frogcryptoGrayscale = true;
   const fetchTimestamp = useFetchTimestamp();
 
   return (
     <Container
       style={
-        frogcryptoDisabled
+        frogcryptoGrayscale
           ? {
-              filter: "grayscale(100%)",
-              cursor: "default"
+              filter: "grayscale(100%)"
             }
           : {}
       }
-      onClick={(): void => {
-        if (!frogcryptoDisabled) onFolderClick(FrogCryptoFolderName);
-      }}
+      onClick={(): void => onFolderClick(FrogCryptoFolderName)}
     >
       <img
         draggable="false"
@@ -59,7 +56,7 @@ export function FrogFolder({
         height={18}
       />
       <SuperFunkyFont>
-        {frogcryptoDisabled ? (
+        {frogcryptoGrayscale ? (
           <DisabledText>{FrogCryptoFolderName}</DisabledText>
         ) : (
           FrogCryptoFolderName.split("").map((letter, i) => (
@@ -69,11 +66,11 @@ export function FrogFolder({
           ))
         )}
       </SuperFunkyFont>
-      {(typeof fetchTimestamp === "number" || frogcryptoDisabled) && (
-        <NewFont $disabled={frogcryptoDisabled}>
+      {(typeof fetchTimestamp === "number" || frogcryptoGrayscale) && (
+        <NewFont $disabled={frogcryptoGrayscale}>
           <CountDown
             timestamp={fetchTimestamp}
-            frogcryptoDisabled={frogcryptoDisabled}
+            frogcryptoGrayscale={frogcryptoGrayscale}
           />
         </NewFont>
       )}
@@ -124,18 +121,16 @@ function useFetchTimestamp(): number | null {
  */
 function CountDown({
   timestamp,
-  frogcryptoDisabled
+  frogcryptoGrayscale
 }: {
   timestamp: number;
-  frogcryptoDisabled: boolean;
+  frogcryptoGrayscale: boolean;
 }): JSX.Element {
   const end = useMemo(() => {
     return new Date(timestamp);
   }, [timestamp]);
   const [diffText, setDiffText] = useState(
-    frogcryptoDisabled
-      ? _.upperCase("Returning Soon")
-      : timestamp < Date.now()
+    timestamp < Date.now() && !frogcryptoGrayscale
       ? _.upperCase("Available Now")
       : ""
   );
@@ -144,8 +139,8 @@ function CountDown({
     const interval = setInterval(() => {
       const now = new Date();
       const diffMs = end.getTime() - now.getTime();
-      if (frogcryptoDisabled) {
-        setDiffText(_.upperCase("Returning Soon"));
+      if (frogcryptoGrayscale) {
+        setDiffText("");
       } else if (diffMs < 0) {
         setDiffText(_.upperCase("Available Now"));
       } else {
@@ -161,7 +156,7 @@ function CountDown({
     return () => {
       clearInterval(interval);
     };
-  }, [end, frogcryptoDisabled]);
+  }, [end, frogcryptoGrayscale]);
 
   return <>{diffText}</>;
 }

--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -1,7 +1,4 @@
-import {
-  EdgeCityFolderName,
-  FrogCryptoFolderName
-} from "@pcd/passport-interface";
+import { FrogCryptoFolderName } from "@pcd/passport-interface";
 import _ from "lodash";
 import prettyMilliseconds from "pretty-ms";
 import { PropsWithChildren, useEffect, useMemo, useState } from "react";
@@ -11,7 +8,7 @@ import styled, {
   css,
   keyframes
 } from "styled-components";
-import { usePCDsInFolder, useSubscriptions } from "../../../src/appHooks";
+import { useSubscriptions } from "../../../src/appHooks";
 import { useUserFeedState } from "./FrogCryptoHomeSection";
 
 /**
@@ -37,8 +34,7 @@ export function FrogFolder({
     }>
   >;
 }): JSX.Element {
-  const edgePCDs = usePCDsInFolder(EdgeCityFolderName);
-  const frogcryptoDisabled = edgePCDs.length === 0;
+  const frogcryptoDisabled = true;
   const fetchTimestamp = useFetchTimestamp();
 
   return (

--- a/apps/passport-client/components/screens/HomeScreen/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen/HomeScreen.tsx
@@ -211,10 +211,7 @@ export function HomeScreenImpl(): JSX.Element {
               setBrowsingFolder={setFolderAndTab}
             />
           ) : isEdgeCity ? (
-            <EdgeCityHome
-              confetti={f_confetti}
-              setBrowsingFolder={setFolderAndTab}
-            />
+            <EdgeCityHome />
           ) : (
             <>
               {!(foldersInFolder.length === 0 && isRoot) && <Separator />}

--- a/apps/passport-client/components/screens/HomeScreen/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen/HomeScreen.tsx
@@ -31,7 +31,6 @@ import { EdgeCityHome } from "../EdgeCityScreens/EdgeCityHome";
 import { useZucashConfetti } from "../EdgeCityScreens/useZucashConfetti";
 import { FrogCryptoHomeSection } from "../FrogScreens/FrogCryptoHomeSection";
 import { FrogFolder } from "../FrogScreens/FrogFolder";
-import { useFrogConfetti } from "../FrogScreens/useFrogParticles";
 import {
   FolderCard,
   FolderDetails,
@@ -76,7 +75,6 @@ export function HomeScreenImpl(): JSX.Element {
   const foldersInFolder = useFolders(browsingFolder);
 
   const z_confetti = useZucashConfetti();
-  const f_confetti = useFrogConfetti();
 
   const setFolderAndTab = useCallback(
     (folder?: string, tab?: string) => {

--- a/packages/lib/passport-interface/src/edgecity.ts
+++ b/packages/lib/passport-interface/src/edgecity.ts
@@ -39,201 +39,170 @@ export const BADGES_EDGE_CITY: BadgeConfigUI[] = [
     eventName: "Star",
     productName: "",
     imageUrl: "/images/star.webp",
-    hiddenWhenEmpty: false,
+    hiddenWhenEmpty: true,
     infinite: true,
-    givers: ["*"],
-    description:
-      "Scan another resident's ticket to give them a star of appreciation." +
-      " You have 3 stars to give a day, worth 10 EXP each.",
-    button: {
-      text: "Award Star",
-      link: "/scan"
-    }
+    givers: ["*"]
   },
   {
     id: "Check In",
     eventName: "Check In",
     imageUrl: "/images/wristband.webp",
     grantOnCheckin: true,
-    givers: ["richard@pcd.team", "ivan@0xparc.org"],
-    description:
-      "Checking into Edge City earns you the Check In badge. Worth 10 EXP."
+    givers: ["richard@pcd.team", "ivan@0xparc.org"]
   },
   {
     id: "Cold Plunge.Tuesday",
     eventName: "Cold Plunge",
     productName: "Tuesday",
     imageUrl: "/images/cold.webp",
-    givers: ["richard@pcd.team"],
-    description: "Revitalize your energy with a cold plunge! Worth 10 EXP."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Cold Plunge.Wednesday",
     eventName: "Cold Plunge",
     productName: "Wednesday",
     imageUrl: "/images/cold.webp",
-    givers: ["richard@pcd.team"],
-    description: "Revitalize your energy with a cold plunge! Worth 10 EXP."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Cold Plunge.Thursday",
     eventName: "Cold Plunge",
     productName: "Thursday",
     imageUrl: "/images/cold.webp",
-    givers: ["richard@pcd.team"],
-    description: "Revitalize your energy with a cold plunge! Worth 10 EXP."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Cold Plunge.Friday",
     eventName: "Cold Plunge",
     productName: "Friday",
     imageUrl: "/images/cold.webp",
-    givers: ["richard@pcd.team"],
-    description: "Revitalize your energy with a cold plunge! Worth 10 EXP."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Cold Plunge.Saturday",
     eventName: "Cold Plunge",
     productName: "Saturday",
     imageUrl: "/images/cold.webp",
-    givers: ["richard@pcd.team"],
-    description: "Revitalize your energy with a cold plunge! Worth 10 EXP."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Cold Plunge.Sunday",
     eventName: "Cold Plunge",
     productName: "Sunday",
     imageUrl: "/images/cold.webp",
-    givers: ["richard@pcd.team"],
-    description: "Revitalize your energy with a cold plunge! Worth 10 EXP."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Sauna.Tuesday",
     eventName: "Sauna",
     productName: "Tuesday",
     imageUrl: "/images/sauna.webp",
-    givers: ["richard@pcd.team"],
-    description: "Go to the Sauna! 10 EXP per day."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Sauna.Wednesday",
     eventName: "Sauna",
     productName: "Wednesday",
     imageUrl: "/images/sauna.webp",
-    givers: ["richard@pcd.team"],
-    description: "Go to the Sauna! 10 EXP per day."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Sauna.Thursday",
     eventName: "Sauna",
     productName: "Thursday",
     imageUrl: "/images/sauna.webp",
-    givers: ["richard@pcd.team"],
-    description: "Go to the Sauna! 10 EXP per day."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Sauna.Friday",
     eventName: "Sauna",
     productName: "Friday",
     imageUrl: "/images/sauna.webp",
-    givers: ["richard@pcd.team"],
-    description: "Go to the Sauna! 10 EXP per day."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Sauna.Saturday",
     eventName: "Sauna",
     productName: "Saturday",
     imageUrl: "/images/sauna.webp",
-    givers: ["richard@pcd.team"],
-    description: "Go to the Sauna! 10 EXP per day."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Sauna.Sunday",
     eventName: "Sauna",
     productName: "Sunday",
     imageUrl: "/images/sauna.webp",
-    givers: ["richard@pcd.team"],
-    description: "Go to the Sauna! 10 EXP per day."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Met Zupass.Josh",
     eventName: "Met Zupass",
     productName: "Josh",
     imageUrl: "/images/hat.webp",
-    givers: ["jgarza@0xparc.org"],
-    description: "Meet the Zupass team. 10 EXP per member."
+    givers: ["jgarza@0xparc.org"]
   },
   {
     id: "Met Zupass.Richard",
     eventName: "Met Zupass",
     productName: "Richard",
     imageUrl: "/images/hat.webp",
-    givers: ["richard@pcd.team"],
-    description: "Meet the Zupass team. 10 EXP per member."
+    givers: ["richard@pcd.team"]
   },
   {
     id: "Met Zupass.Ivan",
     eventName: "Met Zupass",
     productName: "Ivan",
     imageUrl: "/images/hat.webp",
-    givers: ["ivan@0xparc.org"],
-    description: "Meet the Zupass team. 10 EXP per member."
+    givers: ["ivan@0xparc.org"]
   },
   {
     id: "Met Zupass.Rob",
     eventName: "Met Zupass",
     productName: "Rob",
     imageUrl: "/images/hat.webp",
-    givers: ["themanhimself@robknight.org.uk"],
-    description: "Meet the Zupass team. 10 EXP per member."
+    givers: ["themanhimself@robknight.org.uk"]
   },
   {
     id: "Met Gary.Monday",
     eventName: "Met Gary",
     productName: "Monday",
     imageUrl: "/images/johnwick.webp",
-    givers: ["garysheng11@gmail.com"],
-    description: "Where's Gary?"
+    givers: ["garysheng11@gmail.com"]
   },
   {
     id: "Met Timour",
     eventName: "Met Timour",
     productName: "",
     imageUrl: "/images/owl.webp",
-    givers: ["timour.kosters@gmail.com"],
-    description: "Can you find Timour?"
+    givers: ["timour.kosters@gmail.com"]
   },
   {
     id: "Met Afra",
     eventName: "Met Afra",
     productName: "",
     imageUrl: "/images/afra.webp",
-    givers: ["afrazhaowang@gmail.com"],
-    description: "How about Afra?"
+    givers: ["afrazhaowang@gmail.com"]
   },
   {
     id: "Met Arjun",
     eventName: "Met Arjun",
     productName: "",
     imageUrl: "/images/arjun.webp",
-    givers: ["arjun.khemani@gmail.com"],
-    description: "And Arjun?"
+    givers: ["arjun.khemani@gmail.com"]
   },
   {
     id: "Met Eggy",
     eventName: "Met Eggy",
     productName: "",
     imageUrl: "/images/egg.webp",
-    givers: ["eggy@sola.day"],
-    description: "Or Eggy?"
+    givers: ["eggy@sola.day"]
   },
   {
     id: "You're Doin it Right",
     eventName: "You're Doin It Right",
     productName: "",
     imageUrl: "/images/elephant.webp",
-    givers: ["cait@maitri.network"],
-    description: "Cait says, “you're doing it right!”"
+    givers: ["cait@maitri.network"]
   },
   {
     id: "Decentralized Social Hacker",
@@ -241,9 +210,6 @@ export const BADGES_EDGE_CITY: BadgeConfigUI[] = [
     productName: "",
     imageUrl: "/images/social.webp",
     hiddenWhenEmpty: true,
-    givers: ["abishek@zerion.io", "afrazhaowang@gmail.com"],
-    description:
-      "Attend the Decentralized Social Hackathon on Sunday and get scanned" +
-      " by an organizer to get this badge. Worth 10 EXP."
+    givers: ["abishek@zerion.io", "afrazhaowang@gmail.com"]
   }
 ];


### PR DESCRIPTION
1. Clean up inventory page - remove detailed descriptions, hide stars/contacts sections if no badges, remove 'add' buttons, and change section description to a "Thank you" message.
2. Remove frogs for ECD attendees - FROGCRYPTO button grayscale but clickable for all.
3. Prevent giving new stars/contacts/badges (will need to be changed in prodbox when this is deployed).

**Inventory page (with some collectibles):**

<img width="399" alt="Screenshot 2024-03-13 at 6 20 04 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/d3f1797c-e19d-4c95-bb77-c5abac080a9d">

**Inventory page (with no collectibles):**

<img width="425" alt="Screenshot 2024-03-13 at 6 18 31 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/9042fa22-9bae-43a6-a906-8af9c44c6ff7">

**Page when scanning ECD tickets as a non-superuser (before, they had 'give star' and 'collect contact' options):**

<img width="422" alt="Screenshot 2024-03-13 at 6 23 07 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/c319edd4-1523-4861-a2c4-5ac2491522f4">
