### PR TITLE
Fix warnings from `web-worker` transitive dependency

### DIFF
--- a/packages/lib/gpc/package.json
+++ b/packages/lib/gpc/package.json
@@ -32,7 +32,7 @@
     "@pcd/util": "0.5.0",
     "@semaphore-protocol/identity": "^3.15.2",
     "json-bigint": "^1.0.0",
-    "snarkjs": "^0.7.3"
+    "snarkjs": "^0.7.4"
   },
   "devDependencies": {
     "@pcd/eslint-config-custom": "0.11.0",

--- a/packages/lib/gpcircuits/package.json
+++ b/packages/lib/gpcircuits/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@pcd/pod": "0.1.0",
     "fastfile": "0.0.20",
-    "snarkjs": "^0.7.3"
+    "snarkjs": "^0.7.4"
   },
   "devDependencies": {
     "@pcd/eslint-config-custom": "0.11.0",

--- a/packages/pcd/gpc-pcd/package.json
+++ b/packages/pcd/gpc-pcd/package.json
@@ -34,7 +34,7 @@
     "@pcd/semaphore-identity-pcd": "0.11.0",
     "@pcd/util": "0.5.0",
     "json-bigint": "^1.0.0",
-    "snarkjs": "^0.7.3",
+    "snarkjs": "^0.7.4",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/pcd/zk-eddsa-event-ticket-pcd/package.json
+++ b/packages/pcd/zk-eddsa-event-ticket-pcd/package.json
@@ -42,7 +42,7 @@
     "@semaphore-protocol/identity": "^3.15.2",
     "circomlibjs": "^0.1.7",
     "json-bigint": "^1.0.0",
-    "snarkjs": "^0.7.3",
+    "snarkjs": "^0.7.4",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/pcd/zk-eddsa-frog-pcd/package.json
+++ b/packages/pcd/zk-eddsa-frog-pcd/package.json
@@ -42,7 +42,7 @@
     "@semaphore-protocol/identity": "^3.15.2",
     "circomlibjs": "^0.1.7",
     "json-bigint": "^1.0.0",
-    "snarkjs": "^0.7.3",
+    "snarkjs": "^0.7.4",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/tools/artifacts/package.json
+++ b/packages/tools/artifacts/package.json
@@ -27,7 +27,7 @@
     "js-logger": "^1.6.1",
     "log-symbols": "^5.1.0",
     "ora": "^7.0.1",
-    "snarkjs": "^0.7.3"
+    "snarkjs": "^0.7.4"
   },
   "devDependencies": {
     "@pcd/eslint-config-custom": "0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3349,6 +3349,14 @@
     fastfile "0.0.20"
     ffjavascript "^0.2.48"
 
+"@iden3/binfileutils@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@iden3/binfileutils/-/binfileutils-0.0.12.tgz#3772552f57551814ff606fa68ea1e0ef52795ce3"
+  integrity sha512-naAmzuDufRIcoNfQ1d99d7hGHufLA3wZSibtr4dMe6ZeiOPV1KwOZWTJ1YVz4HbaWlpDuzVU72dS4ATQS4PXBQ==
+  dependencies:
+    fastfile "0.0.20"
+    ffjavascript "^0.3.0"
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -9131,6 +9139,13 @@ circom_runtime@0.1.24:
   dependencies:
     ffjavascript "0.2.60"
 
+circom_runtime@0.1.25:
+  version "0.1.25"
+  resolved "https://registry.yarnpkg.com/circom_runtime/-/circom_runtime-0.1.25.tgz#62a33b371f4633f30238db7a326c43d988e3a170"
+  integrity sha512-xBGsBFF5Uv6AKvbpgExYqpHfmfawH2HKe+LyjfKSRevqEV8u63i9KGHVIILsbJNW+0c5bm/66f0PUYQ7qZSkJA==
+  dependencies:
+    ffjavascript "0.3.0"
+
 circom_tester@^0.0.19:
   version "0.0.19"
   resolved "https://registry.yarnpkg.com/circom_tester/-/circom_tester-0.0.19.tgz#e8bed494d080f8186bd0ac6571755d00ccec83bd"
@@ -11770,6 +11785,15 @@ ffjavascript@0.2.63, ffjavascript@^0.2.56:
   version "0.2.63"
   resolved "https://registry.yarnpkg.com/ffjavascript/-/ffjavascript-0.2.63.tgz#0c1216a1f123dc9181df69e144473704d2f115eb"
   integrity sha512-dBgdsfGks58b66JnUZeZpGxdMIDQ4QsD3VYlRJyFVrKQHb2kJy4R2gufx5oetrTxXPT+aEjg0dOvOLg1N0on4A==
+  dependencies:
+    wasmbuilder "0.0.16"
+    wasmcurves "0.2.2"
+    web-worker "1.2.0"
+
+ffjavascript@0.3.0, ffjavascript@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ffjavascript/-/ffjavascript-0.3.0.tgz#442cd8fbb1ee4cbb1be9d26fd7b2951a1ea45d6a"
+  integrity sha512-l7sR5kmU3gRwDy8g0Z2tYBXy5ttmafRPFOqY7S6af5cq51JqJWt5eQ/lSR/rs2wQNbDYaYlQr5O+OSUf/oMLoQ==
   dependencies:
     wasmbuilder "0.0.16"
     wasmcurves "0.2.2"
@@ -17620,6 +17644,16 @@ r1csfile@0.0.47:
     fastfile "0.0.20"
     ffjavascript "0.2.60"
 
+r1csfile@0.0.48:
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/r1csfile/-/r1csfile-0.0.48.tgz#a317fc75407a9da92631666c75bdfc13f0a7835a"
+  integrity sha512-kHRkKUJNaor31l05f2+RFzvcH5XSa7OfEfd/l4hzjte6NL6fjRkSMfZ4BjySW9wmfdwPOtq3mXurzPvPGEf5Tw==
+  dependencies:
+    "@iden3/bigarray" "0.0.2"
+    "@iden3/binfileutils" "0.0.12"
+    fastfile "0.0.20"
+    ffjavascript "0.3.0"
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -18937,7 +18971,7 @@ snarkjs@^0.4.22:
     logplease "^1.2.15"
     r1csfile "0.0.40"
 
-snarkjs@^0.7.0, snarkjs@^0.7.3:
+snarkjs@^0.7.0:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/snarkjs/-/snarkjs-0.7.3.tgz#7f703d05b810235255f2d0a70d8a9b8b3ea916e5"
   integrity sha512-cDLpWqdqEJSCQNc+cXYX1XTKdUZBtYEisuOsgmXf/HUsN5WmGN+FO7HfCS+cMQT1Nzbm1a9gAEpKH6KRtDtS1Q==
@@ -18952,6 +18986,22 @@ snarkjs@^0.7.0, snarkjs@^0.7.3:
     js-sha3 "^0.8.0"
     logplease "^1.2.15"
     r1csfile "0.0.47"
+
+snarkjs@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/snarkjs/-/snarkjs-0.7.4.tgz#b9ad5813f055ab84d33f1831a6f1f34a71b6cd46"
+  integrity sha512-x4cOCR4YXSyBlLtfnUUwfbZrw8wFd/Y0lk83eexJzKwZB8ELdpH+10ts8YtDsm2/a3WK7c7p514bbE8NpqxW8w==
+  dependencies:
+    "@iden3/binfileutils" "0.0.12"
+    bfj "^7.0.2"
+    blake2b-wasm "^2.4.0"
+    circom_runtime "0.1.25"
+    ejs "^3.1.6"
+    fastfile "0.0.20"
+    ffjavascript "0.3.0"
+    js-sha3 "^0.8.0"
+    logplease "^1.2.15"
+    r1csfile "0.0.48"
 
 socks-proxy-agent@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-870/fix-build-warning-from-web-worker-dependency

The warning comes from a dependency of `snarkjs` and is fixed by a minor version upgrade, which pulls in a fixed version of the dependency.

The changes between `0.7.3` and `0.7.4` seem to be minor, mostly relating to testing and removal of NodeJS 16 support for SnarkJS: https://github.com/iden3/snarkjs/compare/v0.7.3...v0.7.4

The diff is a bit confusing to read as it includes build output. The changes in the SnarkJS build seem to result from an upgrade to the `circom_runtime` dependency, from `0.1.24` to `0.1.25`: https://github.com/iden3/circom_runtime/releases/tag/v0.1.25

The changes are "Support negative numbers with circom2 implementation" and "Use Uint32Array when calculating prime as is done in circom2", which seem like they ought not to cause any problems for us (by my limited judgement).