### PR TITLE
Show full diff between expected and actual objects in tests

### DIFF
--- a/apps/passport-server/test/globalhooks.ts
+++ b/apps/passport-server/test/globalhooks.ts
@@ -8,6 +8,7 @@ export const mochaHooks = {
    * This is executed once prior to the rest of the test suite.
    */
   beforeAll(): void {
+    chai.config.truncateThreshold = 0;
     chai.use(chaiAsPromised);
     chai.use(spies);
     chai.use(deepEqualInAnyOrder);


### PR DESCRIPTION
We occasionally get a flaky test in `passport-server` that involves a comparison between two sets. Debugging this is not helped by the fact that the printout of the set contents is truncated.

chai has a configuration option which causes it to print out the full contents of the compared object, instead of truncating it.