### PR TITLE
Tidy up turbo configs for POD packages

### DIFF
--- a/packages/lib/pod/turbo.json
+++ b/packages/lib/pod/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", "src/**"],
+      "inputs": ["$TURBO_DEFAULT$", "src/**", "test/**"],
       "outputs": ["dist/**", "*.tsbuildinfo"],
       "cache": true
     }

--- a/packages/ui/pod-pcd-ui/turbo.json
+++ b/packages/ui/pod-pcd-ui/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", "src/**", "typedoc.json", "artifacts/**"],
+      "inputs": ["$TURBO_DEFAULT$", "src/**"],
       "outputs": ["dist/**", "*.tsbuildinfo"],
       "cache": true
     }


### PR DESCRIPTION
I set out to add a turbo.json to @pcd/pod-pcd-ui, which turned out to already have one.
In the process, though, I noticed a few cases where the input config didn't match the files on disk, so here are the resulting cleanups.