### PR TITLE
Typedoc errors

### DIFF
--- a/packages/lib/client-shared/typedoc.json
+++ b/packages/lib/client-shared/typedoc.json
@@ -1,3 +1,3 @@
 {
-  "entryPoints": ["src/index.ts"]
+  "entryPoints": ["src/index.tsx"]
 }


### PR DESCRIPTION
I noticed that pcd-docs deployment was failing on render for this reason.
This change makes `yarn docs` complete successfully for me locally.  Lots of warnings, but no errors.
