### PR TITLE
Perf tests for GPC PCD

### DIFF
--- a/packages/tools/perftest/package.json
+++ b/packages/tools/perftest/package.json
@@ -14,6 +14,8 @@
     "log-symbols": "^4.1.0",
     "uuid": "^9.0.0",
     "@pcd/eddsa-ticket-pcd": "^0.6.0",
+    "@pcd/gpc": "^0.0.1",
+    "@pcd/gpc-pcd": "^0.0.1",
     "@pcd/pcd-types": "^0.11.0",
     "@pcd/pod": "^0.1.0",
     "@pcd/pod-pcd": "^0.1.0",

--- a/packages/tools/perftest/src/cases/GPCTimer.ts
+++ b/packages/tools/perftest/src/cases/GPCTimer.ts
@@ -1,0 +1,135 @@
+import { GPCProofConfig, serializeGPCProofConfig } from "@pcd/gpc";
+import { GPCPCD, GPCPCDArgs, GPCPCDPackage } from "@pcd/gpc-pcd";
+import { ArgumentTypeName } from "@pcd/pcd-types";
+import { POD, PODEntries } from "@pcd/pod";
+import { PODPCD, PODPCDPackage } from "@pcd/pod-pcd";
+import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
+import { BABY_JUB_NEGATIVE_ONE } from "@pcd/util";
+import { Identity } from "@semaphore-protocol/identity";
+import path from "path";
+import { v4 as uuid } from "uuid";
+import { TimerCase } from "../types";
+
+export const GPC_TEST_ARTIFACTS_PATH = path.join(
+  __dirname,
+  "../../../../lib/gpcircuits/artifacts/test"
+);
+
+async function setupProveArgs(): Promise<GPCPCDArgs> {
+  // Key borrowed from https://github.com/iden3/circomlibjs/blob/4f094c5be05c1f0210924a3ab204d8fd8da69f49/test/eddsa.js#L103
+  const privateKey =
+    "0001020304050607080900010203040506070809000102030405060708090001";
+
+  const ownerIdentity = new Identity(
+    '["329061722381819402313027227353491409557029289040211387019699013780657641967", "99353161014976810914716773124042455250852206298527174581112949561812190422"]'
+  );
+
+  // 11 entries, max depth 5
+  // Defined out of order, but will be sorted by POD construction.
+  const sampleEntries = {
+    E: { type: "cryptographic", value: 123n },
+    F: { type: "cryptographic", value: BABY_JUB_NEGATIVE_ONE },
+    C: { type: "string", value: "hello" },
+    D: { type: "string", value: "foobar" },
+    A: { type: "int", value: 123n },
+    B: { type: "int", value: 321n },
+    G: { type: "int", value: 7n },
+    H: { type: "int", value: 8n },
+    I: { type: "int", value: 9n },
+    J: { type: "int", value: 10n },
+    owner: { type: "cryptographic", value: ownerIdentity.commitment }
+  } satisfies PODEntries;
+
+  const proofConfig: GPCProofConfig = {
+    pods: {
+      pod0: {
+        entries: {
+          A: { isRevealed: true },
+          E: { isRevealed: false, equalsEntry: "pod0.A" },
+          owner: { isRevealed: false, isOwnerID: true }
+        }
+      }
+    }
+  };
+
+  const pod = POD.sign(sampleEntries, privateKey);
+  const podPCD = new PODPCD(uuid(), pod);
+
+  const identityPCD = await SemaphoreIdentityPCDPackage.prove({
+    identity: ownerIdentity
+  });
+
+  return {
+    proofConfig: {
+      argumentType: ArgumentTypeName.String,
+      value: serializeGPCProofConfig(proofConfig)
+    },
+    pod: {
+      value: await PODPCDPackage.serialize(podPCD),
+      argumentType: ArgumentTypeName.PCD
+    },
+    identity: {
+      value: await SemaphoreIdentityPCDPackage.serialize(identityPCD),
+      argumentType: ArgumentTypeName.PCD
+    },
+    externalNullifier: {
+      value: "some external nullifier",
+      argumentType: ArgumentTypeName.String
+    },
+    watermark: {
+      value: "some watermark",
+      argumentType: ArgumentTypeName.String
+    },
+    id: {
+      argumentType: ArgumentTypeName.String,
+      value: uuid()
+    }
+  } satisfies GPCPCDArgs;
+}
+
+export class GPCPCDProveCase extends TimerCase {
+  proveArgs?: GPCPCDArgs;
+
+  constructor() {
+    super("gpc-pcd.prove");
+  }
+
+  async init(): Promise<void> {
+    await GPCPCDPackage.init?.({ zkArtifactPath: GPC_TEST_ARTIFACTS_PATH });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  async setup(_: number): Promise<void> {
+    this.proveArgs = await setupProveArgs();
+  }
+
+  async op(_: number): Promise<void> {
+    if (!this.proveArgs) {
+      throw new Error("Missing proveArgs.  Skipped setup?");
+    }
+    await GPCPCDPackage.prove(this.proveArgs);
+  }
+}
+
+export class GPCPCDVerifyCase extends TimerCase {
+  pcd?: GPCPCD;
+
+  constructor() {
+    super("gpc-pcd.verify");
+  }
+
+  async init(): Promise<void> {
+    await GPCPCDPackage.init?.({ zkArtifactPath: GPC_TEST_ARTIFACTS_PATH });
+  }
+
+  async setup(_: number): Promise<void> {
+    this.pcd = await GPCPCDPackage.prove(await setupProveArgs());
+  }
+
+  async op(_: number): Promise<void> {
+    if (!this.pcd) {
+      throw new Error("Missing PCD.  Skipped setup?");
+    }
+    await GPCPCDPackage.verify(this.pcd);
+  }
+}

--- a/packages/tools/perftest/src/timer.ts
+++ b/packages/tools/perftest/src/timer.ts
@@ -1,4 +1,5 @@
 import { EdDSATicketPCDPackage } from "@pcd/eddsa-ticket-pcd";
+import { GPCPCDPackage } from "@pcd/gpc-pcd";
 import { PODPCDPackage } from "@pcd/pod-pcd";
 import { SemaphoreSignaturePCDPackage } from "@pcd/semaphore-signature-pcd";
 import { ZKEdDSAEventTicketPCDPackage } from "@pcd/zk-eddsa-event-ticket-pcd";
@@ -8,6 +9,7 @@ import {
   EdDSATicketProveCase,
   EdDSATicketVerifyCase
 } from "./cases/EdDSATicketTimer";
+import { GPCPCDProveCase, GPCPCDVerifyCase } from "./cases/GPCTimer";
 import { PODProveCase, PODVerifyCase } from "./cases/PODTimer";
 import {
   SemaphoreSignatureProveCase,
@@ -35,6 +37,10 @@ const TIME_TEST_CONFIGS: Record<string, Record<string, () => TimerCase>> = {
   [ZKEdDSAEventTicketPCDPackage.name]: {
     prove: () => new ZKEdDSAEventTicketProveCase(),
     verify: () => new ZKEdDSAEventTicketVerifyCase()
+  },
+  [GPCPCDPackage.name]: {
+    prove: () => new GPCPCDProveCase(),
+    verify: () => new GPCPCDVerifyCase()
   }
 };
 

--- a/packages/tools/perftest/tsconfig.json
+++ b/packages/tools/perftest/tsconfig.json
@@ -27,6 +27,12 @@
       "path": "../../pcd/eddsa-ticket-pcd"
     },
     {
+      "path": "../../lib/gpc"
+    },
+    {
+      "path": "../../pcd/gpc-pcd"
+    },
+    {
       "path": "../../lib/pcd-types"
     },
     {


### PR DESCRIPTION
Adds basic benchmarking for GPC PCD prove and verify operations (useful for getting a sense of how long they take vs. ZKEdDSAEventTicketPCD or Semaphore signature).