### PR TITLE
Reload Semaphore groups before testing to see if they have changed

### DIFF
--- a/apps/passport-server/test/devconnect.spec.ts
+++ b/apps/passport-server/test/devconnect.spec.ts
@@ -353,7 +353,7 @@ describe("devconnect functionality", function () {
         throw new Error("expected user");
       }
 
-      await sleep(100);
+      await application.services.semaphoreService.reload();
 
       expectCurrentSemaphoreToBe(application, {
         p: [residentUser.commitment],
@@ -417,6 +417,8 @@ describe("devconnect functionality", function () {
       if (!residentUser || !visitorUser || !organizerUser) {
         throw new Error("expected user");
       }
+
+      await application.services.semaphoreService.reload();
 
       expectCurrentSemaphoreToBe(application, {
         p: [
@@ -631,6 +633,8 @@ describe("devconnect functionality", function () {
         throw new Error("expected user");
       }
 
+      await application.services.semaphoreService.reload();
+
       expectCurrentSemaphoreToBe(application, {
         p: [
           updatedToOrganizerUser.commitment,
@@ -683,6 +687,8 @@ describe("devconnect functionality", function () {
       ) {
         throw new Error("expected user");
       }
+
+      await application.services.semaphoreService.reload();
 
       expectCurrentSemaphoreToBe(application, {
         p: [
@@ -737,6 +743,8 @@ describe("devconnect functionality", function () {
         throw new Error("expected user");
       }
 
+      await application.services.semaphoreService.reload();
+
       expectCurrentSemaphoreToBe(application, {
         p: [
           updatedToOrganizerUser.commitment,
@@ -789,6 +797,8 @@ describe("devconnect functionality", function () {
       ) {
         throw new Error("expected user");
       }
+
+      await application.services.semaphoreService.reload();
 
       expectCurrentSemaphoreToBe(application, {
         p: [],
@@ -1817,6 +1827,7 @@ describe("devconnect functionality", function () {
     "semaphore service should now be aware of the new user" +
       " and their old commitment should have been removed",
     async function () {
+      await application.services.semaphoreService.reload();
       expectCurrentSemaphoreToBe(application, {
         p: [],
         r: [],


### PR DESCRIPTION
As per @artwyman's comment on https://github.com/proofcarryingdata/zupass/pull/1718#issuecomment-2125925267, we still get some flaky tests when checking Semaphore group memberships, presumably because the groups have not reloaded by the time the check is performed. This PR adds a manual reload before each check.