### PR TITLE
Hide PODTicketPCDs visually

### DIFF
--- a/apps/passport-client/.env.example
+++ b/apps/passport-client/.env.example
@@ -18,3 +18,6 @@ STRICH_LICENSE_KEY=""
 
 # Enable choice between different scanning libraries. Set to "true" to enable.
 MULTI_CHOICE_SCAN_ENABLED=""
+
+# Should PODTicketPCDs be visible? Set to "true" to enable.
+SHOW_POD_TICKET_PCDS=""

--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -69,6 +69,13 @@ const define = {
           process.env.MULTI_CHOICE_SCAN_ENABLED
         )
       }
+    : {}),
+  ...(process.env.SHOW_POD_TICKET_PCDS !== undefined
+    ? {
+        "process.env.SHOW_POD_TICKET_PCDS": JSON.stringify(
+          process.env.SHOW_POD_TICKET_PCDS
+        )
+      }
     : {})
 };
 

--- a/apps/passport-client/components/screens/HomeScreen/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen/HomeScreen.tsx
@@ -17,8 +17,8 @@ import {
   useDispatch,
   useFolders,
   usePCDCollection,
-  usePCDsInFolder,
-  useSelf
+  useSelf,
+  useVisiblePCDsInFolder
 } from "../../../src/appHooks";
 import { useSyncE2EEStorage } from "../../../src/useSyncE2EEStorage";
 import { isEdgeCityFolder, isFrogCryptoFolder } from "../../../src/util";
@@ -71,7 +71,7 @@ export function HomeScreenImpl(): JSX.Element | null {
   }, [pcdCollection, searchParams]);
 
   const [browsingFolder, setBrowsingFolder] = useState(defaultBrowsingFolder);
-  const pcdsInFolder = usePCDsInFolder(browsingFolder);
+  const pcdsInFolder = useVisiblePCDsInFolder(browsingFolder);
   const foldersInFolder = useFolders(browsingFolder);
 
   useEffect(() => {

--- a/apps/passport-client/components/shared/PCDCardList.tsx
+++ b/apps/passport-client/components/shared/PCDCardList.tsx
@@ -1,9 +1,7 @@
 import { PCD } from "@pcd/pcd-types";
-import { PODTicketPCDTypeName } from "@pcd/pod-ticket-pcd";
 import _ from "lodash";
 import { useCallback, useMemo, useState } from "react";
 import styled from "styled-components";
-import { appConfig } from "../../src/appConfig";
 import { usePCDCollection, useUserIdentityPCD } from "../../src/appHooks";
 import { PCDCard } from "./PCDCard";
 
@@ -86,13 +84,7 @@ export function PCDCardList({
       (sortState.sortBy && sortState.sortOrder
         ? _.orderBy(sortablePCDs, [sortState.sortBy], [sortState.sortOrder])
         : sortablePCDs
-      )
-        .map((o) => o.value)
-        .filter(
-          (pcd) =>
-            // Filter out PODTicketPCDs unless showPODTicketPCDs is true
-            pcd.type !== PODTicketPCDTypeName || appConfig.showPODTicketPCDs
-        ),
+      ).map((o) => o.value),
     [sortState, sortablePCDs]
   );
 

--- a/apps/passport-client/components/shared/PCDCardList.tsx
+++ b/apps/passport-client/components/shared/PCDCardList.tsx
@@ -1,7 +1,9 @@
 import { PCD } from "@pcd/pcd-types";
+import { PODTicketPCDTypeName } from "@pcd/pod-ticket-pcd";
 import _ from "lodash";
 import { useCallback, useMemo, useState } from "react";
 import styled from "styled-components";
+import { appConfig } from "../../src/appConfig";
 import { usePCDCollection, useUserIdentityPCD } from "../../src/appHooks";
 import { PCDCard } from "./PCDCard";
 
@@ -84,7 +86,13 @@ export function PCDCardList({
       (sortState.sortBy && sortState.sortOrder
         ? _.orderBy(sortablePCDs, [sortState.sortBy], [sortState.sortOrder])
         : sortablePCDs
-      ).map((o) => o.value),
+      )
+        .map((o) => o.value)
+        .filter(
+          (pcd) =>
+            // Filter out PODTicketPCDs unless showPODTicketPCDs is true
+            pcd.type !== PODTicketPCDTypeName || appConfig.showPODTicketPCDs
+        ),
     [sortState, sortablePCDs]
   );
 

--- a/apps/passport-client/src/appConfig.ts
+++ b/apps/passport-client/src/appConfig.ts
@@ -19,6 +19,8 @@ interface AppConfig {
   scanditLicenseKey: string | undefined;
   // is a choice of multiple scanning engines enabled?
   multiChoiceScanEnabled: boolean;
+  // should PODTicketPCDs be visible?
+  showPODTicketPCDs: boolean;
 }
 
 if (
@@ -64,7 +66,8 @@ export const appConfig: AppConfig = {
   rollbarEnvName: process.env.ROLLBAR_ENV_NAME,
   strichLicenseKey: process.env.STRICH_LICENSE_KEY,
   scanditLicenseKey: process.env.SCANDIT_LICENSE_KEY,
-  multiChoiceScanEnabled: process.env.MULTI_CHOICE_SCAN_ENABLED === "true"
+  multiChoiceScanEnabled: process.env.MULTI_CHOICE_SCAN_ENABLED === "true",
+  showPODTicketPCDs: process.env.SHOW_POD_TICKET_PCDS === "true"
 };
 
 console.log("App Config: " + JSON.stringify(appConfig));

--- a/apps/passport-client/src/appHooks.ts
+++ b/apps/passport-client/src/appHooks.ts
@@ -9,10 +9,12 @@ import {
 } from "@pcd/passport-interface";
 import { PCDCollection } from "@pcd/pcd-collection";
 import { PCD } from "@pcd/pcd-types";
+import { PODTicketPCDTypeName } from "@pcd/pod-ticket-pcd";
 import { SemaphoreIdentityPCD } from "@pcd/semaphore-identity-pcd";
 import { Identity } from "@semaphore-protocol/identity";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { appConfig } from "./appConfig";
 import {
   Dispatcher,
   StateContext,
@@ -64,7 +66,13 @@ export function usePCDs(): PCD[] {
 
 export function usePCDsInFolder(folder: string): PCD[] {
   const pcds = usePCDCollection();
-  return [...pcds.getAllPCDsInFolder(folder)];
+  return [
+    ...pcds.getAllPCDsInFolder(folder).filter(
+      (pcd) =>
+        // Filter out PODTicketPCDs unless showPODTicketPCDs is true
+        pcd.type !== PODTicketPCDTypeName || appConfig.showPODTicketPCDs
+    )
+  ];
 }
 
 export function useFolders(path: string): string[] {

--- a/apps/passport-client/src/appHooks.ts
+++ b/apps/passport-client/src/appHooks.ts
@@ -66,13 +66,16 @@ export function usePCDs(): PCD[] {
 
 export function usePCDsInFolder(folder: string): PCD[] {
   const pcds = usePCDCollection();
-  return [
-    ...pcds.getAllPCDsInFolder(folder).filter(
-      (pcd) =>
-        // Filter out PODTicketPCDs unless showPODTicketPCDs is true
-        pcd.type !== PODTicketPCDTypeName || appConfig.showPODTicketPCDs
-    )
-  ];
+  return [...pcds.getAllPCDsInFolder(folder)];
+}
+
+export function useVisiblePCDsInFolder(folder: string): PCD[] {
+  const pcds = usePCDsInFolder(folder);
+  return pcds.filter(
+    (pcd) =>
+      // Filter out PODTicketPCDs unless showPODTicketPCDs is true
+      pcd.type !== PODTicketPCDTypeName || appConfig.showPODTicketPCDs
+  );
 }
 
 export function useFolders(path: string): string[] {

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -1,3 +1,4 @@
+import { isEdDSATicketPCD } from "@pcd/eddsa-ticket-pcd";
 import { EmailPCDTypeName } from "@pcd/email-pcd";
 import { PCDCrypto } from "@pcd/passport-crypto";
 import {
@@ -20,6 +21,7 @@ import {
 } from "@pcd/passport-interface";
 import { PCDCollection, PCDPermission } from "@pcd/pcd-collection";
 import { PCD, SerializedPCD } from "@pcd/pcd-types";
+import { isPODTicketPCD, PODTicketPCDTypeName } from "@pcd/pod-ticket-pcd";
 import {
   isSemaphoreIdentityPCD,
   SemaphoreIdentityPCDPackage,
@@ -562,6 +564,30 @@ async function removePCD(
   update: ZuUpdate,
   pcdId: string
 ): Promise<void> {
+  const pcd = state.pcds.getById(pcdId);
+  if (!appConfig.showPODTicketPCDs && pcd && isEdDSATicketPCD(pcd)) {
+    // EdDSATicketPCDs are currently duplicated as PODTicketPCDs. Since
+    // PODTicketPCDs are hidden, they cannot be removed via the UI. IF an
+    // EdDSATicketPCD is remove but its counterpart PODTicketPCD is not, then
+    // the folder containing them both will remain but will appear to be empty,
+    // as it only contains the PODTicketPCD.
+    // Therefore, when removing the EdDSATicketPCD, we should check to see if
+    // there is a matching PODTicketPCD, and remove that too.
+    const podTickets = state.pcds.getPCDsByType(PODTicketPCDTypeName);
+    for (const podTicket of podTickets) {
+      if (
+        isPODTicketPCD(podTicket) &&
+        // Check for the same ticket ID
+        podTicket.claim.ticket.ticketId === pcd.claim.ticket.ticketId &&
+        // Check they're in the same folder
+        state.pcds.getFolderOfPCD(pcd.id) ===
+          state.pcds.getFolderOfPCD(podTicket.id)
+      ) {
+        // Remove the PODTicketPCD
+        state.pcds.remove(podTicket.id);
+      }
+    }
+  }
   state.pcds.remove(pcdId);
   await savePCDs(state.pcds);
   update({ pcds: state.pcds });

--- a/turbo.json
+++ b/turbo.json
@@ -209,6 +209,7 @@
     "SCANDIT_LICENSE_KEY",
     "MULTI_CHOICE_SCAN_ENABLED",
     "IRON_SESSION_PASSWORD",
+    "SHOW_POD_TICKET_PCDS",
     "//// add env vars above this line ////"
   ]
 }


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-546/hide-podticketpcd-visually-in-zupass-folder

Part of the Podbox Ticket Epic. Builds on top of #1643.

Adds an environment variable which causes `passport-client` to show `PODTicketPCD`s when enabled. The default is to hide them.

If PODTicketPCDs are hidden, then removing the EdDSATicketPCD will also remove the PODTicketPCD.