### PR TITLE
Lint checks for strict equality comparisons

### DIFF
--- a/apps/consumer-client/src/pages/examples/group-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/group-proof.tsx
@@ -121,7 +121,7 @@ export default function Page(): JSX.Element {
             />
           </>
         )}
-        {proof != null && (
+        {proof && (
           <>
             <p>Got Group Membership Proof from Zupass</p>
             <CollapsableCode code={JSON.stringify(proof, null, 2)} />

--- a/apps/consumer-client/src/pages/examples/signature-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/signature-proof.tsx
@@ -84,7 +84,7 @@ export default function Page(): JSX.Element {
             />
           </>
         )}
-        {signatureProof != null && (
+        {signatureProof && (
           <>
             <p>Got Semaphore Signature Proof from Zupass</p>
 

--- a/apps/consumer-client/src/pages/examples/zk-eddsa-event-ticket-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/zk-eddsa-event-ticket-proof.tsx
@@ -48,15 +48,15 @@ export default function Page(): JSX.Element {
   const validEventIds = validEventIdsInput
     .split(",")
     .map((s) => s.trim())
-    .filter((s) => s != "");
+    .filter((s) => s !== "");
   const displayValidEventIds = validDisplayEventIdsInput
     .split(",")
     .map((s) => s.trim())
-    .filter((s) => s != "");
+    .filter((s) => s !== "");
   const displayValidProductIds = validDisplayProductIdsInput
     .split(",")
     .map((s) => s.trim())
-    .filter((s) => s != "");
+    .filter((s) => s !== "");
 
   const fieldsToReveal: EdDSATicketFieldsToReveal = useMemo(
     () => ({
@@ -425,7 +425,7 @@ export function openZKEdDSAEventTicketPopup(
     },
     validEventIds: {
       argumentType: ArgumentTypeName.StringArray,
-      value: validEventIds.length != 0 ? validEventIds : undefined,
+      value: validEventIds.length !== 0 ? validEventIds : undefined,
       userProvided: false
     },
     fieldsToReveal: {

--- a/apps/consumer-client/src/pages/examples/zu-auth/utils.ts
+++ b/apps/consumer-client/src/pages/examples/zu-auth/utils.ts
@@ -55,7 +55,7 @@ export function openZKEdDSAEventTicketPopup(
     },
     validEventIds: {
       argumentType: ArgumentTypeName.StringArray,
-      value: validEventIds.length != 0 ? validEventIds : undefined,
+      value: validEventIds.length !== 0 ? validEventIds : undefined,
       userProvided: false
     },
     fieldsToReveal: {

--- a/apps/generic-issuance-client/src/main.tsx
+++ b/apps/generic-issuance-client/src/main.tsx
@@ -173,7 +173,7 @@ function InitScripts(): ReactNode {
   useEffect(() => {
     if (!hasSetTitle.current) {
       hasSetTitle.current = true;
-      if (process.env.PODBOX_TITLE_TAG != null) {
+      if (process.env.PODBOX_TITLE_TAG) {
         document.title = `Podbox (${process.env.PODBOX_TITLE_TAG})`;
       }
     }

--- a/apps/kudosbot-client/src/components/SingleKudosDisplay.tsx
+++ b/apps/kudosbot-client/src/components/SingleKudosDisplay.tsx
@@ -31,7 +31,7 @@ const SingleKudosDisplay = (props: {
 
   return (
     <>
-      {signatureProof != null && (
+      {signatureProof && (
         <>
           <p>Kudosbot Proof {props.id}</p>
           <p>{`Kudos giver: ${kudosData.giver}`}</p>

--- a/apps/passport-client/components/modals/Modal.tsx
+++ b/apps/passport-client/components/modals/Modal.tsx
@@ -50,7 +50,7 @@ export function MaybeModal({
 
   const body = getModalBody(modal, isProveOrAddScreen);
 
-  if (body == null)
+  if (!body)
     return (
       <>
         <Overscroll />

--- a/apps/passport-client/components/screens/AddScreen/AddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/AddScreen.tsx
@@ -47,11 +47,11 @@ export function AddScreen(): JSX.Element {
   }, [dispatch, screen]);
 
   useEffect(() => {
-    if (self == null || userForcedToLogout) {
+    if (!self || userForcedToLogout) {
       clearAllPendingRequests();
       const stringifiedRequest = JSON.stringify(request);
       setPendingAddRequest(stringifiedRequest);
-      if (self == null) {
+      if (!self) {
         window.location.href = `/#/login?redirectedFromAction=true&${pendingAddRequestKey}=${encodeURIComponent(
           stringifiedRequest
         )}`;
@@ -59,11 +59,11 @@ export function AddScreen(): JSX.Element {
     }
   }, [request, self, userForcedToLogout]);
 
-  if (self == null) {
+  if (!self) {
     return null;
   }
 
-  if (screen == null) {
+  if (!screen) {
     // Need AppContainer to display error
     return <AppContainer bg="gray" />;
   }

--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -84,14 +84,14 @@ export function AddSubscriptionScreen(): JSX.Element {
   const [mismatchedEmails, setMismatchedEmails] = useState<boolean>(false);
 
   useEffect(() => {
-    if (self == null || userForcedToLogout) {
+    if (!self || userForcedToLogout) {
       clearAllPendingRequests();
       const stringifiedRequest = JSON.stringify(url ?? "");
       setPendingAddSubscriptionRequest(stringifiedRequest);
       const emailParameter = suggestedEmail
         ? `&email=${encodeURIComponent(suggestedEmail)}`
         : "";
-      if (self == null) {
+      if (!self) {
         window.location.href = `/#/login?redirectedFromAction=true&${pendingAddSubscriptionRequestKey}=${encodeURIComponent(
           stringifiedRequest
         )}${emailParameter}`;

--- a/apps/passport-client/components/screens/ChangePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/ChangePasswordScreen.tsx
@@ -43,7 +43,7 @@ export function ChangePasswordScreen(): JSX.Element {
   const [finished, setFinished] = useState(false);
 
   useEffect(() => {
-    if (self == null) {
+    if (!self) {
       navigate("/login", { replace: true });
     }
   }, [self, navigate]);

--- a/apps/passport-client/components/screens/FrogScreens/FrogSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogSubscriptionScreen.tsx
@@ -62,11 +62,11 @@ export function FrogSubscriptionScreen(): JSX.Element {
   const userForcedToLogout = useUserForcedToLogout();
 
   useEffect(() => {
-    if (self == null || userForcedToLogout) {
+    if (!self || userForcedToLogout) {
       clearAllPendingRequests();
       const stringifiedRequest = feedCode ? JSON.stringify(feedCode) : "";
       setPendingViewFrogCryptoRequest(stringifiedRequest);
-      if (self == null) {
+      if (!self) {
         window.location.href = `/#/login?redirectedFromAction=true&${pendingViewFrogCryptoRequestKey}=${encodeURIComponent(
           stringifiedRequest
         )}`;

--- a/apps/passport-client/components/screens/GetWithoutProvingScreen.tsx
+++ b/apps/passport-client/components/screens/GetWithoutProvingScreen.tsx
@@ -74,11 +74,11 @@ export function GetWithoutProvingScreen(): JSX.Element {
   const userForcedToLogout = useUserForcedToLogout();
 
   useEffect(() => {
-    if (self == null || userForcedToLogout) {
+    if (!self || userForcedToLogout) {
       clearAllPendingRequests();
       const stringifiedRequest = JSON.stringify(request);
       setPendingGetWithoutProvingRequest(stringifiedRequest);
-      if (self == null) {
+      if (!self) {
         window.location.href = `/#/login?redirectedFromAction=true&${pendingGetWithoutProvingRequestKey}=${encodeURIComponent(
           stringifiedRequest
         )}`;
@@ -104,7 +104,7 @@ export function GetWithoutProvingScreen(): JSX.Element {
     return null;
   }
 
-  if (self == null) {
+  if (!self) {
     return null;
   }
 

--- a/apps/passport-client/components/screens/HaloScreen/HaloScreen.tsx
+++ b/apps/passport-client/components/screens/HaloScreen/HaloScreen.tsx
@@ -33,7 +33,7 @@ export function HaloScreen(): JSX.Element {
     );
   }
 
-  if (screen == null) {
+  if (!screen) {
     // Need AppContainer to display error
     return <AppContainer bg="gray" />;
   }
@@ -46,7 +46,7 @@ function getScreen(params: URLSearchParams): JSX.Element | null {
   const rnd = params.get("rnd");
   const rndsig = params.get("rndsig");
 
-  if (pk2 == null || rnd == null || rndsig == null) {
+  if (!pk2 || !rnd || !rndsig) {
     return null;
   } else {
     return <AddHaloScreen pk2={pk2} rnd={rnd} rndsig={rndsig} />;

--- a/apps/passport-client/components/screens/HomeScreen/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen/HomeScreen.tsx
@@ -74,14 +74,14 @@ export function HomeScreenImpl(): JSX.Element {
   const foldersInFolder = useFolders(browsingFolder);
 
   useEffect(() => {
-    if (self == null) {
+    if (!self) {
       console.log("Redirecting to login screen");
       navigate("/login", { replace: true });
     }
   });
 
   useEffect(() => {
-    if (sessionStorage.newAddedPCDID != null) {
+    if (sessionStorage.newAddedPCDID) {
       // scroll to element with id of newAddedPCDID
       const el = document.getElementById(sessionStorage.newAddedPCDID);
       if (el) {
@@ -135,7 +135,7 @@ export function HomeScreenImpl(): JSX.Element {
     }
   }, [browsingFolder, dispatch]);
 
-  if (self == null) return null;
+  if (!self) return null;
 
   return (
     <>

--- a/apps/passport-client/components/screens/ImportBackupScreen.tsx
+++ b/apps/passport-client/components/screens/ImportBackupScreen.tsx
@@ -271,7 +271,7 @@ export function ImportBackupScreen(): JSX.Element {
           )}
           {importState.state === "valid-file-selected" && (
             <>
-              {importState.mergeablePcdIds.size == 0 && (
+              {importState.mergeablePcdIds.size === 0 && (
                 <>
                   <p>
                     The selected file does not contain any PCDs you don't

--- a/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/AlreadyRegisteredScreen.tsx
@@ -75,7 +75,7 @@ export function AlreadyRegisteredScreen(): JSX.Element {
       if (!result.success) {
         setError("Couldn't send pasword reset email. Try again later.");
         setSendingConfirmationEmail(false);
-      } else if (result.value?.devToken != null) {
+      } else if (result.value?.devToken) {
         setSendingConfirmationEmail(false);
         verifyToken(result.value?.devToken);
       } else {
@@ -122,7 +122,7 @@ export function AlreadyRegisteredScreen(): JSX.Element {
       e.preventDefault();
       setError(undefined);
 
-      if (password == "" || password == null) {
+      if (password === "" || password === null) {
         return setError("Enter a password");
       }
 

--- a/apps/passport-client/components/screens/LoginScreens/CreatePasswordScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/CreatePasswordScreen.tsx
@@ -78,7 +78,7 @@ export function CreatePasswordScreen(): JSX.Element {
 
   useEffect(() => {
     // Redirect to home if already logged in
-    if (self != null) {
+    if (self) {
       if (hasPendingRequest()) {
         window.location.hash = "#/login-interstitial";
       } else {

--- a/apps/passport-client/components/screens/LoginScreens/LoginInterstitialScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/LoginInterstitialScreen.tsx
@@ -25,44 +25,44 @@ export function LoginInterstitialScreen(): JSX.Element {
 
   useLayoutEffect(() => {
     if (loadedIssuedPCDs) {
-      if (getPendingProofRequest() != null) {
+      if (getPendingProofRequest()) {
         console.log("Redirecting to prove screen");
         const encReq = encodeURIComponent(getPendingProofRequest());
         clearAllPendingRequests();
         navigate("/prove?request=" + encReq, { replace: true });
-      } else if (getPendingAddRequest() != null) {
+      } else if (getPendingAddRequest()) {
         console.log("Redirecting to add screen");
         const encReq = encodeURIComponent(getPendingAddRequest());
         clearAllPendingRequests();
         navigate("/add?request=" + encReq, { replace: true });
-      } else if (getPendingHaloRequest() != null) {
+      } else if (getPendingHaloRequest()) {
         console.log("Redirecting to halo screen");
         clearAllPendingRequests();
         navigate(`/halo${getPendingHaloRequest()}`, { replace: true });
-      } else if (getPendingGetWithoutProvingRequest() != null) {
+      } else if (getPendingGetWithoutProvingRequest()) {
         console.log("Redirecting to get without proving screen");
         const encReq = encodeURIComponent(getPendingGetWithoutProvingRequest());
         clearAllPendingRequests();
         navigate(`/get-without-proving?request=${encReq}`, { replace: true });
-      } else if (getPendingViewSubscriptionsPageRequest() != null) {
+      } else if (getPendingViewSubscriptionsPageRequest()) {
         console.log("Redirecting to view subscription screen");
         clearAllPendingRequests();
         navigate(`/subscriptions`, { replace: true });
-      } else if (getPendingAddSubscriptionPageRequest() != null) {
+      } else if (getPendingAddSubscriptionPageRequest()) {
         console.log("Redirecting to add subscription screen");
         const encReq = encodeURIComponent(
           JSON.parse(getPendingAddSubscriptionPageRequest())
         );
         clearAllPendingRequests();
         navigate(`/add-subscription?url=${encReq}`, { replace: true });
-      } else if (getPendingViewFrogCryptoPageRequest() != null) {
+      } else if (getPendingViewFrogCryptoPageRequest()) {
         console.log("Redirecting to frog crypto screen");
         const encReq = encodeURIComponent(
           JSON.parse(getPendingViewFrogCryptoPageRequest())
         );
         clearAllPendingRequests();
         navigate(`/frogscriptions/${encReq}`, { replace: true });
-      } else if (getPendingGenericIssuanceCheckinRequest() != null) {
+      } else if (getPendingGenericIssuanceCheckinRequest()) {
         console.log("Redirecting to Generic Issuance checkin screen");
         const encReq = new URLSearchParams(
           JSON.parse(getPendingGenericIssuanceCheckinRequest())

--- a/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
@@ -63,32 +63,32 @@ export function LoginScreen(): JSX.Element {
   useEffect(() => {
     let pendingRequestForLogging: string | undefined = undefined;
 
-    if (pendingGetWithoutProvingRequest != null) {
+    if (pendingGetWithoutProvingRequest) {
       setPendingGetWithoutProvingRequest(pendingGetWithoutProvingRequest);
       pendingRequestForLogging = pendingGetWithoutProvingRequestKey;
-    } else if (pendingAddRequest != null) {
+    } else if (pendingAddRequest) {
       setPendingAddRequest(pendingAddRequest);
       pendingRequestForLogging = pendingAddRequestKey;
-    } else if (pendingProveRequest != null) {
+    } else if (pendingProveRequest) {
       setPendingProofRequest(pendingProveRequest);
       pendingRequestForLogging = pendingProofRequestKey;
-    } else if (pendingViewSubscriptionsRequest != null) {
+    } else if (pendingViewSubscriptionsRequest) {
       setPendingViewSubscriptionsRequest(pendingViewSubscriptionsRequest);
       pendingRequestForLogging = pendingViewSubscriptionsRequestKey;
-    } else if (pendingAddSubscriptionRequest != null) {
+    } else if (pendingAddSubscriptionRequest) {
       setPendingAddSubscriptionRequest(pendingAddSubscriptionRequest);
       pendingRequestForLogging = pendingAddSubscriptionRequestKey;
-    } else if (pendingViewFrogCryptoRequest != null) {
+    } else if (pendingViewFrogCryptoRequest) {
       setPendingViewFrogCryptoRequest(pendingViewFrogCryptoRequest);
       pendingRequestForLogging = pendingViewFrogCryptoRequestKey;
-    } else if (pendingGenericIssuanceCheckinRequest != null) {
+    } else if (pendingGenericIssuanceCheckinRequest) {
       setPendingGenericIssuanceCheckinRequest(
         pendingGenericIssuanceCheckinRequest
       );
       pendingRequestForLogging = pendingGenericIssuanceCheckinRequestKey;
     }
 
-    if (pendingRequestForLogging != null) {
+    if (pendingRequestForLogging) {
       requestLogToServer(appConfig.zupassServer, "login-with-pending", {
         pending: pendingRequestForLogging
       });
@@ -127,7 +127,7 @@ export function LoginScreen(): JSX.Element {
 
   useEffect(() => {
     // Redirect to home if already logged in
-    if (self != null) {
+    if (self) {
       window.location.hash = "#/";
     }
   }, [self]);

--- a/apps/passport-client/components/screens/LoginScreens/NewPassportScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/NewPassportScreen.tsx
@@ -135,7 +135,7 @@ function SendEmailVerification({ email }: { email: string }): JSX.Element {
         } else {
           err(dispatch, "Email failed", saltResult.error);
         }
-      } else if (result.value?.devToken != null) {
+      } else if (result.value?.devToken) {
         verifyToken(result.value.devToken);
       } else {
         setEmailSent(true);

--- a/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
@@ -54,11 +54,11 @@ export function ProveScreen(): JSX.Element {
   }, [dispatch, screen]);
 
   useEffect(() => {
-    if (self == null || userForcedToLogout) {
+    if (!self || userForcedToLogout) {
       clearAllPendingRequests();
       const stringifiedRequest = JSON.stringify(request);
       setPendingProofRequest(stringifiedRequest);
-      if (self == null) {
+      if (!self) {
         window.location.href = `/#/login?redirectedFromAction=true&${pendingProofRequestKey}=${encodeURIComponent(
           stringifiedRequest
         )}`;
@@ -66,7 +66,7 @@ export function ProveScreen(): JSX.Element {
     }
   }, [request, self, userForcedToLogout]);
 
-  if (self == null) {
+  if (!self) {
     return null;
   }
 
@@ -78,7 +78,7 @@ export function ProveScreen(): JSX.Element {
     );
   }
 
-  if (screen == null) {
+  if (!screen) {
     // Need AppContainer to display error
     return <AppContainer bg="gray" />;
   }

--- a/apps/passport-client/components/screens/ScanScreen.tsx
+++ b/apps/passport-client/components/screens/ScanScreen.tsx
@@ -43,14 +43,14 @@ export function ScanScreen(): JSX.Element {
           <QrReader
             className="qr"
             onResult={(result, error): void => {
-              if (result != null) {
+              if (result) {
                 console.log(
                   `Got result, considering redirect`,
                   result.getText()
                 );
                 const newLoc = maybeRedirect(result.getText());
                 if (newLoc) nav(newLoc);
-              } else if (error != null) {
+              } else if (error) {
                 //    console.info(error);
               }
             }}

--- a/apps/passport-client/components/screens/ScannedTicketScreens/PodboxScannedTicketScreen/PodboxScannedTicketScreen.tsx
+++ b/apps/passport-client/components/screens/ScannedTicketScreens/PodboxScannedTicketScreen/PodboxScannedTicketScreen.tsx
@@ -58,13 +58,13 @@ export function PodboxScannedTicketScreen(): JSX.Element {
   );
 
   useEffect(() => {
-    if (self == null || userForcedToLogout) {
+    if (!self || userForcedToLogout) {
       clearAllPendingRequests();
       const stringifiedRequest = JSON.stringify(
         query.get("id") ? { id: query.get("id") } : { pcd: query.get("pcd") }
       );
       setPendingGenericIssuanceCheckinRequest(stringifiedRequest);
-      if (self == null) {
+      if (!self) {
         window.location.href = `/#/login?redirectedFromAction=true&${pendingGenericIssuanceCheckinRequestKey}=${encodeURIComponent(
           stringifiedRequest
         )}`;

--- a/apps/passport-client/components/screens/SubscriptionsScreen.tsx
+++ b/apps/passport-client/components/screens/SubscriptionsScreen.tsx
@@ -31,11 +31,11 @@ export function SubscriptionsScreen(): JSX.Element {
   }, []);
 
   useEffect(() => {
-    if (self == null || userForcedToLogout) {
+    if (!self || userForcedToLogout) {
       clearAllPendingRequests();
       const stringifiedRequest = JSON.stringify("");
       setPendingViewSubscriptionsRequest(stringifiedRequest);
-      if (self == null) {
+      if (!self) {
         window.location.href = `/#/login?redirectedFromAction=true&${pendingViewSubscriptionsRequestKey}=${encodeURIComponent(
           stringifiedRequest
         )}`;

--- a/apps/passport-client/components/shared/PCDCardList.tsx
+++ b/apps/passport-client/components/shared/PCDCardList.tsx
@@ -90,7 +90,7 @@ export function PCDCardList({
   const [selectedPCDID, setSelectedPCDID] = useState("");
   const selectedPCD = useMemo(() => {
     // if user just added a PCD, highlight that one
-    if (sessionStorage.newAddedPCDID != null) {
+    if (sessionStorage.newAddedPCDID) {
       const added = pcds.find((pcd) => pcd.id === sessionStorage.newAddedPCDID);
       if (added) {
         return added;

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -108,7 +108,7 @@ class App extends React.Component<object, AppState> {
       return null;
     }
 
-    const hasStack = state.error?.stack != null;
+    const hasStack = !!state.error?.stack;
     return (
       <StateContext.Provider value={this.stateContextState}>
         {!isWebAssemblySupported() ? (
@@ -405,7 +405,7 @@ function setupUsingLaserScanning(): void {
 async function loadInitialState(): Promise<AppState> {
   let identity = loadIdentity();
 
-  if (identity == null) {
+  if (!identity) {
     console.log("Generating a new Semaphore identity...");
     identity = new Identity();
     saveIdentity(identity);
@@ -423,9 +423,9 @@ async function loadInitialState(): Promise<AppState> {
 
   if (
     // If on Zupass legacy login, ask user to set password
-    self != null &&
-    encryptionKey == null &&
-    self.salt == null
+    self &&
+    !encryptionKey &&
+    !self.salt
   ) {
     console.log("Asking existing user to set a password");
     modal = { modalType: "upgrade-account-modal" };

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -468,7 +468,7 @@ async function setSelf(
   let userMismatched = false;
   let hasChangedPassword = false;
 
-  if (state.self && self.salt != state.self.salt) {
+  if (state.self && self.salt !== state.self.salt) {
     // If the password has been changed on a different device, the salts will mismatch
     console.log("User salt mismatch");
     hasChangedPassword = true;
@@ -625,9 +625,9 @@ async function loadAfterLogin(
   let modal: AppState["modal"] = { modalType: "none" };
   if (
     // If on Zupass legacy login, ask user to set passwrod
-    self != null &&
-    encryptionKey == null &&
-    storage.storage.self.salt == null
+    self &&
+    !encryptionKey &&
+    !storage.storage.self.salt
   ) {
     console.log("Asking existing user to set a password");
     modal = { modalType: "upgrade-account-modal" };
@@ -785,7 +785,7 @@ async function doSync(
     console.log("[SYNC] no user available to sync");
     return undefined;
   }
-  if (loadEncryptionKey() == null) {
+  if (!loadEncryptionKey()) {
     console.log("[SYNC] no encryption key, can't sync");
     return undefined;
   }
@@ -814,7 +814,7 @@ async function doSync(
       state.pcds,
       state.subscriptions
     );
-    if (dlRes.success && dlRes.value != null) {
+    if (dlRes.success && dlRes.value) {
       const { pcds, subscriptions, serverRevision, serverHash } = dlRes.value;
       return {
         downloadedPCDs: true,

--- a/apps/passport-client/src/localstorage.ts
+++ b/apps/passport-client/src/localstorage.ts
@@ -146,7 +146,7 @@ export function loadEncryptionKey(): string | undefined {
 
 export function loadSelf(): User | undefined {
   const self = window.localStorage["self"];
-  if (self != null && self !== "") {
+  if (self && self !== "") {
     return JSON.parse(self);
   }
 }

--- a/apps/passport-client/src/sessionStorage.ts
+++ b/apps/passport-client/src/sessionStorage.ts
@@ -33,7 +33,7 @@ export function clearPendingGetWithoutProvingRequest(): void {
 
 export function getPendingGetWithoutProvingRequest(): string | undefined {
   const value = sessionStorage.getItem(pendingGetWithoutProvingRequestKey);
-  return value == null ? undefined : value;
+  return value ?? undefined;
 }
 
 export const pendingAddRequestKey = "pendingAddRequest";
@@ -48,7 +48,7 @@ export function clearPendingAddRequest(): void {
 
 export function getPendingAddRequest(): string | undefined {
   const value = sessionStorage.getItem(pendingAddRequestKey);
-  return value == null ? undefined : value;
+  return value ?? undefined;
 }
 
 export const pendingHaloRequestKey = "pendingHaloRequest";
@@ -63,7 +63,7 @@ export function clearPendingHaloRequest(): void {
 
 export function getPendingHaloRequest(): string | undefined {
   const value = sessionStorage.getItem(pendingHaloRequestKey);
-  return value == null ? undefined : value;
+  return value ?? undefined;
 }
 
 export const pendingProofRequestKey = "pendingProofRequest";
@@ -78,7 +78,7 @@ export function clearPendingProofRequest(): void {
 
 export function getPendingProofRequest(): string | undefined {
   const value = sessionStorage.getItem(pendingProofRequestKey);
-  return value == null ? undefined : value;
+  return value ?? undefined;
 }
 
 export const pendingViewSubscriptionsRequestKey = "pendingViewSubscriptions";
@@ -93,7 +93,7 @@ export function clearPendingViewSubscriptionsRequest(): void {
 
 export function getPendingViewSubscriptionsPageRequest(): string | undefined {
   const value = sessionStorage.getItem(pendingViewSubscriptionsRequestKey);
-  return value == null ? undefined : value;
+  return value ?? undefined;
 }
 
 export const pendingAddSubscriptionRequestKey = "pendingAddSubscription";
@@ -108,7 +108,7 @@ export function clearPendingAddSubscriptionRequest(): void {
 
 export function getPendingAddSubscriptionPageRequest(): string | undefined {
   const value = sessionStorage.getItem(pendingAddSubscriptionRequestKey);
-  return value == null ? undefined : value;
+  return value ?? undefined;
 }
 
 export const pendingViewFrogCryptoRequestKey = "pendingViewFrogCrypto";
@@ -123,7 +123,7 @@ export function clearPendingViewFrogCryptoRequest(): void {
 
 export function getPendingViewFrogCryptoPageRequest(): string | undefined {
   const value = sessionStorage.getItem(pendingViewFrogCryptoRequestKey);
-  return value == null ? undefined : value;
+  return value ?? undefined;
 }
 
 export const pendingGenericIssuanceCheckinRequestKey =
@@ -139,5 +139,5 @@ export function clearPendingGenericIssuanceCheckinRequest(): void {
 
 export function getPendingGenericIssuanceCheckinRequest(): string | undefined {
   const value = sessionStorage.getItem(pendingGenericIssuanceCheckinRequestKey);
-  return value == null ? undefined : value;
+  return value ?? undefined;
 }

--- a/apps/passport-client/src/useSyncE2EEStorage.tsx
+++ b/apps/passport-client/src/useSyncE2EEStorage.tsx
@@ -280,7 +280,7 @@ export async function mergeStorage(
     final: remoteFields.pcds.size()
   };
   if (
-    (await localFields.pcds.getHash()) != (await remoteFields.pcds.getHash())
+    (await localFields.pcds.getHash()) !== (await remoteFields.pcds.getHash())
   ) {
     identicalPCDs = false;
     const pcdMergePredicate = (
@@ -326,7 +326,7 @@ export async function mergeStorage(
     final: remoteCount
   };
   if (
-    (await localFields.subscriptions.getHash()) !=
+    (await localFields.subscriptions.getHash()) !==
     (await remoteFields.subscriptions.getHash())
   ) {
     identicalSubs = false;

--- a/apps/passport-client/src/user.ts
+++ b/apps/passport-client/src/user.ts
@@ -42,7 +42,7 @@ export async function pollUser(
 
 // Function that checks whether the user has set a password for their account
 export function hasSetupPassword(user: User): boolean {
-  return user != null && user.salt != null;
+  return !!user && !!user.salt;
 }
 
 export function findUserIdentityPCD(

--- a/apps/passport-server/src/apis/devconnect/devconnectPretixAPI.ts
+++ b/apps/passport-server/src/apis/devconnect/devconnectPretixAPI.ts
@@ -141,7 +141,7 @@ export class DevconnectPretixAPI implements IDevconnectPretixAPI {
 
       // Fetch orders from paginated API
       let url = `${orgUrl}/events`;
-      while (url != null) {
+      while (url) {
         logger(`[DEVCONNECT PRETIX] Fetching events: ${url}`);
         const res = await this.queuedFetch(url, {
           headers: { Authorization: `Token ${token}` }
@@ -215,7 +215,7 @@ export class DevconnectPretixAPI implements IDevconnectPretixAPI {
 
       // Fetch categories from paginated API
       let url = `${orgUrl}/events/${eventID}/categories/`;
-      while (url != null) {
+      while (url) {
         logger(`[DEVCONNECT PRETIX] Fetching categories: ${url}`);
         const res = await this.queuedFetch(url, {
           headers: { Authorization: `Token ${token}` }
@@ -245,7 +245,7 @@ export class DevconnectPretixAPI implements IDevconnectPretixAPI {
 
       // Fetch orders from paginated API
       let url = `${orgUrl}/events/${eventID}/items/`;
-      while (url != null) {
+      while (url) {
         logger(`[DEVCONNECT PRETIX] Fetching items: ${url}`);
         const res = await this.queuedFetch(url, {
           headers: { Authorization: `Token ${token}` }
@@ -276,7 +276,7 @@ export class DevconnectPretixAPI implements IDevconnectPretixAPI {
 
       // Fetch orders from paginated API
       let url = `${orgUrl}/events/${eventID}/orders/`;
-      while (url != null) {
+      while (url) {
         logger(`[DEVCONNECT PRETIX] Fetching orders ${url}`);
         const res = await this.queuedFetch(url, {
           headers: { Authorization: `Token ${token}` }
@@ -307,7 +307,7 @@ export class DevconnectPretixAPI implements IDevconnectPretixAPI {
 
       // Fetch check-in lists from paginated API
       let url = `${orgUrl}/events/${eventID}/checkinlists/`;
-      while (url != null) {
+      while (url) {
         logger(`[DEVCONNECT PRETIX] Fetching orders ${url}`);
         const res = await this.queuedFetch(url, {
           headers: { Authorization: `Token ${token}` }

--- a/apps/passport-server/src/apis/pretix/genericPretixAPI.ts
+++ b/apps/passport-server/src/apis/pretix/genericPretixAPI.ts
@@ -252,7 +252,7 @@ export class GenericPretixAPI implements IGenericPretixAPI {
 
       // Fetch orders from paginated API
       let url = `${orgUrl}/events`;
-      while (url != null) {
+      while (url) {
         logger(`[GENERIC PRETIX] Fetching events: ${url}`);
         const res = await this.getOrCreateQueue(orgUrl).fetch(url, {
           headers: { Authorization: `Token ${token}` }
@@ -352,7 +352,7 @@ export class GenericPretixAPI implements IGenericPretixAPI {
 
       // Fetch categories from paginated API
       let url = `${orgUrl}/events/${eventID}/categories/`;
-      while (url != null) {
+      while (url) {
         logger(`[GENERIC PRETIX] Fetching categories: ${url}`);
         const res = await this.getOrCreateQueue(orgUrl).fetch(url, {
           headers: { Authorization: `Token ${token}` }
@@ -391,7 +391,7 @@ export class GenericPretixAPI implements IGenericPretixAPI {
 
       // Fetch orders from paginated API
       let url = `${orgUrl}/events/${eventID}/items/`;
-      while (url != null) {
+      while (url) {
         logger(`[GENERIC PRETIX] Fetching items: ${url}`);
         const res = await this.getOrCreateQueue(orgUrl).fetch(url, {
           headers: { Authorization: `Token ${token}` }
@@ -431,7 +431,7 @@ export class GenericPretixAPI implements IGenericPretixAPI {
 
       // Fetch orders from paginated API
       let url = `${orgUrl}/events/${eventID}/orders/`;
-      while (url != null) {
+      while (url) {
         logger(`[GENERIC PRETIX] Fetching orders ${url}`);
         const res = await this.getOrCreateQueue(orgUrl).fetch(url, {
           headers: { Authorization: `Token ${token}` }
@@ -480,7 +480,7 @@ export class GenericPretixAPI implements IGenericPretixAPI {
 
       // Fetch check-in lists from paginated API
       let url = `${orgUrl}/events/${eventID}/checkinlists/`;
-      while (url != null) {
+      while (url) {
         logger(`[GENERIC PRETIX] Fetching orders ${url}`);
         const res = await this.getOrCreateQueue(orgUrl).fetch(url, {
           headers: { Authorization: `Token ${token}` }

--- a/apps/passport-server/src/apis/zuzaluPretixAPI.ts
+++ b/apps/passport-server/src/apis/zuzaluPretixAPI.ts
@@ -25,7 +25,7 @@ export class ZuzaluPretixAPI implements IZuzaluPretixAPI {
 
       // Fetch orders from paginated API
       let url = `${this.config.orgUrl}/events/${eventID}/orders/`;
-      while (url != null) {
+      while (url) {
         logger(`[PRETIX] Fetching ${url}`);
         const res = await instrumentedFetch(url, {
           headers: { Authorization: `Token ${this.config.token}` }
@@ -53,7 +53,7 @@ export class ZuzaluPretixAPI implements IZuzaluPretixAPI {
 
       // Fetch orders from paginated API
       let url = `${this.config.orgUrl}/events/${eventID}/subevents/`;
-      while (url != null) {
+      while (url) {
         logger(`[PRETIX] Fetching ${url}`);
         const res = await instrumentedFetch(url, {
           headers: { Authorization: `Token ${this.config.token}` }

--- a/apps/passport-server/src/database/queries/pipelineUserDB.ts
+++ b/apps/passport-server/src/database/queries/pipelineUserDB.ts
@@ -58,7 +58,7 @@ export class PipelineUserDB implements IPipelineUserDB {
         async (client): Promise<PipelineUser> => {
           span?.setAttribute("email", email);
           const existingUser = await this.getUserByEmail(email, client);
-          if (existingUser != null) {
+          if (existingUser) {
             span?.setAttribute("is_new", false);
             traceUser(existingUser);
             return existingUser;

--- a/apps/passport-server/src/database/queries/saveUser.ts
+++ b/apps/passport-server/src/database/queries/saveUser.ts
@@ -57,7 +57,7 @@ WHERE email = $1 AND commitment = $2`,
     [email, commitment]
   );
   const uuid = uuidResult.rows[0]?.uuid as string | undefined;
-  if (uuid == null) {
+  if (!uuid) {
     throw new Error(
       `Failed to save commitment. Wrong email? ${email} ${commitment} ${salt} ${encryptionKey}`
     );

--- a/apps/passport-server/src/database/queries/telegram/fetchSemaphoreId.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchSemaphoreId.ts
@@ -13,7 +13,7 @@ export async function fetchSemaphoreIdFromTelegramUsername(
     `,
     [telegramUsername]
   );
-  if (result.rowCount == 0) {
+  if (result.rowCount === 0) {
     return null;
   }
   const semaphoreId: string = result.rows[0].semaphore_id;

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramUsername.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramUsername.ts
@@ -13,7 +13,7 @@ export async function fetchTelegramUsernameFromSemaphoreId(
     `,
     [sempahoreId]
   );
-  if (result.rowCount == 0) {
+  if (result.rowCount === 0) {
     return null;
   }
   const telegramUsername: string = result.rows[0].telegram_username;

--- a/apps/passport-server/src/routing/params.ts
+++ b/apps/passport-server/src/routing/params.ts
@@ -97,7 +97,7 @@ export function checkBody<T, U extends keyof T>(
 ): NonNullable<T[U]> {
   const value = req.body[name];
 
-  if (value == null) {
+  if (value === null || value === undefined) {
     throw new PCDHTTPError(
       400,
       `missing required request body field: '${String(name)}' - was ${value}`

--- a/apps/passport-server/src/routing/pcdHttpError.ts
+++ b/apps/passport-server/src/routing/pcdHttpError.ts
@@ -28,7 +28,7 @@ export function respondWithError(
   res: Response
 ): void {
   if (e instanceof PCDHTTPError) {
-    if (e.message == null) {
+    if (!e.message) {
       res.sendStatus(e.code);
     } else {
       res.status(e.code).send(e.message);

--- a/apps/passport-server/src/routing/routes/kudosbotRoutes.ts
+++ b/apps/passport-server/src/routing/routes/kudosbotRoutes.ts
@@ -66,7 +66,7 @@ export function initKudosbotRoutes(
     if (!kudosData) {
       return res.status(400).send("Error: not a valid kudos proof.");
     }
-    if (kudosData.giver != kudosGiverSemaphoreId) {
+    if (kudosData.giver !== kudosGiverSemaphoreId) {
       return res
         .status(400)
         .send(

--- a/apps/passport-server/src/routing/routes/pcdIssuanceRoutes.ts
+++ b/apps/passport-server/src/routing/routes/pcdIssuanceRoutes.ts
@@ -50,7 +50,7 @@ export function initPCDIssuanceRoutes(
    * Zuconnect, Zuzalu, etc.
    */
   app.get("/issue/enabled", async (req: Request, res: Response) => {
-    const result = issuanceService != null;
+    const result = issuanceService !== null;
     res.json(result satisfies IssuanceEnabledResponseValue);
   });
 

--- a/apps/passport-server/src/routing/routes/semaphoreRoutes.ts
+++ b/apps/passport-server/src/routing/routes/semaphoreRoutes.ts
@@ -62,7 +62,7 @@ export function initSemaphoreRoutes(
         checkUrlParam(req, "root")
       );
 
-      if (historicGroup == null) {
+      if (!historicGroup) {
         throw new PCDHTTPError(404, "Semaphore group not found");
       }
 
@@ -85,7 +85,7 @@ export function initSemaphoreRoutes(
     const latestGroups = await semaphoreService.getLatestSemaphoreGroups();
     const matchingGroup = latestGroups.find((g) => g.groupId.toString() === id);
 
-    if (matchingGroup == null) {
+    if (!matchingGroup) {
       throw new PCDHTTPError(404, "Semaphore group not found");
     }
 
@@ -104,7 +104,7 @@ export function initSemaphoreRoutes(
     const semaphoreId = checkUrlParam(req, "id");
     const namedGroup = semaphoreService.getNamedGroup(semaphoreId);
 
-    if (namedGroup == null) {
+    if (!namedGroup) {
       throw new PCDHTTPError(404, "Semaphore group not found");
     }
 

--- a/apps/passport-server/src/routing/server.ts
+++ b/apps/passport-server/src/routing/server.ts
@@ -70,7 +70,7 @@ export async function startHttpServer(
         let corsOptions: CorsOptions;
         const methods = ["GET", "POST", "PUT", "DELETE"];
         if (
-          genericIssuanceClientUrl != null &&
+          genericIssuanceClientUrl &&
           req.header("Origin") === genericIssuanceClientUrl
         ) {
           corsOptions = {

--- a/apps/passport-server/src/services/devconnect/organizerSync.ts
+++ b/apps/passport-server/src/services/devconnect/organizerSync.ts
@@ -1046,7 +1046,7 @@ export class OrganizerSync {
 
           let pretix_checkin_timestamp: Date | null = null;
 
-          if (pretix_checkin_timestamp_string != null) {
+          if (pretix_checkin_timestamp_string !== null) {
             try {
               const parsedDate = Date.parse(
                 pretix_checkin_timestamp_string ?? ""

--- a/apps/passport-server/src/services/discordService.ts
+++ b/apps/passport-server/src/services/discordService.ts
@@ -39,14 +39,14 @@ export class DiscordService {
 export async function startDiscordService(): Promise<DiscordService | null> {
   logger(`[INIT] initializing Discord`);
 
-  if (process.env.DISCORD_ALERTS_CHANNEL_ID == null) {
+  if (!process.env.DISCORD_ALERTS_CHANNEL_ID) {
     logger(
       `[INIT] missing DISCORD_ALERTS_CHANNEL_ID, not instantiating discord service`
     );
     return null;
   }
 
-  if (process.env.DISCORD_TOKEN == null) {
+  if (!process.env.DISCORD_TOKEN) {
     logger(`[INIT] missing DISCORD_TOKEN, not instantiating discord service`);
     return null;
   }

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -715,7 +715,7 @@ export class PretixPipeline implements BasePipeline {
 
         const nameQuestionAnswer = answers?.find(
           (a) =>
-            product?.nameQuestionPretixQuestionIdentitifier != null &&
+            product?.nameQuestionPretixQuestionIdentitifier &&
             a?.question_identifier ===
               product?.nameQuestionPretixQuestionIdentitifier
         )?.answer;
@@ -736,7 +736,7 @@ export class PretixPipeline implements BasePipeline {
 
           let pretix_checkin_timestamp: Date | null = null;
 
-          if (pretix_checkin_timestamp_string != null) {
+          if (pretix_checkin_timestamp_string !== null) {
             try {
               const parsedDate = Date.parse(
                 pretix_checkin_timestamp_string ?? ""

--- a/apps/passport-server/src/services/generic-issuance/subservices/utils/startGenericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/subservices/utils/startGenericIssuanceService.ts
@@ -44,7 +44,7 @@ export async function startGenericIssuanceService(
   }
 
   const pkeyEnv = process.env.GENERIC_ISSUANCE_EDDSA_PRIVATE_KEY;
-  if (pkeyEnv == null) {
+  if (!pkeyEnv) {
     logger(
       "[INIT] missing environment variable GENERIC_ISSUANCE_EDDSA_PRIVATE_KEY"
     );
@@ -69,12 +69,12 @@ export async function startGenericIssuanceService(
   let stytchClient: Client | undefined = undefined;
 
   if (!BYPASS_EMAIL) {
-    if (projectIdEnv == null) {
+    if (!projectIdEnv) {
       logger("[INIT] missing environment variable STYTCH_PROJECT_ID");
       return null;
     }
 
-    if (secretEnv == null) {
+    if (!secretEnv) {
       logger("[INIT] missing environment variable STYTCH_SECRET");
       return null;
     }
@@ -86,7 +86,7 @@ export async function startGenericIssuanceService(
   }
 
   const genericIssuanceClientUrl = process.env.GENERIC_ISSUANCE_CLIENT_URL;
-  if (genericIssuanceClientUrl == null) {
+  if (!genericIssuanceClientUrl) {
     logger("[INIT] missing GENERIC_ISSUANCE_CLIENT_URL");
     return null;
   }

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -685,7 +685,7 @@ export class IssuanceService {
       signature.claim.identityCommitment
     );
 
-    if (user == null) {
+    if (user === null) {
       logger(
         `can't issue PCDs for ${signature.claim.identityCommitment} because ` +
           `we don't have a user with that commitment in the database`
@@ -718,7 +718,7 @@ export class IssuanceService {
           span?.setAttribute("email", email);
         }
 
-        if (commitmentRow == null || email == null) {
+        if (!commitmentRow || !email) {
           return [];
         }
 
@@ -897,7 +897,7 @@ export class IssuanceService {
       eventId: t.pretix_events_config_id,
       productId: t.devconnect_pretix_items_info_id,
       timestampConsumed:
-        t.zupass_checkin_timestamp == null
+        t.zupass_checkin_timestamp === null
           ? 0
           : new Date(t.zupass_checkin_timestamp).getTime(),
       timestampSigned: Date.now(),
@@ -1009,7 +1009,7 @@ export class IssuanceService {
           span?.setAttribute("email", email);
         }
 
-        if (commitmentRow == null || email == null) {
+        if (!commitmentRow || !email) {
           return [];
         }
 
@@ -1067,7 +1067,7 @@ export class IssuanceService {
         span?.setAttribute("email", email);
       }
 
-      if (commitmentRow == null || email == null) {
+      if (!commitmentRow || !email) {
         return [];
       }
 
@@ -1125,7 +1125,7 @@ export class IssuanceService {
           span?.setAttribute("email", email);
         }
 
-        if (user == null || email == null) {
+        if (!user || !email) {
           return [];
         }
 
@@ -1473,7 +1473,7 @@ export async function startIssuanceService(
   const zupassRsaKey = loadRSAPrivateKey();
   const zupassEddsaKey = loadEdDSAPrivateKey();
 
-  if (zupassRsaKey == null || zupassEddsaKey == null) {
+  if (zupassRsaKey === null || zupassEddsaKey === null) {
     logger("[INIT] can't start issuance service, missing private key");
     return null;
   }
@@ -1571,7 +1571,7 @@ async function setupKnownTicketTypes(
 export function loadRSAPrivateKey(): NodeRSA | null {
   const pkeyEnv = process.env.SERVER_RSA_PRIVATE_KEY_BASE64;
 
-  if (pkeyEnv == null) {
+  if (!pkeyEnv) {
     logger("[INIT] missing environment variable SERVER_RSA_PRIVATE_KEY_BASE64");
     return null;
   }
@@ -1592,7 +1592,7 @@ export function loadRSAPrivateKey(): NodeRSA | null {
 function loadEdDSAPrivateKey(): string | null {
   const pkeyEnv = process.env.SERVER_EDDSA_PRIVATE_KEY;
 
-  if (pkeyEnv == null) {
+  if (!pkeyEnv) {
     logger("[INIT] missing environment variable SERVER_EDDSA_PRIVATE_KEY");
     return null;
   }

--- a/apps/passport-server/src/services/kudosbotService.ts
+++ b/apps/passport-server/src/services/kudosbotService.ts
@@ -155,7 +155,7 @@ export class KudosbotService {
         this.context.dbPool,
         chatId
       );
-      if (telegramConversations.length == 0) {
+      if (telegramConversations.length === 0) {
         return await ctx.reply(
           "Error fetching conversations for given telegram chat id"
         );

--- a/apps/passport-server/src/services/persistentCacheService.ts
+++ b/apps/passport-server/src/services/persistentCacheService.ts
@@ -60,7 +60,7 @@ export class PersistentCacheService {
     return traced("Cache", "getValue", async (span) => {
       span?.setAttribute("cache_key", key);
       const value = getCacheValue(this.db, key);
-      span?.setAttribute("hit", value != null);
+      span?.setAttribute("hit", !!value);
       return value;
     });
   }

--- a/apps/passport-server/src/services/poapService.ts
+++ b/apps/passport-server/src/services/poapService.ts
@@ -114,7 +114,7 @@ export class PoapService {
       `[POAP] checking that signer of ticket ${pcd.claim.partialTicket.ticketId} matches intended signer`
     );
 
-    if (signerPublicKey == null) {
+    if (!signerPublicKey) {
       if (!process.env.SERVER_EDDSA_PRIVATE_KEY)
         throw new Error(`missing server eddsa private key .env value`);
 
@@ -174,7 +174,7 @@ export class PoapService {
         throw new Error("valid event IDs of PCD does not match Zuzalu 2023");
       }
 
-      if (ticketId == null) {
+      if (!ticketId) {
         throw new Error("ticket ID must be revealed");
       }
       span?.setAttribute("ticketId", ticketId);
@@ -188,7 +188,7 @@ export class PoapService {
         this.context.dbPool,
         { uuid: ticketId }
       );
-      if (zuzaluPretixTicket == null) {
+      if (zuzaluPretixTicket === null) {
         throw new Error("zuzalu ticket does not exist");
       }
 
@@ -230,18 +230,18 @@ export class PoapService {
         );
       }
 
-      if (ticketId == null) {
+      if (!ticketId) {
         throw new Error("ticket ID must be revealed");
       }
       span?.setAttribute("ticketId", ticketId);
 
       logger(`[POAP] fetching zuconnect ticket ${ticketId} from database`);
 
-      const zuconnectTicket = fetchZuconnectTicketById(
+      const zuconnectTicket = await fetchZuconnectTicketById(
         this.context.dbPool,
         ticketId
       );
-      if (zuconnectTicket == null) {
+      if (!zuconnectTicket) {
         throw new Error("zuconnect ticket does not exist");
       }
 
@@ -286,7 +286,7 @@ export class PoapService {
         throw new Error("valid event IDs of PCD does not match Vitalia 2024");
       }
 
-      if (ticketId == null) {
+      if (!ticketId) {
         throw new Error("ticket ID must be revealed");
       }
       span?.setAttribute("ticketId", ticketId);
@@ -337,7 +337,7 @@ export class PoapService {
       }
 
       logger(`[POAP] fetching devconnect ticket ${ticketId} from database`);
-      if (ticketId == null) {
+      if (!ticketId) {
         throw new Error("ticket ID must be revealed");
       }
       const devconnectPretixTicket =
@@ -345,7 +345,7 @@ export class PoapService {
           this.context.dbPool,
           ticketId
         );
-      if (devconnectPretixTicket == null) {
+      if (!devconnectPretixTicket) {
         throw new Error("ticket ID does not exist");
       }
       const { devconnect_pretix_items_info_id, is_consumed, email } =
@@ -398,7 +398,7 @@ export class PoapService {
         ticketId,
         "devconnect"
       );
-      if (poapLink == null) {
+      if (poapLink === null) {
         throw new Error("Not enough Devconnect POAP links");
       }
       return poapLink;
@@ -432,7 +432,7 @@ export class PoapService {
         ticketId,
         "zuzalu23"
       );
-      if (poapLink == null) {
+      if (poapLink === null) {
         throw new Error("Not enough Zuzalu 2023 POAP links");
       }
       return poapLink;
@@ -466,7 +466,7 @@ export class PoapService {
         ticketId,
         "zuconnect"
       );
-      if (poapLink == null) {
+      if (poapLink === null) {
         throw new Error("Not enough ZuConnect POAP links");
       }
       return poapLink;
@@ -500,7 +500,7 @@ export class PoapService {
         ticketId,
         "vitalia"
       );
-      if (poapLink == null) {
+      if (poapLink === null) {
         throw new Error("Not enough Vitalia POAP links");
       }
       return poapLink;
@@ -545,7 +545,7 @@ export class PoapService {
             this.context.dbPool,
             hashedTicketId
           );
-          if (existingPoapLink != null) {
+          if (existingPoapLink !== null) {
             span?.setAttribute("alreadyClaimed", true);
             span?.setAttribute("poapLink", existingPoapLink);
             return existingPoapLink;

--- a/apps/passport-server/src/services/provingService.ts
+++ b/apps/passport-server/src/services/provingService.ts
@@ -85,7 +85,7 @@ export class ProvingService {
     // malicious DoS attacks on the proving queue
     if (!this.pendingPCDResponse.has(hash)) {
       this.queue.push(request);
-      if (this.queue.length == 1) {
+      if (this.queue.length === 1) {
         this.pendingPCDResponse.set(hash, {
           status: PendingPCDStatus.PROVING,
           serializedPCD: undefined,

--- a/apps/passport-server/src/services/semaphoreService.ts
+++ b/apps/passport-server/src/services/semaphoreService.ts
@@ -288,7 +288,7 @@ export class SemaphoreService {
       );
 
       if (
-        correspondingLatestGroup == null ||
+        !correspondingLatestGroup ||
         correspondingLatestGroup.rootHash !== localGroup.group.root.toString()
       ) {
         logger(

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -1078,14 +1078,14 @@ export class TelegramService {
       span?.setAttribute("chatTitle", chat.title);
 
       const parsed = JSON.parse(serializedPCD) as SerializedPCD;
-      if (parsed.type == ZKEdDSAEventTicketPCDTypeName) {
+      if (parsed.type === ZKEdDSAEventTicketPCDTypeName) {
         await this.handleTicketVerification(
           serializedPCD,
           telegramUserId,
           chat.id,
           telegramUsername
         );
-      } else if (parsed.type == ZKEdDSAFrogPCDTypeName) {
+      } else if (parsed.type === ZKEdDSAFrogPCDTypeName) {
         await handleFrogVerification(
           this.context.dbPool,
           serializedPCD,
@@ -1158,7 +1158,7 @@ export class TelegramService {
         this.context.dbPool,
         telegramChatId
       );
-      if (eventsByChat.length == 0)
+      if (eventsByChat.length === 0)
         throw new Error(`No valid events found for given chat`);
       if (!verifyUserEventIds(eventsByChat, validEventIds)) {
         throw new Error(`User submitted event Ids are invalid `);
@@ -1250,7 +1250,7 @@ export class TelegramService {
         this.context.dbPool,
         telegramChatId
       );
-      if (eventsByChat.length == 0)
+      if (eventsByChat.length === 0)
         throw new Error(`No valid events found for given chat`);
       if (!verifyUserEventIds(eventsByChat, validEventIds)) {
         throw new Error(`User submitted event Ids are invalid `);
@@ -1392,7 +1392,7 @@ export class TelegramService {
         this.context.dbPool,
         telegramChatId
       );
-      if (eventsByChat.length == 0)
+      if (eventsByChat.length === 0)
         throw new Error(`No valid events found for given chat`);
       if (!verifyUserEventIds(eventsByChat, validEventIds)) {
         throw new Error(`User submitted event Ids are invalid `);

--- a/apps/passport-server/src/services/telemetryService.ts
+++ b/apps/passport-server/src/services/telemetryService.ts
@@ -184,9 +184,9 @@ export async function traced<T>(
     try {
       const result = await func(span);
       if (
-        options == null ||
-        options.autoEndSpan == null ||
-        options.autoEndSpan == true
+        !options ||
+        options.autoEndSpan === undefined ||
+        options.autoEndSpan === true
       ) {
         span.end();
       }

--- a/apps/passport-server/src/services/userService.ts
+++ b/apps/passport-server/src/services/userService.ts
@@ -122,7 +122,7 @@ export class UserService {
     );
 
     if (
-      existingCommitment != null &&
+      existingCommitment !== null &&
       !force &&
       // Users with an `encryption_key` do not have a password,
       // so we will need to verify email ownership with code.

--- a/apps/passport-server/src/services/zuzaluPretixSyncService.ts
+++ b/apps/passport-server/src/services/zuzaluPretixSyncService.ts
@@ -322,7 +322,7 @@ export class ZuzaluPretixSyncService {
               (subEvent) => subEvent.id === positionSubeventId
             )
           )
-          .filter((subEvent) => subEvent != null);
+          .filter((subEvent) => !!subEvent);
 
         const visitorDateRanges = orderSubevents.map(
           (subEvent) =>

--- a/apps/passport-server/src/util/util.ts
+++ b/apps/passport-server/src/util/util.ts
@@ -10,7 +10,7 @@ export const execAsync = promisify(exec);
  */
 export function requireEnv(str: string): string {
   const val = process.env[str];
-  if (val == null || val === "") {
+  if (val === null || val === undefined || val === "") {
     throw str;
   }
   return val;

--- a/apps/passport-server/test/devconnectdb.spec.ts
+++ b/apps/passport-server/test/devconnectdb.spec.ts
@@ -496,7 +496,7 @@ describe("database reads and writes for devconnect ticket features", function ()
         return (
           tickets.filter(
             (ticket: DevconnectPretixTicketDBWithEmailAndItem) =>
-              ticket.position_id == firstTicket.position_id
+              ticket.position_id === firstTicket.position_id
           ).length === 0
         );
       }
@@ -515,7 +515,7 @@ describe("database reads and writes for devconnect ticket features", function ()
         return (
           tickets.filter(
             (ticket: DevconnectPretixTicketDBWithEmailAndItem) =>
-              ticket.position_id == firstTicket.position_id
+              ticket.position_id === firstTicket.position_id
           ).length === 1
         );
       }

--- a/apps/passport-server/test/generic-issuance/pipelines/pretix/setupTestPretixPipeline.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/pretix/setupTestPretixPipeline.ts
@@ -73,11 +73,11 @@ export function setupTestPretixPipeline(): PretixPipelineTestData {
   ];
 
   const ethLatAmAttendeeProduct = ethLatAmConfiguredEvents[0].products.find(
-    (product) => product.name == "eth-latam-attendee-product"
+    (product) => product.name === "eth-latam-attendee-product"
   );
   expectToExist(ethLatAmAttendeeProduct);
   const ethLatAmBouncerProduct = ethLatAmConfiguredEvents[0].products.find(
-    (product) => product.name == "eth-lat-am-bouncer-product"
+    (product) => product.name === "eth-lat-am-bouncer-product"
   );
   expectToExist(ethLatAmBouncerProduct);
 

--- a/apps/passport-server/test/semaphore/checkSemaphore.ts
+++ b/apps/passport-server/test/semaphore/checkSemaphore.ts
@@ -48,7 +48,7 @@ export async function testLatestHistoricSemaphoreGroups(
 
 function nonZeroGroupMembers(group: Group): BigNumberish[] {
   return group.members.filter(
-    (m) => m.toString() != group.zeroValue.toString()
+    (m) => m.toString() !== group.zeroValue.toString()
   );
 }
 

--- a/apps/passport-server/test/user/testLogin.ts
+++ b/apps/passport-server/test/user/testLogin.ts
@@ -56,7 +56,7 @@ export async function testLogin(
   if (userService.bypassEmail) {
     expect(confirmationEmailResult.value).to.not.eq(undefined);
 
-    if (confirmationEmailResult.value?.devToken == null) {
+    if (!confirmationEmailResult.value?.devToken) {
       throw new Error(
         "expected to get the verification token in bypassEmail mode"
       );
@@ -64,7 +64,7 @@ export async function testLogin(
     token = confirmationEmailResult.value.devToken;
   } else {
     const serverToken = await emailTokenService.getTokenForEmail(email);
-    if (serverToken == null) {
+    if (serverToken === null) {
       throw new Error(
         "expected to be able to get the verification token from the internal server state"
       );

--- a/packages/lib/gpcircuits/test/proto-pod-gpc.spec.ts
+++ b/packages/lib/gpcircuits/test/proto-pod-gpc.spec.ts
@@ -332,7 +332,7 @@ describe("proto-pod-gpc.ProtoPODGPC should work", function () {
 
       // Fill in entry value for supported types.  Value hash is arbitrarily
       // revealed for even-numbered entries.
-      const isValueHashRevealed = entryIndex % 2 == 0;
+      const isValueHashRevealed = entryIndex % 2 === 0;
       const entryValueHash = entrySignals.valueHash;
       if (!isEntryEnabled) {
         sigEntryValue.push(0n);

--- a/packages/lib/passport-interface/src/PassportPopup.ts
+++ b/packages/lib/passport-interface/src/PassportPopup.ts
@@ -40,7 +40,7 @@ export function useZupassPopupSetup(): string {
   const [error, setError] = useState("");
 
   useEffect(() => {
-    if (window.opener == null) {
+    if (!window.opener) {
       setError("Not a popup window");
       return;
     }
@@ -66,11 +66,11 @@ export function useZupassPopupSetup(): string {
     const finished = params.get("finished");
 
     // First, this page is window.open()-ed. Redirect to Zupass.
-    if (paramsProofUrl != null) {
+    if (paramsProofUrl) {
       window.location.href = paramsProofUrl;
     } else if (finished) {
       // Later, Zupass redirects back with a result. Send it to our parent.
-      if (paramsProof != null) {
+      if (paramsProof) {
         window.opener.postMessage({ encodedPCD: paramsProof }, "*");
       }
 
@@ -78,7 +78,7 @@ export function useZupassPopupSetup(): string {
       setTimeout(() => {
         setError("Finished. Please close this window.");
       }, 1000 * 3);
-    } else if (paramsEncodingPendingPCD != null) {
+    } else if (paramsEncodingPendingPCD) {
       // Later, Zupass redirects back with a encodedPendingPCD. Send it to our parent.
       window.opener.postMessage(
         { encodedPendingPCD: paramsEncodingPendingPCD },

--- a/packages/lib/passport-interface/src/User.ts
+++ b/packages/lib/passport-interface/src/User.ts
@@ -13,7 +13,7 @@ export function useFetchUser(
 
   useEffect(() => {
     const doLoad = async (): Promise<void> => {
-      if (uuid == undefined) {
+      if (uuid === undefined) {
         setUser(null);
         setError(null);
         setLoading(false);

--- a/packages/lib/passport-interface/src/api/apiResult.ts
+++ b/packages/lib/passport-interface/src/api/apiResult.ts
@@ -99,16 +99,16 @@ export async function onNamedAPIError<TResult>(
     const resJSON = JSON.parse(resText);
     // Server must at least specify error.name for us to take its other
     // fields.  If so, we take all fields, but delete any with the wrong type.
-    if (resJSON.error?.name && typeof resJSON.error.name == "string") {
+    if (resJSON.error?.name && typeof resJSON.error.name === "string") {
       serverProvidedError = true;
       apiError = resJSON.error;
       if (
         "detailedMessage" in apiError &&
-        typeof apiError.detailedMessage != "string"
+        typeof apiError.detailedMessage !== "string"
       ) {
         delete apiError.detailedMessage;
       }
-      if ("code" in apiError && typeof apiError.code != "number") {
+      if ("code" in apiError && typeof apiError.code !== "number") {
         delete apiError.code;
       }
     } else {

--- a/packages/lib/passport-interface/src/api/makeRequest.ts
+++ b/packages/lib/passport-interface/src/api/makeRequest.ts
@@ -185,7 +185,7 @@ async function httpRequest<T extends APIResult<unknown, unknown>>(
     };
   }
 
-  if (requestBody != null) {
+  if (requestBody) {
     requestOptions = {
       ...requestOptions,
       ...POST,
@@ -193,7 +193,7 @@ async function httpRequest<T extends APIResult<unknown, unknown>>(
     };
   }
 
-  if (method != null) {
+  if (method) {
     requestOptions = { ...requestOptions, method };
   }
 

--- a/packages/lib/passport-ui/src/QR.tsx
+++ b/packages/lib/passport-ui/src/QR.tsx
@@ -58,7 +58,7 @@ export function QRDisplayWithRegenerateAndStorage({
     const { timestamp, payload } = savedState;
 
     if (
-      timestamp != null &&
+      timestamp &&
       Date.now() - timestamp < maxAgeMs &&
       payload !== undefined
     ) {

--- a/packages/pcd/ethereum-group-pcd/test/EthereumGroupPCD.spec.ts
+++ b/packages/pcd/ethereum-group-pcd/test/EthereumGroupPCD.spec.ts
@@ -52,7 +52,7 @@ async function groupProof(
   for (let i = 0; i < randM; i++) {
     const otherWallet = ethers.Wallet.createRandom();
     tree.insert(
-      groupType == GroupType.ADDRESS
+      groupType === GroupType.ADDRESS
         ? BigInt(otherWallet.address)
         : poseidon.hashPubKey(getRawPubKeyBuffer(otherWallet.publicKey))
     );
@@ -60,7 +60,7 @@ async function groupProof(
   // Add the prover's ID to the tree
   const proverPubkeyBuffer: Buffer = getRawPubKeyBuffer(wallet.publicKey);
   tree.insert(
-    groupType == GroupType.ADDRESS
+    groupType === GroupType.ADDRESS
       ? BigInt(wallet.address)
       : poseidon.hashPubKey(proverPubkeyBuffer)
   );
@@ -70,7 +70,7 @@ async function groupProof(
   for (let i = 0; i < randN; i++) {
     const otherWallet = ethers.Wallet.createRandom();
     tree.insert(
-      groupType == GroupType.ADDRESS
+      groupType === GroupType.ADDRESS
         ? BigInt(otherWallet.address)
         : poseidon.hashPubKey(getRawPubKeyBuffer(otherWallet.publicKey))
     );
@@ -78,7 +78,7 @@ async function groupProof(
 
   // Get the index of the prover's public key in the tree
   const idIndex = tree.indexOf(
-    groupType == GroupType.ADDRESS
+    groupType === GroupType.ADDRESS
       ? BigInt(wallet.address)
       : poseidon.hashPubKey(proverPubkeyBuffer)
   );

--- a/packages/pcd/message-pcd/src/MessagePCD.ts
+++ b/packages/pcd/message-pcd/src/MessagePCD.ts
@@ -53,11 +53,11 @@ export class MessagePCD implements PCD<Message, MessageProof> {
 }
 
 export async function prove(args: Args): Promise<MessagePCD> {
-  if (args.message.value == null) {
+  if (args.message.value === undefined) {
     throw new Error("missing message");
   }
 
-  if (args.privateKey.value == null) {
+  if (args.privateKey.value === undefined || args.privateKey.value === "") {
     throw new Error("missing private key");
   }
 

--- a/packages/pcd/rsa-image-pcd/src/RSAImagePCD.ts
+++ b/packages/pcd/rsa-image-pcd/src/RSAImagePCD.ts
@@ -43,15 +43,15 @@ export class RSAImagePCD implements PCD<RSAImagePCDClaim, RSAImagePCDProof> {
 }
 
 export async function prove(args: RSAImagePCDArgs): Promise<RSAImagePCD> {
-  if (args.url.value == null) {
+  if (args.url.value === undefined || args.url.value === "") {
     throw new Error("missing url");
   }
 
-  if (args.title.value == null) {
+  if (args.title.value === undefined || args.title.value === "") {
     throw new Error("missing title");
   }
 
-  if (args.privateKey.value == null) {
+  if (args.privateKey.value === undefined || args.title.value === "") {
     throw new Error("missing private key");
   }
 

--- a/packages/pcd/rsa-pcd/src/RSAPCD.ts
+++ b/packages/pcd/rsa-pcd/src/RSAPCD.ts
@@ -54,11 +54,11 @@ export class RSAPCD implements PCD<RSAPCDClaim, RSAPCDProof> {
 }
 
 export async function prove(args: RSAPCDArgs): Promise<RSAPCD> {
-  if (args.privateKey.value == null) {
+  if (args.privateKey.value === undefined || args.privateKey.value === "") {
     throw new Error("missing private key value");
   }
 
-  if (args.signedMessage.value == null) {
+  if (args.signedMessage.value === undefined) {
     throw new Error("missing message to sign");
   }
 

--- a/packages/tools/eslint-config-custom/index.js
+++ b/packages/tools/eslint-config-custom/index.js
@@ -47,7 +47,8 @@ module.exports = {
     "prettier/prettier": "error",
     "@typescript-eslint/explicit-function-return-type": "error",
     "@typescript-eslint/no-explicit-any": "error",
-    "import/default": "off"
+    "import/default": "off",
+    eqeqeq: ["error", "always"]
   },
   settings: {
     "import/resolver": {


### PR DESCRIPTION
So far, this enables a single new linting rule, which forbids non-strict equality comparisons. In other words, `==` and `!=` are disallowed, and `===` and `!==` are enforced.

I've fixed various instances of this across the codebase. They break down into roughly three categories:

**Comparisons between values**. For example, `someFunc() == someOtherFunc()`, where both functions return a value type like a string or number. In these cases, we can avoid ambiguity by making the comparison stricter, and so I have replaced the `==` with `===`.

**Nullish comparisons**. These are things like `result == null` or `result != null`. In a non-strict comparison, `null` is regarded as equivalent to `undefined`, and also to some other special values such as the empty string `""`. So `"" == null` evaluatues to `true`, as does `undefined == null`. There were various places where we were using `result == null` comparisons to check the return value of a function which actually returns something like `string | undefined` (and therefore never `null` itself). Because `undefined` is loosely equivalent to `null`, these comparisons would successfully catch the case in which the function returns `undefined`. However, it makes the code harder to read, and could lead to mistakes. Mostly I've replaced `result == null` with `!result` and `result != null` with either `result` or `!!result` depending on which seems clearer (`if (result)` seems fine to me). In some cases I made the comparisons more explicit, e.g. `if (result === undefined || result === null || result === "")`, where it seemed worth distinguishing between the distinct possible false-ish values.

**Genuine null comparisons**. In some cases we have functions with return types like `string | null`, where it makes sense to compare the return value to `null`. In these cases, I've converted them to strict equality checks (`result === null`).