### PR TITLE
Fix flaky Semaphore Group membership test

### DIFF
--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -1844,6 +1844,11 @@ describe("devconnect functionality", function () {
         }
       );
 
+      // Logging in schedules an asynchronous reload, which sometimes occurs
+      // before the subsequent tests, and sometimes does not. To be sure, we
+      // will await the reload here.
+      await application.services.semaphoreService.reload();
+
       expectCurrentSemaphoreToBe(application, {
         p: [],
         r: [],


### PR DESCRIPTION
Based on this test failure:
```
  1) devconnect functionality
       logging in a regular user adds them to devconnect attendees but not superuser semaphore group:

      AssertionError: expected Set{ '17897125398569023886017903601703460777658723655304251383893454150330783750292', '8546499026879587215003695272936502204401396401706680943652441126315548873750' } to deeply equal Set{ '17897125398569023886017903601703460777658723655304251383893454150330783750292', '8546499026879587215003695272936502204401396401706680943652441126315548873750', '5259217903257657023086231321275719449317234823584086099673836811917464634591' }
      + expected - actual


      at expectGroupsEqual (test/semaphore/checkSemaphore.ts:25:34)
      at testLatestHistoricSemaphoreGroups (test/semaphore/checkSemaphore.ts:46:3)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Context.<anonymous> (test/devconnect.spec.ts:1859:7)
```

... it seems that the Devconnect Semaphore group only has two members rather than three. The missing member is the user who was logged in during the test, so the problem seems to be that the Semaphore group has not updated to include the user by the time the subsequent checks are run.

Logging in schedules an asynchronous reload of the Semaphore Groups, and the flakiness is probably due to the concurrency here. I've resolved that by awaiting on a reload of the group before checking the group memberships. Hopefully this works!