### PR TITLE
Run CI on PRs on any branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - main
+      - "**"
   merge_group:
 jobs:
   Build-and-Test:


### PR DESCRIPTION
Useful for testing of PRs merging into feature branches, or for ephemeral testing of experimental code.
PRs are low-volume enough (for our current team size) to seem like a valid signal that a piece of code is worth a CI run.
