### PR TITLE
Allow environment-specific NODE_OPTIONS so we can use more RAM in production

### DIFF
--- a/apps/passport-server/package.json
+++ b/apps/passport-server/package.json
@@ -8,7 +8,7 @@
     "start:dev": "NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=development ts-node-dev --inspect=4321 --respawn --watch=.env,.env.local src/main.ts -p ./tsconfig.json",
     "dev:worker": "nodemon -w src/multiprocess/worker.ts --exec \"yarn tsc -p ./tsconfig.json\"",
     "dev": "yarn tsc -p ./tsconfig.json && concurrently -r \"yarn start:dev\" \"yarn dev:worker\"",
-    "start": "NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=production PORT=8080 node -r source-map-support/register build/src/main.js",
+    "start": "NODE_OPTIONS=${NODE_OPTIONS:---max_old_space_size=4096} NODE_ENV=production PORT=8080 node -r source-map-support/register build/src/main.js",
     "lint": "eslint \"**/*.ts{,x}\"",
     "test:single-threaded": "ts-mocha --require test/globalhooks.ts --config ../../.mocharc.js --exit 'test/**/*.spec.ts'",
     "test": "ts-mocha --parallel --require test/globalhooks.ts --config ../../.mocharc.js --exit 'test/**/*.spec.ts'",

--- a/apps/passport-server/src/main.ts
+++ b/apps/passport-server/src/main.ts
@@ -17,6 +17,7 @@ logger(
   `[INIT] cwd:${process.cwd()}; Loading environment variables from: ${dotEnvPath} `
 );
 dotenv.config({ path: dotEnvPath });
+logger(`NODE_OPTIONS is ${process.env.NODE_OPTIONS}`);
 logger("[INIT] Starting application");
 
 startApplication();

--- a/turbo.json
+++ b/turbo.json
@@ -109,6 +109,7 @@
     "PAGER_DUTY_SERVICE_ID",
     "NEXT_PUBLIC_PASSPORT_CLIENT_URL",
     "NEXT_PUBLIC_PASSPORT_SERVER_URL",
+    "NODE_OPTIONS",
     "//// add env vars above this line ////"
   ],
   "globalEnv": [


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-431/increase-max-ram-usage-for-zupass-server-in-prod

Makes NODE_OPTIONS configurable via environment-specific environment variables, with a default set in the `package.json` that is only used if the environment variable is not set. Here's what happens when it runs:

![image](https://github.com/proofcarryingdata/zupass/assets/20022/4455db6b-5d65-4c9c-a606-916ca99baecb)

The default max RAM in the package.json is 4096, but in the environment it's set to 4095, and that's what gets used.