### PR TITLE
remove manual test timeout in proto-pod-gpc-spec

### DIFF
--- a/packages/lib/gpcircuits/test/proto-pod-gpc.spec.ts
+++ b/packages/lib/gpcircuits/test/proto-pod-gpc.spec.ts
@@ -22,7 +22,6 @@ import {
 
 describe("proto-pod-gpc.ProtoPODGPC should work", function () {
   // Circuit compilation sometimes takes more than the default timeout of 2s.
-  this.timeout(30_000);
   let circuit: WitnessTester<
     ProtoPODGPCInputNamesType,
     ProtoPODGPCOutputNamesType


### PR DESCRIPTION
this is ok to do because we have a default timeout of 120s configured [here](https://github.com/proofcarryingdata/zupass/blob/main/.mocharc.js#L7)