### PR TITLE
Fix flaky Semaphore group test

### DIFF
--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -1636,6 +1636,10 @@ describe("devconnect functionality", function () {
   );
 
   step("semaphore service should reflect correct state", async function () {
+    // New user login schedules an asynchronous reload of the Semaphore
+    // service, which we can't rely on having completed by the time we run this
+    // test, so we must ensure that groups are reloaded here.
+    await application.services.semaphoreService.reload();
     expectCurrentSemaphoreToBe(application, {
       p: [],
       r: [],


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-252/fix-flaky-semaphore-service-testimplementation#comment-2322d5eb

In the Devconnect tests, we log some users in and then test to see if those user's commitments show up in the expected Semaphore groups. However, the `UserService` only *schedules* an asynchronous reload of the Semaphore groups, and sometimes this does not occur before the subsequent test runs. This means that sometimes the commitments are not in the expected group.

In this PR I've added an explicit call to the Semaphore service to reload groups before testing the group membership.