### PR TITLE
Catch localStorage accessibility issue

### DIFF
--- a/apps/passport-client/components/screens/LocalStorageNotAccessibleScreen.tsx
+++ b/apps/passport-client/components/screens/LocalStorageNotAccessibleScreen.tsx
@@ -1,0 +1,24 @@
+import { H2, Spacer, TextCenter } from "../core";
+import { AppContainer } from "../shared/AppContainer";
+
+export function LocalStorageNotAccessibleScreen(): JSX.Element {
+  return (
+    <>
+      <AppContainer bg="primary">
+        <Spacer h={64} />
+        <TextCenter>
+          <H2>Please update your browser</H2>
+          <Spacer h={24} />
+          Your browser does not currently support accessing local storage, which
+          is required for Zupass to store cryptographic data locally. Try
+          <a href="https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document/">
+            enabling third-party cookies
+          </a>{" "}
+          or switching/updating your browser. You can view a list of supported
+          browsers <a href="https://caniuse.com/?search=localstorage">here</a>.
+        </TextCenter>
+        <Spacer h={64} />
+      </AppContainer>
+    </>
+  );
+}

--- a/apps/passport-client/components/screens/LocalStorageNotAccessibleScreen.tsx
+++ b/apps/passport-client/components/screens/LocalStorageNotAccessibleScreen.tsx
@@ -1,4 +1,4 @@
-import { H2, Spacer, TextCenter } from "../core";
+import { H2, Spacer, SupportLink, TextCenter } from "../core";
 import { AppContainer } from "../shared/AppContainer";
 
 export function LocalStorageNotAccessibleScreen(): JSX.Element {
@@ -9,13 +9,15 @@ export function LocalStorageNotAccessibleScreen(): JSX.Element {
         <TextCenter>
           <H2>Please update your browser</H2>
           <Spacer h={24} />
-          Your browser does not currently support accessing local storage, which
-          is required for Zupass to store cryptographic data locally. Try
+          Your browser does not support accessing local storage, which is
+          required for Zupass to store cryptographic data. Try{" "}
           <a href="https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document/">
             enabling third-party cookies
           </a>{" "}
           or switching/updating your browser. You can view a list of supported
           browsers <a href="https://caniuse.com/?search=localstorage">here</a>.
+          <Spacer h={24} />
+          If you continue having issues, please email <SupportLink />.
         </TextCenter>
         <Spacer h={64} />
       </AppContainer>

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -4,7 +4,11 @@ import {
   requestOfflineTickets,
   requestOfflineTicketsCheckin
 } from "@pcd/passport-interface";
-import { getErrorMessage, isWebAssemblySupported } from "@pcd/util";
+import {
+  getErrorMessage,
+  isLocalStorageAvailable,
+  isWebAssemblySupported
+} from "@pcd/util";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -27,6 +31,7 @@ import { GetWithoutProvingScreen } from "../components/screens/GetWithoutProving
 import { HaloScreen } from "../components/screens/HaloScreen/HaloScreen";
 import { HomeScreen } from "../components/screens/HomeScreen/HomeScreen";
 import { ImportBackupScreen } from "../components/screens/ImportBackupScreen";
+import { LocalStorageNotAccessibleScreen } from "../components/screens/LocalStorageNotAccessibleScreen";
 import { AlreadyRegisteredScreen } from "../components/screens/LoginScreens/AlreadyRegisteredScreen";
 import { CreatePasswordScreen } from "../components/screens/LoginScreens/CreatePasswordScreen";
 import { LoginInterstitialScreen } from "../components/screens/LoginScreens/LoginInterstitialScreen";
@@ -268,6 +273,13 @@ function App(): JSX.Element {
           <Routes>
             <Route path="/terms" element={<TermsScreen />} />
             <Route path="*" element={<NoWASMScreen />} />
+          </Routes>
+        </HashRouter>
+      ) : !isLocalStorageAvailable() ? (
+        <HashRouter>
+          <Routes>
+            <Route path="/terms" element={<TermsScreen />} />
+            <Route path="*" element={<LocalStorageNotAccessibleScreen />} />
           </Routes>
         </HashRouter>
       ) : !hasStack ? (

--- a/packages/lib/util/src/Environment.ts
+++ b/packages/lib/util/src/Environment.ts
@@ -52,3 +52,23 @@ export function isWebAssemblySupported(): boolean {
     return false;
   }
 }
+
+/**
+ * Method that tests whether local storage is available by setting and
+ * resetting a test entry in localStorage.
+ */
+export function isLocalStorageAvailable(): boolean {
+  try {
+    const key = `__storage__test`;
+    const originalValue = window.localStorage.getItem(key);
+    window.localStorage.setItem(key, "test");
+    if (originalValue !== null) {
+      window.localStorage.setItem(key, originalValue);
+    } else {
+      window.localStorage.removeItem(key);
+    }
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
Fixes #1031 

Shows this error page when it catches any localStorage accessibility issues:

<img width="443" alt="Screenshot 2024-04-18 at 7 02 33 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/89d3b88c-6b07-4812-b98a-d7a1caea47b4">
