### PR TITLE
Test gpc-pcd against artifacts both locally-built and NPM-released

### DIFF
--- a/packages/pcd/gpc-pcd/package.json
+++ b/packages/pcd/gpc-pcd/package.json
@@ -41,6 +41,7 @@
     "@pcd/eslint-config-custom": "0.11.0",
     "@pcd/tsconfig": "0.11.0",
     "@pcd/pod": "0.1.0",
+    "@pcd/proto-pod-gpc-artifacts": "0.0.3",
     "@semaphore-protocol/identity": "^3.15.2",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",

--- a/packages/pcd/gpc-pcd/test/gpc-pcd.spec.ts
+++ b/packages/pcd/gpc-pcd/test/gpc-pcd.spec.ts
@@ -20,6 +20,11 @@ export const GPC_TEST_ARTIFACTS_PATH = path.join(
   "../../../lib/gpcircuits/artifacts/test"
 );
 
+export const GPC_NPM_ARTIFACTS_PATH = path.join(
+  __dirname,
+  "../../../../node_modules/@pcd/proto-pod-gpc-artifacts"
+);
+
 // Key borrowed from https://github.com/iden3/circomlibjs/blob/4f094c5be05c1f0210924a3ab204d8fd8da69f49/test/eddsa.js#L103
 export const privateKey =
   "0001020304050607080900010203040506070809000102030405060708090001";
@@ -45,11 +50,9 @@ export const sampleEntries = {
 } satisfies PODEntries;
 
 describe("GPCPCD should work", async function () {
-  this.beforeAll(async () => {
-    GPCPCDPackage.init?.({ zkArtifactPath: GPC_TEST_ARTIFACTS_PATH });
-  });
+  async function runGPCPCDTest(artifactsPath: string): Promise<void> {
+    GPCPCDPackage.init?.({ zkArtifactPath: artifactsPath });
 
-  it("GPCPCD should prove and verify", async function () {
     const proofConfig: GPCProofConfig = {
       pods: {
         pod0: {
@@ -116,6 +119,18 @@ describe("GPCPCD should work", async function () {
     const serialized = await GPCPCDPackage.serialize(gpcPCD);
     const deserialized = await GPCPCDPackage.deserialize(serialized.pcd);
     expect(await GPCPCDPackage.verify(deserialized)).to.be.true;
+  }
+
+  it("GPCPCD should prove and verify with test artifacts", async function () {
+    // Confirms that the code in the repo is compatible with circuit
+    // artifacts built from circuits in the repo.
+    await runGPCPCDTest(GPC_TEST_ARTIFACTS_PATH);
+  });
+
+  it("GPCPCD should prove and verify with NPM artifacts", async function () {
+    // Confirms that the code in the repo is compatible with circuit
+    // artifacts released on NPM.
+    await runGPCPCDTest(GPC_NPM_ARTIFACTS_PATH);
   });
 });
 


### PR DESCRIPTION
#1708 made it possible for web servers/clients to use pre-built GPC artifacts released on NPM.  However the only link between the code in the repo and the NPM packages is a manual release process.  That leaves a risk that we won't notice when making incompatible changes, and end up with code pushed to prod which doesn't work with the NPM artifacts.  I want a test which will flag such a situation and remind us that we need to make a new artifact package.

The simplest safety-check I could think of is a unit test which runs against both sets of artifacts (locally built, and NPM released).  I put that test in the @pcd/gpc-pcd package, as the middle layer between the GPC code (where we want to allow local development) and the servers.  The same test steps in `gpc-pcd.spec.ts` are now run on each set of artifacts.

To confirm this really does catch incompatibilities, I changed the circuits by removing the watermark, and removed all the references to it in code.  After rebuilding everything, the gpcircuits and gpc utests passed, as did the gpc-pcd test on test artifacts, but the new test on NPM artifacts failed as expected.

CC @ax0 FYI regarding what it'll mean if you see this test fail in future.
