### PR TITLE
Fix failed match if product ID was revealed but no product ID included in config

### DIFF
--- a/packages/lib/zuauth/src/server.ts
+++ b/packages/lib/zuauth/src/server.ts
@@ -39,7 +39,12 @@ export async function authenticate(
   }
 
   const publicKeys = config.map((em) => em.publicKey);
-  const productIds = new Set(config.map((em) => em.productId));
+  const productIds = new Set(
+    // Product ID is optional, so it's important to filter out undefined values
+    config
+      .map((em) => em.productId)
+      .filter((productId) => productId !== undefined)
+  );
 
   if (
     publicKeys.length > 0 &&


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-869/allow-zuauth-to-work-properly-if-dev-requests-product-id-but-doesnt