### PR TITLE
GPC-related Cleanups

### DIFF
--- a/packages/lib/gpc/src/gpcChecks.ts
+++ b/packages/lib/gpc/src/gpcChecks.ts
@@ -24,13 +24,13 @@ import {
   GPCRevealedObjectClaims
 } from "./gpcTypes";
 import {
-  checkPODEntryIdentifier,
-  splitCircuitIdentifier,
-  splitPODEntryIdentifier,
   DEFAULT_MAX_LISTS,
   DEFAULT_MAX_LIST_ELEMENTS,
   DEFAULT_MAX_TUPLES,
-  DEFAULT_TUPLE_ARITY
+  DEFAULT_TUPLE_ARITY,
+  checkPODEntryIdentifier,
+  splitCircuitIdentifier,
+  splitPODEntryIdentifier
 } from "./gpcUtil";
 
 // TODO(POD-P2): Split out the parts of this which should be public from
@@ -210,7 +210,7 @@ export function checkProofInputs(
 
   return ProtoPODGPCCircuitParams(
     totalObjects,
-    1,
+    totalObjects,
     requiredMerkleDepth,
     DEFAULT_MAX_LISTS,
     DEFAULT_MAX_LIST_ELEMENTS,

--- a/packages/lib/gpc/test/gpc.spec.ts
+++ b/packages/lib/gpc/test/gpc.spec.ts
@@ -21,7 +21,7 @@ import {
   sampleEntries2
 } from "./common";
 
-describe("gpc library (Precompiled Artifact) should work", async function () {
+describe("gpc library (Precompiled Artifacts) should work", async function () {
   function makeMinimalArgs(includeWatermark?: boolean): {
     proofConfig: GPCProofConfig;
     proofInputs: GPCProofInputs;

--- a/packages/lib/gpcircuits/circuits/entry.circom
+++ b/packages/lib/gpcircuits/circuits/entry.circom
@@ -1,6 +1,6 @@
 pragma circom 2.1.8;
 
-include "@zk-kit/circuits/circom/binary-merkle-root.circom";
+include "@zk-kit/binary-merkle-root.circom/src/binary-merkle-root.circom";
 include "circomlib/circuits/bitify.circom";
 include "gpc-util.circom";
 

--- a/packages/lib/gpcircuits/package.json
+++ b/packages/lib/gpcircuits/package.json
@@ -44,7 +44,7 @@
     "@semaphore-protocol/identity": "^3.15.2",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
-    "@zk-kit/circuits": "1.0.0-beta",
+    "@zk-kit/binary-merkle-root.circom": "1.0.0",
     "circomkit": "^0.0.24",
     "circomlib": "^2.0.5",
     "eslint": "^8.57.0",

--- a/packages/lib/gpcircuits/package.json
+++ b/packages/lib/gpcircuits/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pcd/gpcircuits",
   "version": "0.1.0",
-  "license": "GPL-3.0-or-laterX",
+  "license": "GPL-3.0-or-later",
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",

--- a/packages/lib/gpcircuits/package.json
+++ b/packages/lib/gpcircuits/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pcd/gpcircuits",
   "version": "0.1.0",
-  "license": "GPL-3.0-or-later",
+  "license": "GPL-3.0-or-laterX",
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",

--- a/packages/lib/gpcircuits/src/list-membership.ts
+++ b/packages/lib/gpcircuits/src/list-membership.ts
@@ -1,8 +1,8 @@
-import { ProtoPODGPCCircuitParams } from "./proto-pod-gpc";
-import { CircuitSignal } from "./types";
 import { PODValueTuple, podValueHash } from "@pcd/pod";
 import { BABY_JUB_NEGATIVE_ONE } from "@pcd/util";
 import { computeTupleIndices, hashTuple } from "./multituple";
+import { ProtoPODGPCCircuitParams } from "./proto-pod-gpc";
+import { CircuitSignal } from "./types";
 import { extendedSignalArray, padArray } from "./util";
 
 export type ListMembershipModuleInputs = {

--- a/packages/lib/gpcircuits/src/tuple.ts
+++ b/packages/lib/gpcircuits/src/tuple.ts
@@ -1,5 +1,5 @@
-import { CircuitSignal } from "./types";
 import { poseidon2, poseidon3, poseidon4 } from "poseidon-lite";
+import { CircuitSignal } from "./types";
 
 // We restrict attention to smaller tuple sizes for simplicity, i.e.
 // arities 2, 3 and 4.

--- a/packages/lib/gpcircuits/test/list-membership.spec.ts
+++ b/packages/lib/gpcircuits/test/list-membership.spec.ts
@@ -1,18 +1,18 @@
+import { PODValue, podValueHash } from "@pcd/pod";
 import { expect } from "chai";
 import { WitnessTester } from "circomkit";
 import "mocha";
-import { PODValue, podValueHash } from "@pcd/pod";
 import {
-  extendedSignalArray,
   ListMembershipModuleInputNamesType,
   ListMembershipModuleInputs,
   ListMembershipModuleOutputNamesType,
   ListMembershipModuleOutputs,
+  ProtoPODGPC,
+  extendedSignalArray,
+  hashTuple,
   padArray,
   processLists,
   processSingleList,
-  ProtoPODGPC,
-  hashTuple,
   zipLists
 } from "../src";
 import { circomkit } from "./common";

--- a/packages/lib/gpcircuits/test/multituple.spec.ts
+++ b/packages/lib/gpcircuits/test/multituple.spec.ts
@@ -1,23 +1,23 @@
+import { PODValue, podValueHash } from "@pcd/pod";
+import { BABY_JUB_NEGATIVE_ONE } from "@pcd/util";
 import { expect } from "chai";
 import { WitnessTester } from "circomkit";
 import "mocha";
 import { poseidon2, poseidon3, poseidon4 } from "poseidon-lite";
 import {
+  MultiTupleModuleInputNamesType,
+  MultiTupleModuleInputs,
+  MultiTupleModuleOutputNamesType,
+  MultiTupleModuleOutputs,
   computeTupleIndices,
   hashTuple,
   maxTupleArity,
   multiTupleHasher,
   padArray,
   requiredNumTuples,
-  tupleHasher,
-  MultiTupleModuleInputNamesType,
-  MultiTupleModuleInputs,
-  MultiTupleModuleOutputNamesType,
-  MultiTupleModuleOutputs
+  tupleHasher
 } from "../src";
 import { circomkit } from "./common";
-import { PODValue, podValueHash } from "@pcd/pod";
-import { BABY_JUB_NEGATIVE_ONE } from "@pcd/util";
 
 describe("MultiTuple helpers should work", function () {
   it("should compute the right number of required tuples for different input tuple arities", () => {

--- a/packages/lib/gpcircuits/test/proto-pod-gpc.spec.ts
+++ b/packages/lib/gpcircuits/test/proto-pod-gpc.spec.ts
@@ -14,7 +14,6 @@ import path from "path";
 import { poseidon2 } from "poseidon-lite";
 import {
   CircuitArtifactPaths,
-  processLists,
   PROTO_POD_GPC_PUBLIC_INPUT_NAMES,
   ProtoPODGPC,
   ProtoPODGPCCircuitParams,
@@ -26,6 +25,7 @@ import {
   extendedSignalArray,
   gpcArtifactPaths,
   maxTupleArity,
+  processLists,
   protoPODGPCCircuitParamArray,
   zipLists
 } from "../src";

--- a/yarn.lock
+++ b/yarn.lock
@@ -7501,10 +7501,10 @@
   dependencies:
     "@zk-kit/utils" "1.0.0-beta"
 
-"@zk-kit/circuits@1.0.0-beta":
-  version "1.0.0-beta"
-  resolved "https://registry.yarnpkg.com/@zk-kit/circuits/-/circuits-1.0.0-beta.tgz#4f41315839855762dac11b2ba2ce5e58fd8ad1e9"
-  integrity sha512-ZJBkmm//iFlDB3pQOWAOqSCeUQFYWzI00a980jjbEcuzQgq2PqBxiq36TFxnZHkbrOh39XpeWOoEpCXRkjS2KQ==
+"@zk-kit/binary-merkle-root.circom@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zk-kit/binary-merkle-root.circom/-/binary-merkle-root.circom-1.0.0.tgz#b91890fb7b87c8a8b57953ee95ec0351eb4fe241"
+  integrity sha512-yVyx9e+iNYuFvOtKt/f4i+QBhey78VM6K6svwqkgqdi55vnz3MRtXn8dqvnKibNAUEBmnjuwe4SDONgeOQpFEw==
   dependencies:
     circomlib "^2.0.5"
 
@@ -19268,16 +19268,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -19410,14 +19401,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21781,7 +21765,7 @@ workspace-tools@^0.36.4:
     js-yaml "^4.1.0"
     micromatch "^4.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21794,15 +21778,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Random cleanups and followups for GPC code:

- Switch to `@zk-kit/binary-merkle-root.circom`, now that zk-kit has broken up the old `@zk-kit/circuits` into multiple packages.
- Change size calculation to more correctly reflect the minimum of 1 entry per object (no effect on end-to-end functionality since that requirement is always enforced elsewhere).
- Let VSCode sort imports on files from @ax0's recent PRs.  May as well take the hit all at once.
- Typo fix
