### PR TITLE
Upgrade 'flat' to >=5.0.1, fixes critical vulnerability

### DIFF
--- a/apps/passport-server/package.json
+++ b/apps/passport-server/package.json
@@ -54,7 +54,7 @@
     "email-validator": "^2.0.4",
     "express": "^5.0.0-beta.1",
     "fast-json-stable-stringify": "^2.1.0",
-    "flat": "5",
+    "flat": "^5.0.1",
     "grammy": "^1.18.1",
     "graphql": "^16.8.1",
     "js-sha256": "^0.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10894,7 +10894,7 @@ flat-cache@^3.0.4:
     keyv "^4.5.3"
     rimraf "^3.0.2"
 
-flat@5, flat@^5.0.2:
+flat@^5.0.1, flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==


### PR DESCRIPTION
Fixes https://github.com/proofcarryingdata/zupass/security/dependabot/44