### PR TITLE
Don't show scan button on prove/add screens

### DIFF
--- a/apps/passport-client/components/shared/AppHeader.tsx
+++ b/apps/passport-client/components/shared/AppHeader.tsx
@@ -51,25 +51,26 @@ function AppHeaderImpl({
       </CircleButton>
       {children}
       {!isProveOrAddScreen && (
-        <CircleButton diameter={34} padding={8} onClick={openSubscriptions}>
-          {subscriptions.value.getAllErrors().size > 0 && (
-            <ErrorDotContainer>
-              <ErrorDot />
-            </ErrorDotContainer>
-          )}
-          <MdRssFeed
-            size={34}
-            color={isEdgeCity ? "white" : "var(--accent-lite)"}
-          />
-        </CircleButton>
+        <>
+          <CircleButton diameter={34} padding={8} onClick={openSubscriptions}>
+            {subscriptions.value.getAllErrors().size > 0 && (
+              <ErrorDotContainer>
+                <ErrorDot />
+              </ErrorDotContainer>
+            )}
+            <MdRssFeed
+              size={34}
+              color={isEdgeCity ? "white" : "var(--accent-lite)"}
+            />
+          </CircleButton>
+          <CircleButton diameter={34} padding={8} onClick={openScanner}>
+            <MdOutlineQrCodeScanner
+              size={34}
+              color={isEdgeCity ? "white" : "var(--accent-lite)"}
+            />
+          </CircleButton>
+        </>
       )}
-
-      <CircleButton diameter={34} padding={8} onClick={openScanner}>
-        <MdOutlineQrCodeScanner
-          size={34}
-          color={isEdgeCity ? "white" : "var(--accent-lite)"}
-        />
-      </CircleButton>
 
       <CircleButton diameter={34} padding={8} onClick={openSettings}>
         <IoMdSettings


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-519/remove-qr-code-scanner-button-from-zk-prove-screen

This removes the button from _all_ prove and add screens.