### PR TITLE
Set cache headers for CORS responses

### DIFF
--- a/apps/passport-server/src/routing/server.ts
+++ b/apps/passport-server/src/routing/server.ts
@@ -85,9 +85,27 @@ export async function startHttpServer(
           };
         }
 
+        // 86400 is the highest value supported by browsers for caching CORS
+        // responses
+        corsOptions.maxAge = 86400;
+
+        // Allows a later middleware to add additional caching headers
+        corsOptions.preflightContinue = true;
+
         callback(null, corsOptions);
       })
     );
+
+    // Add cache-control to preflight CORS responses in a separate middleware
+    // This is required for the browser to be able to cache these requests
+    app.use((req, res, next) => {
+      if (req.method === "OPTIONS") {
+        res.setHeader("Cache-Control", "public, max-age=86400");
+        res.end();
+      } else {
+        next();
+      }
+    });
 
     initAllRoutes(app, context, globalServices);
 


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-608/cache-cors-headers

As part of 0XP-585, I've been speeding up check-in requests. Since a check-in requires two API requests, and we currently require a CORS pre-flight `OPTIONS` request for each API request, this adds a total overhead of around 600ms to check-in.

Since the request itself takes very little time to handle, we are simply trying to avoid the latency of the round-trip to the server, which is ~300ms per request for me (on fiber broadband in Lisbon). Latency may be lower if closer to the server, or higher if further from the server or on a worse wifi/mobile connection.

We can eliminate most of these requests by simply caching them. This PR adds cache headers to CORS responses.

In production, each request has a pre-flight OPTIONS request:
<img width="725" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/fd41ed22-0847-4a38-b383-0a65a981be31">

In staging-rob, these are eliminated once cached:
<img width="718" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/b4946379-3a4c-4721-9c04-518e2f5f9d74">

A nice benefit is that this applies to _all_ API requests, including e2ee download and fetching of feeds, so also ought to speed up the "syncing PCDs" phase of loading.

I considered two alternative approaches to this problem, both of which seemed like more effort for questionable reward:

1) Using a proxy so that API requests go to `zupass.org`, bypassing the need for a CORS check
2) Converting our POST requests from using `application/json` content type to using `text/plain`, which would trick the browser into treating the request as a "simple" request that does not require CORS headers. This seemed brittle and likely to have non-obvious side-effects later.