### PR TITLE
Let pod-ticket-pcd be published

### DIFF
--- a/packages/pcd/gpc-pcd/package.json
+++ b/packages/pcd/gpc-pcd/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@pcd/gpc-pcd",
-  "private": true,
   "version": "0.0.1",
   "license": "GPL-3.0-or-later",
   "main": "./dist/cjs/src/index.js",

--- a/packages/pcd/pod-ticket-pcd/package.json
+++ b/packages/pcd/pod-ticket-pcd/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@pcd/pod-ticket-pcd",
-  "private": true,
   "version": "0.1.0",
   "license": "GPL-3.0-or-later",
   "main": "./dist/cjs/src/index.js",

--- a/packages/ui/gpc-pcd-ui/package.json
+++ b/packages/ui/gpc-pcd-ui/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@pcd/gpc-pcd-ui",
-  "private": true,
   "version": "0.0.1",
   "license": "GPL-3.0-or-later",
   "main": "./dist/cjs/src/index.js",


### PR DESCRIPTION
pod-ticket-pcd was still marked private, even though pod-ticket-pcd-ui is already published.
This will fix that missing dependency, as well as letting devs try integrating with pod-ticket-pcd if they wish.