### PR TITLE
Add imageDetails config to PretixPipeline

### DIFF
--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -13,6 +13,7 @@ import {
   GenericPretixOrder,
   GenericPretixProduct,
   GenericPretixProductCategory,
+  ImageOptions,
   ManualTicket,
   PipelineLoadSummary,
   PipelineLog,
@@ -800,6 +801,7 @@ export class PretixPipeline implements BasePipeline {
       attendeeEmail: manualTicket.attendeeEmail,
       attendeeName: manualTicket.attendeeName,
       attendeeSemaphoreId: sempahoreId,
+      imageUrl: this.imageOptionsToImageUrl(event.imageOptions, !!checkIn),
       isConsumed: checkIn ? true : false,
       isRevoked: false,
       timestampSigned: Date.now(),
@@ -943,6 +945,7 @@ export class PretixPipeline implements BasePipeline {
       timestampConsumed: atom.timestampConsumed?.getTime() ?? 0,
       timestampSigned: Date.now(),
       attendeeSemaphoreId: semaphoreId,
+      imageUrl: this.atomToImageUrl(atom),
       isConsumed: atom.isConsumed,
       isRevoked: false,
       ticketCategory: TicketCategory.Generic
@@ -1626,8 +1629,24 @@ export class PretixPipeline implements BasePipeline {
     return product.name;
   }
 
+  private imageOptionsToImageUrl(
+    imageOptions: ImageOptions | undefined,
+    isCheckedIn: boolean
+  ): string | undefined {
+    if (!imageOptions) return undefined;
+    if (imageOptions.requireCheckedIn && !isCheckedIn) return undefined;
+    return imageOptions.imageUrl;
+  }
+
   private atomToPretixEventId(ticketAtom: PretixAtom): string {
     return this.getEventById(ticketAtom.eventId).externalId;
+  }
+
+  private atomToImageUrl(ticketAtom: PretixAtom): string | undefined {
+    return this.imageOptionsToImageUrl(
+      this.getEventById(ticketAtom.eventId).imageOptions,
+      ticketAtom.isConsumed
+    );
   }
 
   private getEventById(eventId: string): PretixEventConfig {

--- a/apps/passport-server/test/generic-issuance/pipelines/pretix/pretixPipeline.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/pretix/pretixPipeline.spec.ts
@@ -67,12 +67,12 @@ describe("generic issuance - PretixPipeline", function () {
     EthLatAmManualAttendeeEmail,
     EthLatAmManualBouncerIdentity,
     EthLatAmManualBouncerEmail,
+    EthLatAmImageUrl,
     mockServer,
     pretixBackend,
     ethLatAmPretixOrganizer,
     ethLatAmEvent,
     ethLatAmPipeline,
-
     ethLatAmSemaphoreGroupIds
   } = setupTestPretixPipeline();
 
@@ -324,6 +324,7 @@ describe("generic issuance - PretixPipeline", function () {
       expect(ManualBouncerTicket.claim.ticket.attendeeEmail).to.eq(
         EthLatAmManualBouncerEmail
       );
+      expect(ManualAttendeeTicket.claim.ticket.imageUrl).to.be.undefined;
 
       pretixBackend.checkOut(
         ethLatAmPretixOrganizer.orgUrl,
@@ -361,6 +362,9 @@ describe("generic issuance - PretixPipeline", function () {
           EthLatAmManualAttendeeEmail
         );
         expect(ManualAttendeeTicket.claim.ticket.isConsumed).to.eq(true);
+        expect(ManualAttendeeTicket.claim.ticket.imageUrl).to.eq(
+          EthLatAmImageUrl
+        );
         expect(ManualAttendeeTicket.claim.ticket.timestampConsumed).to.eq(
           Date.now()
         );
@@ -584,6 +588,7 @@ describe("generic issuance - PretixPipeline", function () {
     );
     // Bouncer ticket is checked out
     expect(bouncerTicket.claim.ticket.isConsumed).to.eq(false);
+    expect(bouncerTicket.claim.ticket.imageUrl).to.be.undefined;
 
     // Now check the bouncer in
     const ethLatAmCheckinRoute = pipeline.checkinCapability.getCheckinUrl();

--- a/apps/passport-server/test/generic-issuance/pipelines/pretix/setupTestPretixPipeline.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/pretix/setupTestPretixPipeline.ts
@@ -38,6 +38,8 @@ export function setupTestPretixPipeline(): PretixPipelineTestData {
   const EthLatAmManualBouncerIdentity = new Identity();
   const EthLatAmManualBouncerEmail = "manual_bouncer@example.com";
 
+  const EthLatAmImageUrl = "eth-latam-image-url";
+
   const pretixBackend = new GenericPretixDataMocker();
   const ethLatAmPretixOrganizer = pretixBackend.get().ethLatAmOrganizer;
   const ethLatAmEvent = ethLatAmPretixOrganizer.ethLatAm;
@@ -60,6 +62,10 @@ export function setupTestPretixPipeline(): PretixPipelineTestData {
       genericIssuanceId: ethLatAmEventId,
       externalId: ethLatAmEvent.slug,
       name: "Eth LatAm",
+      imageOptions: {
+        imageUrl: EthLatAmImageUrl,
+        requireCheckedIn: true
+      },
       products: ethLatAmProducts.map((product: GenericPretixProduct) => {
         return {
           externalId: product.id.toString(),
@@ -190,6 +196,7 @@ export function setupTestPretixPipeline(): PretixPipelineTestData {
     EthLatAmManualAttendeeEmail,
     EthLatAmManualBouncerIdentity,
     EthLatAmManualBouncerEmail,
+    EthLatAmImageUrl,
     pretixBackend,
     ethLatAmPretixOrganizer,
     ethLatAmEvent,
@@ -226,6 +233,7 @@ export interface PretixPipelineTestData {
   ethLatAmAttendeeProduct: IConfiguredProduct;
   ethLatAmBouncerProduct: IConfiguredProduct;
   ethLatAmPipeline: PretixPipelineDefinition;
+  EthLatAmImageUrl: string | undefined;
   ethLatAmSemaphoreGroupIds: {
     all: string;
     bouncers: string;
@@ -243,9 +251,15 @@ export interface IConfiguredProduct {
   nameQuestionPretixQuestionIdentitifier: string;
 }
 
+export interface IConfiguredImageDetails {
+  imageUrl: string;
+  requireCheckedIn: boolean;
+}
+
 export interface ConfiguredEvent {
   genericIssuanceId: string;
   externalId: string;
   name: string;
+  imageOptions: IConfiguredImageDetails | undefined;
   products: Array<IConfiguredProduct>;
 }

--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -269,6 +269,13 @@ const FeedIssuanceOptionsSchema = z.object({
 
 export type FeedIssuanceOptions = z.infer<typeof FeedIssuanceOptionsSchema>;
 
+const ImageOptionsSchema = z.object({
+  imageUrl: z.string(),
+  requireCheckedIn: z.boolean()
+});
+
+export type ImageOptions = z.infer<typeof ImageOptionsSchema>;
+
 const LemonadePipelineOptionsSchema = BasePipelineOptionsSchema.extend({
   /**
    * Configured by the user when setting up Lemonade as a data source.
@@ -383,6 +390,10 @@ const PretixEventConfigSchema = z.object({
    * Display name for the event
    */
   name: z.string(),
+  /**
+   * Options to configure displaying an image instead of the QR code
+   */
+  imageOptions: ImageOptionsSchema.optional(),
   products: z.array(PretixProductConfigSchema)
 });
 


### PR DESCRIPTION
## Example config
```
"imageOptions": {
  "imageUrl": "https://i.ibb.co/bP0QDGs/ethlatamcert.jpg",
  "requireCheckedIn": true
}
```

### Scanned ticket

<img width="431" alt="Screenshot 2024-04-18 at 9 55 41 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/a67ce8d1-519d-40eb-a08a-cc5c21ffa141">


### Non scanned ticket

<img width="421" alt="Screenshot 2024-04-18 at 9 56 12 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/e1a8e297-eea6-481a-906b-8b4e53b7486d">
