### PR TITLE
Fetch Email PCD subscription first if the user has no Email PCD

### DIFF
--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -853,6 +853,41 @@ async function doSync(
         state.pcds,
         state.credentialCache
       );
+
+      /**
+       * Because the Email PCD is used as a credential for other feeds, it is
+       * necessary to ensure that the Email PCD is present before polling other
+       * feeds.
+       * We already fetch the Email PCD in {@link finishAccountCreation()}, so
+       * it *should* be present in the PCD collection already. However, there
+       * may have been an intermittent failure (e.g. due to connectivity issues
+       * or the restart of the Zupass server during a deployment). In this
+       * case, we try again here, before continuing to fetch the other feeds.
+       * If there is already an Email PCD then we can skip this step.
+       */
+      if (state.pcds.getPCDsByType(EmailPCDTypeName).length === 0) {
+        console.log(
+          "[SYNC] email PCD not found, attempting to poll Email PCD subscription"
+        );
+        console.log(ZUPASS_FEED_URL);
+        const emailPCDSubscription = state.subscriptions.findSubscription(
+          ZUPASS_FEED_URL,
+          ZupassFeedIds.Email
+        );
+        console.log(emailPCDSubscription);
+        if (emailPCDSubscription) {
+          console.log("[SYNC] Email PCD subscription found, polling");
+          const emailPCDActions =
+            await state.subscriptions.pollSingleSubscription(
+              emailPCDSubscription,
+              credentialManager
+            );
+          console.log(
+            `[SYNC] Fetched ${emailPCDActions.length} actions from Email PCD feed`
+          );
+          await applyActions(state.pcds, emailPCDActions);
+        }
+      }
       console.log("[SYNC] initalized credentialManager", credentialManager);
       const actions =
         await state.subscriptions.pollSubscriptions(credentialManager);

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -869,12 +869,10 @@ async function doSync(
         console.log(
           "[SYNC] email PCD not found, attempting to poll Email PCD subscription"
         );
-        console.log(ZUPASS_FEED_URL);
         const emailPCDSubscription = state.subscriptions.findSubscription(
           ZUPASS_FEED_URL,
           ZupassFeedIds.Email
         );
-        console.log(emailPCDSubscription);
         if (emailPCDSubscription) {
           console.log("[SYNC] Email PCD subscription found, polling");
           const emailPCDActions =

--- a/packages/lib/passport-interface/src/SubscriptionManager.ts
+++ b/packages/lib/passport-interface/src/SubscriptionManager.ts
@@ -360,7 +360,7 @@ export class FeedSubscriptionManager {
     feedId: string
   ): Subscription | undefined {
     return this.activeSubscriptions.find((sub) => {
-      sub.providerUrl === providerUrl && sub.id === feedId;
+      return sub.providerUrl === providerUrl && sub.feed.id === feedId;
     });
   }
 


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-205/ensure-that-zupass-users-who-dont-get-their-email-pcd-initially-have

Since we now have default subscriptions that use Email PCDs as credentials, it is important that the Email PCD is present before polling these subscriptions. Previously we implemented a feature to poll the Email PCD subscription during account creation, which should ensure that the Email PCD is present before the first attempt to poll other subscriptions.

However, this could still fail due to connectivity issues or downtime. Or, the user could delete their Email PCD.

This means that the next attempt to fetch subscriptions using the Email PCD as a credential will fail. Since each periodic polling of subscriptions will also poll the Email PCD subscription, the Email PCD ought to be restored; however, since this happens in parallel with the polling of other subscriptions, the user will have to wait one minute for the *next* poll, or refresh Zupass.

In this PR, the batch polling function now checks to see if the Email PCD is present before polling and, if not, separately polls the Email PCD subscription first, before proceeding to poll all other subscriptions.

This cannot fully protect us against connectivity or downtime issues, but it does ensure that if the feed is available then only a single attempt to poll subscriptions is necessary to get to the best possible state, in which the user has an Email PCD and the subscriptions which depend on the Email PCD can be polled.

I have tested this by:
- Disabling the fetch of the Email PCD during account creation
- Deleting the Email PCD and reloading the app

In both cases, the Email PCD is restored on the next subscription poll, and the other feeds are successfully polled.