### PR TITLE
Disallow manual test timeouts

### DIFF
--- a/packages/pcd/ethereum-group-pcd/test/EthereumGroupPCD.spec.ts
+++ b/packages/pcd/ethereum-group-pcd/test/EthereumGroupPCD.spec.ts
@@ -131,6 +131,8 @@ async function happyPathEthGroupPCD(
 }
 
 describe("Ethereum Group PCD", function () {
+  // eslint-disable-next-line no-restricted-syntax
+  this.timeout(60 * 1000 * 10);
   let ethGroupPCD: EthereumGroupPCD;
 
   this.beforeAll(async function () {

--- a/packages/pcd/ethereum-group-pcd/test/EthereumGroupPCD.spec.ts
+++ b/packages/pcd/ethereum-group-pcd/test/EthereumGroupPCD.spec.ts
@@ -131,7 +131,6 @@ async function happyPathEthGroupPCD(
 }
 
 describe("Ethereum Group PCD", function () {
-  this.timeout(60 * 1000 * 10);
   let ethGroupPCD: EthereumGroupPCD;
 
   this.beforeAll(async function () {

--- a/packages/tools/eslint-config-custom/index.js
+++ b/packages/tools/eslint-config-custom/index.js
@@ -36,7 +36,15 @@ module.exports = {
     "@typescript-eslint/explicit-function-return-type": "error",
     "@typescript-eslint/no-explicit-any": "error",
     "import/default": "off",
-    eqeqeq: ["error", "always"]
+    eqeqeq: ["error", "always"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        selector:
+          "CallExpression[callee.name='describe'] MemberExpression[object.type='ThisExpression'][property.name='timeout']",
+        message: "Manual timeouts in Mocha tests are not allowed."
+      }
+    ]
   },
   settings: {
     "import/resolver": {


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-641/use-linter-to-ban-manual-test-timeouts