### PR TITLE
VSCode config for test debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,14 @@
     {
       "type": "node",
       "request": "attach",
+      "name": "Attach to Mocha test",
+      "port": 9229,
+      "restart": true,
+      "cwd": "${workspaceRoot}"
+    },
+    {
+      "type": "node",
+      "request": "attach",
       "name": "Attach to passport-server",
       "port": 4321,
       "restart": true,


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-326/debugging-in-vs-code-of-apps-tests

Adds a VSCode launch task that will attach to a running Mocha test process. In VSCode, press Cmd-Shift-D to open the "Run" sidebar. Then select "Attach to Mocha test" from the drop-down at the top of the window, then click the "Play" style icon.

To create a process with the inspector port open, run something like:
```
yarn ts-mocha --config ../../.mocharc.js --exit --inspect test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts
```
The only part that should vary is the path at the end, which is the path to the specific test file that you want to run.

`yarn test` seems to not work; as far as I can tell, running `ts-mocha` with a wildcard to match on the test files will run each test file in a separate process and with a different debug port.