### PR TITLE
Less intrusive error message when scanning invalid QR code

### DIFF
--- a/apps/passport-client/components/screens/MultiChoiceScanScreen.tsx
+++ b/apps/passport-client/components/screens/MultiChoiceScanScreen.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useState } from "react";
+import { toast } from "react-hot-toast";
 import { QrReader } from "react-qr-reader";
 import { useNavigate } from "react-router-dom";
 import { SingleValue } from "react-select";
 import styled from "styled-components";
-import { useDispatch, useLaserScannerKeystrokeInput } from "../../src/appHooks";
+import { useLaserScannerKeystrokeInput } from "../../src/appHooks";
 import { loadUsingLaserScanner } from "../../src/localstorage";
 import { maybeRedirect } from "../../src/util";
 import { H5, Spacer, TextCenter } from "../core";
@@ -35,7 +36,6 @@ export function MultiChoiceScanScreen(): JSX.Element {
   const usingLaserScanner = loadUsingLaserScanner();
   useLaserScannerKeystrokeInput();
   const nav = useNavigate();
-  const dispatch = useDispatch();
 
   const [scanner, setScanner] = useState<
     "strich" | "react-qr-reader" | "scandit"
@@ -68,20 +68,17 @@ export function MultiChoiceScanScreen(): JSX.Element {
       console.log(`Got result, considering redirect`, result);
       const newLoc = maybeRedirect(result);
       if (newLoc) {
+        // Instantly remove any error toasts
+        toast.remove();
         nav(newLoc);
       } else {
-        dispatch({
-          type: "error",
-          error: {
-            title: "Not a Zupass QR code",
-            message:
-              "The QR code you scanned is not a Zupass QR code. Make sure the QR code you're scanning comes from the Zupass app.",
-            dismissToCurrentPage: true
-          }
-        });
+        toast.error(
+          "The QR code you scanned is not a Zupass QR code. Make sure the QR code you're scanning comes from the Zupass app.",
+          { id: "scan-error", duration: 10000, position: "bottom-center" }
+        );
       }
     },
-    [dispatch, nav]
+    [nav]
   );
 
   const onQrReaderResult = useCallback(

--- a/apps/passport-client/components/screens/ScanScreen.tsx
+++ b/apps/passport-client/components/screens/ScanScreen.tsx
@@ -1,3 +1,4 @@
+import { toast } from "react-hot-toast";
 import { QrReader } from "react-qr-reader";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
@@ -49,7 +50,20 @@ export function ScanScreen(): JSX.Element {
                   result.getText()
                 );
                 const newLoc = maybeRedirect(result.getText());
-                if (newLoc) nav(newLoc);
+                if (newLoc) {
+                  // Instantly remove any error toasts
+                  toast.remove();
+                  nav(newLoc);
+                } else {
+                  toast.error(
+                    "The QR code you scanned is not a Zupass QR code. Make sure the QR code you're scanning comes from the Zupass app.",
+                    {
+                      id: "scan-error",
+                      duration: 10000,
+                      position: "bottom-center"
+                    }
+                  );
+                }
               } else if (error) {
                 //    console.info(error);
               }


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-657/make-zupass-error-modal-on-qr-scanner-screen-less-intrusive-or-a

`react-hot-toast` doesn't seem to support permanent toasts, but I've given it a duration of 10 seconds, which seems like a reasonably long time.