### PR TITLE
Telegram direct link to group

### DIFF
--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -289,6 +289,7 @@ export class TelegramService {
             if (username) span?.setAttribute("username", username);
             const firstName = ctx?.from?.first_name;
             const name = firstName || username;
+            ctx.session.directLinkMode = false;
             if (ctx.match && Number.isInteger(Number(ctx.match))) {
               const [chatWithMembership] = await getChatsWithMembershipStatus(
                 ctx.session.dbPool,
@@ -298,6 +299,7 @@ export class TelegramService {
               );
               if (chatWithMembership) {
                 ctx.session.chatToJoin = chatWithMembership;
+                ctx.session.directLinkMode = true;
                 const chatTitle = chatWithMembership.chat?.title;
                 return await ctx.reply(
                   `Welcome ${name}! 👋\n\nClick the button below to join${
@@ -1727,7 +1729,8 @@ export async function startTelegramService(
     dbPool: context.dbPool,
     anonBotExists,
     authBotURL,
-    anonBotURL
+    anonBotURL,
+    directLinkMode: false
   });
 
   if (anonBotExists) {

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -88,6 +88,7 @@ import {
   eventsToLink,
   generateReactProofUrl,
   getBotURL,
+  getChatsWithMembershipStatus,
   getDisplayEmojis,
   getGroupChat,
   getSessionKey,
@@ -288,8 +289,26 @@ export class TelegramService {
             if (username) span?.setAttribute("username", username);
             const firstName = ctx?.from?.first_name;
             const name = firstName || username;
+            if (ctx.match && Number.isInteger(Number(ctx.match))) {
+              const [chatWithMembership] = await getChatsWithMembershipStatus(
+                ctx.session.dbPool,
+                ctx,
+                userId,
+                Number(ctx.match)
+              );
+              if (chatWithMembership) {
+                ctx.session.chatToJoin = chatWithMembership;
+                const chatTitle = chatWithMembership.chat?.title;
+                return await ctx.reply(
+                  `Welcome ${name}! 👋\n\nClick the button below to join${
+                    chatTitle ? ` <b>${chatTitle}</b>` : ""
+                  }.\n\nYou will sign in to Zupass, then ZK prove you have a valid ticket.`,
+                  { reply_markup: zupassMenu, parse_mode: "HTML" }
+                );
+              }
+            }
             await ctx.reply(
-              `Welcome ${name}! 👋\n\nClick the group you want to join.\n\nYou will sign in to Zupass, then ZK prove you have a ticket for one of the group's events.\n\nSee you soon 😽`,
+              `Welcome ${name}! 👋\n\nClick the group you want to join.\n\nYou will sign in to Zupass, then ZK prove you have a ticket for one of the group's events.`,
               { reply_markup: zupassMenu }
             );
           }

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -559,17 +559,19 @@ export const generateReactProofUrl = async (
   });
 };
 
-const getChatsWithMembershipStatus = async (
+export const getChatsWithMembershipStatus = async (
   db: Pool,
   ctx: BotContext,
-  userId: number
+  userId: number,
+  chatId?: number // if chatId is provided, only fetch chats with that id
 ): Promise<ChatIDWithChat<ChatIDWithEventsAndMembership>[]> => {
   return traced("telegram", "getChatsWithMembershipStatus", async (span) => {
     span?.setAttribute("userId", userId.toString());
 
     const chatIdsWithMembership = await fetchTelegramChatsWithMembershipStatus(
       db,
-      userId
+      userId,
+      chatId
     );
     const chatsWithMembership = await chatIDsToChats(
       ctx,

--- a/apps/passport-server/src/util/telegramHelpers.ts
+++ b/apps/passport-server/src/util/telegramHelpers.ts
@@ -75,6 +75,7 @@ export interface SessionData {
   selectedEvent?: LinkedPretixTelegramEvent;
   anonBotExists: boolean;
   authBotURL: string;
+  directLinkMode: boolean;
   anonBotURL: string;
   lastMessageId?: number;
   selectedChat?: TopicChat;
@@ -743,10 +744,12 @@ export const chatsToJoinV2 = async (
         );
 
         range.webApp(`Join ${chat.chat?.title}`, proofUrl).row();
-        range.text(`↰  Back`, async (ctx) => {
-          ctx.session.chatToJoin = undefined;
-          ctx.menu.update();
-        });
+        if (!ctx.session.directLinkMode) {
+          range.text(`↰  Back`, async (ctx) => {
+            ctx.session.chatToJoin = undefined;
+            ctx.menu.update();
+          });
+        }
       } else {
         const chatsWithMembership = await getChatsWithMembershipStatus(
           db,


### PR DESCRIPTION
Avoids having to do the initial group selection

Direct link example: t.me/{bot_name}?start={chatId}


https://github.com/proofcarryingdata/zupass/assets/36896271/5b2c090b-2e09-4616-a725-9ea5d0a52583



Regular start flow example: t.me/{bot_name}


https://github.com/proofcarryingdata/zupass/assets/36896271/64956469-a023-4d8c-bb0b-08a602232fb0




