### PR TITLE
Let CSV pipelines issue tickets to anyone who requests them

### DIFF
--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
@@ -121,7 +121,9 @@ export class CSVPipeline implements BasePipeline {
               requesterEmail,
               requesterSemaphoreId,
               eddsaPrivateKey: this.eddsaPrivateKey,
-              pipelineId: this.id
+              pipelineId: this.id,
+              issueToUnmatchedEmail:
+                this.definition.options.issueToUnmatchedEmail
             }
           )
         )
@@ -319,6 +321,7 @@ export async function makeCSVPCD(
     requesterSemaphoreId?: string;
     eddsaPrivateKey: string;
     pipelineId: string;
+    issueToUnmatchedEmail?: boolean;
   }
 ): Promise<SerializedPCD | undefined> {
   return traced("makeCSVPCD", "makeCSVPCD", async (span) => {
@@ -333,7 +336,8 @@ export async function makeCSVPCD(
           opts.eddsaPrivateKey,
           opts.requesterEmail,
           opts.requesterSemaphoreId,
-          opts.pipelineId
+          opts.pipelineId,
+          opts.issueToUnmatchedEmail
         );
       case CSVPipelineOutputType.PODTicket:
         return makePODTicketPCD(
@@ -341,7 +345,8 @@ export async function makeCSVPCD(
           opts.eddsaPrivateKey,
           opts.requesterEmail,
           opts.requesterSemaphoreId,
-          opts.pipelineId
+          opts.pipelineId,
+          opts.issueToUnmatchedEmail
         );
       default:
         // will not compile in case we add a new output type

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makePODTicketPCD.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makePODTicketPCD.ts
@@ -8,7 +8,8 @@ export async function makePODTicketPCD(
   eddsaPrivateKey: string,
   requesterEmail: string | undefined,
   requesterSemaphoreId: string | undefined,
-  pipelineId: string
+  pipelineId: string,
+  issueToUnmatchedEmail: boolean | undefined
 ): Promise<SerializedPCD<PODTicketPCD> | undefined> {
   return traced("", "makePODTicketPCD", async () => {
     if (!requesterEmail || !requesterSemaphoreId) {
@@ -21,7 +22,7 @@ export async function makePODTicketPCD(
       return undefined;
     }
 
-    if (ticket.attendeeEmail !== requesterEmail) {
+    if (!issueToUnmatchedEmail && ticket.attendeeEmail !== requesterEmail) {
       return undefined;
     }
 

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makeTicketPCD.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makeTicketPCD.ts
@@ -85,7 +85,8 @@ export async function makeTicketPCD(
   eddsaPrivateKey: string,
   requesterEmail: string | undefined,
   requesterSemaphoreId: string | undefined,
-  pipelineId: string
+  pipelineId: string,
+  issueToUnmatchedEmail: boolean | undefined
 ): Promise<SerializedPCD | undefined> {
   return traced("", "makeEdDSAMessageCSVPCD", async () => {
     if (!requesterEmail || !requesterSemaphoreId) {
@@ -98,7 +99,7 @@ export async function makeTicketPCD(
       return undefined;
     }
 
-    if (ticket.attendeeEmail !== requesterEmail) {
+    if (!issueToUnmatchedEmail && ticket.attendeeEmail !== requesterEmail) {
       return undefined;
     }
 

--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -475,7 +475,8 @@ export enum CSVPipelineOutputType {
 const CSVPipelineOptionsSchema = BasePipelineOptionsSchema.extend({
   csv: z.string(),
   outputType: z.nativeEnum(CSVPipelineOutputType).optional(),
-  feedOptions: FeedIssuanceOptionsSchema
+  feedOptions: FeedIssuanceOptionsSchema,
+  issueToUnmatchedEmail: z.boolean().optional()
 });
 
 export type CSVPipelineOptions = z.infer<typeof CSVPipelineOptionsSchema>;


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-764/universal-basic-ticket-issuing-pipeline

Not sure if this is the best way to do this.

I'd like to be able to set up a pipeline such that it will issue a ticket with a given event ID and product ID to anyone who requests one. This PR adds an option to the CSV pipeline which causes it to issue all of its configured tickets to anyone who hits the feed. This would allow me to set up a feed which issues one or two tickets, which could then be used for third party ZuAuth testing/development.

This is useful because third party developers may not have any tickets, and I want to be able to give them a constant ZuAuth configuration that is guaranteed to work for them, with a constant public key/event ID/product ID.