### PR TITLE
fix privacy notice escaping the screen

### DIFF
--- a/apps/passport-client/components/shared/PrivacyNotice.tsx
+++ b/apps/passport-client/components/shared/PrivacyNotice.tsx
@@ -260,14 +260,14 @@ export function PrivacyNotice(): JSX.Element {
       <Wrapper>
         {expanded ? (
           <ExpandedNotice>
-            <ExpandedTermsTextContainer>
-              <PrivacyNoticeText />
-            </ExpandedTermsTextContainer>
             <CloseButtonContainer>
               <Button size="large" onClick={toggleExpand}>
                 Minimize
               </Button>
             </CloseButtonContainer>
+            <ExpandedTermsTextContainer>
+              <PrivacyNoticeText />
+            </ExpandedTermsTextContainer>
           </ExpandedNotice>
         ) : (
           <MinimizedNotice onClick={!expanded && toggleExpand}>
@@ -318,12 +318,12 @@ const ExpandedNotice = styled.div`
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
   position: fixed;
-  top: 5vh;
-  left: 5vw;
+  top: 10vh;
+  left: 2.5vw;
 
-  width: 90vw;
-  height: 90vh;
-  max-width: 90vw;
+  width: 95vw;
+  height: 75vh;
+  max-width: 95vw;
   max-height: 90vh;
 
   overflow: hidden;


### PR DESCRIPTION
### before
<img width="440" alt="Screenshot 2024-03-15 at 2 30 34 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/e86d497e-bb74-4268-a6dc-39e3e4c2250e">

### after
<img width="438" alt="Screenshot 2024-03-15 at 2 29 47 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/a9f885df-340f-421c-a9cc-784bf163b1fe">

fixes https://linear.app/0xparc-pcd/issue/0XP-186/clicking-read-privacy-notice-prevents-users-from-navigating-away-from
