### PR TITLE
Use narrower import for poseidon-lite

### DIFF
--- a/packages/lib/gpcircuits/src/tuple.ts
+++ b/packages/lib/gpcircuits/src/tuple.ts
@@ -1,4 +1,7 @@
-import { poseidon2, poseidon3, poseidon4 } from "poseidon-lite";
+import { poseidon2 } from "poseidon-lite/poseidon2";
+import { poseidon3 } from "poseidon-lite/poseidon3";
+import { poseidon4 } from "poseidon-lite/poseidon4";
+
 import { CircuitSignal } from "./types";
 
 // We restrict attention to smaller tuple sizes for simplicity, i.e.


### PR DESCRIPTION
`poseidon-lite` exports a set of functions for hashing differently-sized arrays of values. Each of these functions has an associated set of constants, and the constants are quite large for the functions that deal with large arrays.

Because of the size of the constants (which take up RAM and bandwidth, and some CPU on initialization), it's good to avoid importing poseidon functions for array sizes that we don't actually use. This means we have to use a particular syntax for importing.

Rather than
```typescript
import { poseidon2, poseidon3 } from "poseidon-lite";
```
We should do:
```typescript
import { poseidon2 } from "poseidon-lite/poseidon2";
import { poesidon3 } from "poseidon-lite/poseidon3";
```

The first example imports the entire `poseidon-lite` library, and then picks out two functions from it. The second example imports only those functions, and therefore only the constants they require.

In `gpcircuits` we had some code which was using the former syntax rather than the latter. As a result, about 500KiB of constants were being included. Switching to the latter syntax removes them, as shown in the `esbuild` bundle size analyzer for `passport-client`:

<img width="374" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/de0549b7-eca7-4ab2-ae05-09b13bc7366e">

Using the latter syntax:
<img width="386" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/68acceaf-65ae-42e7-a6cf-b8ebad14dabe">

Importing specific sections of a library is generally only worth worrying about for libraries that are very large or that have large dependencies. `poseidon-lite` is probably the only library we use that is both large enough to worry about and that exposes this degree of choice over which functions to import.