### PR TITLE
Don't fail build when dir doesn't exist

### DIFF
--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -218,7 +218,8 @@ function compileHtml(): void {
 
 function copyGPCArtifacts(): void {
   fs.rmSync(path.join("public/artifacts/proto-pod-gpc"), {
-    recursive: true
+    recursive: true,
+    force: true
   });
   fs.cpSync(
     path.join("../../node_modules/@pcd/proto-pod-gpc-artifacts"),


### PR DESCRIPTION
Issue reported here: https://github.com/proofcarryingdata/zupass/pull/1708#discussion_r1611288084