### PR TITLE
Use local check-in for Lemonade pipeline

### DIFF
--- a/apps/passport-server/src/apis/lemonade/types.ts
+++ b/apps/passport-server/src/apis/lemonade/types.ts
@@ -23,28 +23,47 @@ export type LemonadeTicketTypes =
   GetEventTicketTypesResponse["getEventTicketTypes"];
 export type LemonadeTicketType = LemonadeTicketTypes["ticket_types"][number];
 
-export const LemonadeTicketSchema = z.object({
-  _id: z.string().min(1, "_id cannot be empty"),
-  user_id: z.string(),
-  user_email: z.string(),
-  user_name: z.string(),
-  user_first_name: z.string(),
-  user_last_name: z.string(),
-  type_id: z.string(),
-  type_title: z.string(),
-  checkin_date: z.string().transform((arg) => {
-    try {
-      const time = Date.parse(arg);
-      if (!isNaN(time)) {
-        return new Date(time);
-      } else {
+export const LemonadeTicketSchema = z
+  .object({
+    _id: z.string().min(1, "_id cannot be empty"),
+    assigned_email: z.string(),
+    user_id: z
+      .string()
+      .transform((val) =>
+        typeof val === "string" && val.length === 0 ? undefined : val
+      ),
+    user_email: z.string(),
+    user_name: z.string(),
+    user_first_name: z.string(),
+    user_last_name: z.string(),
+    type_id: z.string(),
+    type_title: z.string(),
+    checkin_date: z.string().transform((arg) => {
+      try {
+        const time = Date.parse(arg);
+        if (!isNaN(time)) {
+          return new Date(time);
+        } else {
+          return null;
+        }
+      } catch (e) {
         return null;
       }
-    } catch (e) {
-      return null;
-    }
+    })
   })
-});
+  .transform((val, ctx) => {
+    if (val.user_email.length > 0) {
+      return { ...val, email: val.user_email };
+    } else if (val.assigned_email.length > 0) {
+      return { ...val, email: val.assigned_email };
+    } else {
+      ctx.addIssue({
+        code: "custom",
+        message: "Neither user_email or assigned_email are present"
+      });
+      return z.NEVER;
+    }
+  });
 
 export type LemonadeTicket = z.infer<typeof LemonadeTicketSchema>;
 

--- a/apps/passport-server/src/apis/lemonade/types.ts
+++ b/apps/passport-server/src/apis/lemonade/types.ts
@@ -26,12 +26,14 @@ export type LemonadeTicketType = LemonadeTicketTypes["ticket_types"][number];
 export const LemonadeTicketSchema = z
   .object({
     _id: z.string().min(1, "_id cannot be empty"),
+    // "Assigned" email is for tickets where the user has no Lemonade account
     assigned_email: z.string(),
     user_id: z
       .string()
       .transform((val) =>
         typeof val === "string" && val.length === 0 ? undefined : val
       ),
+    // "User" email is populated when the user has a Lemonade account
     user_email: z.string(),
     user_name: z.string(),
     user_first_name: z.string(),
@@ -52,11 +54,13 @@ export const LemonadeTicketSchema = z
     })
   })
   .transform((val, ctx) => {
+    // Set a new "email" field using either the assigned or user email.
     if (val.user_email.length > 0) {
       return { ...val, email: val.user_email };
     } else if (val.assigned_email.length > 0) {
       return { ...val, email: val.assigned_email };
     } else {
+      // If neither exist, fail validation.
       ctx.addIssue({
         code: "custom",
         message: "Neither user_email or assigned_email are present"

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -1674,26 +1674,16 @@ export class LemonadePipeline implements BasePipeline {
               );
             }
 
-            if (ticketAtom.lemonadeUserId) {
-              // We found a Lemonade atom and account, so check in with the
-              // Lemonade backend
-              return this.lemonadeCheckin(
-                ticketAtom,
-                ticketAtom.lemonadeUserId,
-                emailClaim.emailAddress
-              );
-            } else {
-              return this.checkInManualTicket(
-                {
-                  id: ticketAtom.id,
-                  eventId: ticketAtom.genericIssuanceEventId,
-                  productId: ticketAtom.genericIssuanceProductId,
-                  attendeeName: ticketAtom.name,
-                  attendeeEmail: ticketAtom.email
-                },
-                emailClaim.emailAddress
-              );
-            }
+            return this.podboxLocalCheckIn(
+              {
+                id: ticketAtom.id,
+                eventId: ticketAtom.genericIssuanceEventId,
+                productId: ticketAtom.genericIssuanceProductId,
+                attendeeName: ticketAtom.name,
+                attendeeEmail: ticketAtom.email
+              },
+              emailClaim.emailAddress
+            );
           } else {
             // No valid Lemonade atom found, try looking for a manual ticket
             const manualTicket = this.getManualTicketById(request.ticketId);
@@ -1706,7 +1696,7 @@ export class LemonadePipeline implements BasePipeline {
               );
 
               // Manual ticket found, check in with the DB
-              return this.checkInManualTicket(
+              return this.podboxLocalCheckIn(
                 manualTicket,
                 emailClaim.emailAddress
               );
@@ -1734,7 +1724,7 @@ export class LemonadePipeline implements BasePipeline {
   /**
    * Checks a manual ticket into the DB.
    */
-  private async checkInManualTicket(
+  private async podboxLocalCheckIn(
     manualTicket: ManualTicket,
     checkerEmail: string
   ): Promise<PodboxTicketActionResponseValue> {

--- a/apps/passport-server/test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts
@@ -1144,7 +1144,7 @@ describe("generic issuance - LemonadePipeline", function () {
   );
 
   step(
-    "Lemonade tickets without user emails should not be loaded",
+    "Lemonade tickets without user emails should be loaded",
     async function () {
       mockServer.use(
         unregisteredLemonadeUserHandler(lemonadeBackend, lemonadeBackendUrl)
@@ -1157,9 +1157,8 @@ describe("generic issuance - LemonadePipeline", function () {
       expect(pipeline.id).to.eq(edgeCityPipeline.id);
       const runInfo = await pipeline.load();
 
-      // Despite receiving a ticket, the ticket was ignored due to not having
-      // a user email
-      expect(runInfo.atomsLoaded).to.eq(0);
+      // The ticket should be loaded
+      expect(runInfo.atomsLoaded).to.eq(1);
     }
   );
 

--- a/apps/passport-server/test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts
@@ -19,7 +19,7 @@ import {
   serializeSemaphoreGroup
 } from "@pcd/semaphore-group-pcd";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
-import { ONE_DAY_MS, ONE_MINUTE_MS, ONE_SECOND_MS } from "@pcd/util";
+import { ONE_DAY_MS, ONE_MINUTE_MS } from "@pcd/util";
 import { Identity } from "@semaphore-protocol/identity";
 import { expect } from "chai";
 import { randomUUID } from "crypto";
@@ -865,6 +865,10 @@ describe("generic issuance - LemonadePipeline", function () {
     }
   );
 
+  /**
+   * Lemonade check-in is disabled for Edge Esmeralda, so this test is not
+   * relevant.
+   
   step("check-in and remote check-out works in Lemonade", async function () {
     expectToExist(giService);
     const pipelines = await giService.getAllPipelineInstances();
@@ -1072,7 +1076,7 @@ describe("generic issuance - LemonadePipeline", function () {
         expect(bouncerPODTicket.claim.ticket.isConsumed).to.eq(true);
       }
     }
-  });
+  });*/
 
   step(
     "Lemonade API will request new token when old one expires",

--- a/apps/passport-server/test/lemonade/LemonadeDataMocker.ts
+++ b/apps/passport-server/test/lemonade/LemonadeDataMocker.ts
@@ -103,10 +103,12 @@ export class LemonadeAccount {
     }
     const user = this.users.get(userId) as LemonadeUser;
     const ticket: LemonadeTicket = {
+      email: user.email,
       _id: randomUUID(),
       type_id: ticketTypeId,
       type_title: this.ticketTypes.get(eventId)?.get(ticketTypeId)
         ?.title as string,
+      assigned_email: "",
       user_id: userId,
       user_email: user.email,
       user_name: userName,
@@ -258,7 +260,7 @@ export class LemonadeDataMocker {
     for (const account of this.accounts.values()) {
       for (const [eventId, eventTickets] of account.getTickets().entries()) {
         for (const ticket of eventTickets.values()) {
-          account.setCheckin(eventId, ticket.user_id, null, true);
+          account.setCheckin(eventId, ticket.user_id as string, null, true);
         }
       }
     }

--- a/apps/passport-server/test/lemonade/MockLemonadeServer.ts
+++ b/apps/passport-server/test/lemonade/MockLemonadeServer.ts
@@ -9,6 +9,9 @@ import {
 } from "../../src/apis/lemonade/types";
 import { LemonadeDataMocker } from "./LemonadeDataMocker";
 
+// Email field is created during parsing and is not present in the back-end
+export type LemonadeBackendTicket = Omit<LemonadeTicket, "email">;
+
 export function loadApolloErrorMessages(): void {
   // Apollo client doesn't load error messages by default so we have to call this
   loadDevMessages();
@@ -33,7 +36,7 @@ function checkEventId(
   }
 }
 
-function stringifyTickets(tickets: LemonadeTicket[]): string {
+function stringifyTickets(tickets: LemonadeBackendTicket[]): string {
   return csv_stringify(tickets, {
     header: true,
     cast: {
@@ -154,12 +157,11 @@ export function unregisteredLemonadeUserHandler(
         ).values()
       ][0];
       // Represents a ticket that has been invited to an event, but the invitee
-      // has not yet registered with Lemonade. We skip these tickets in the
-      // pipeline, because they cannot be checked in as they do not have user
-      // IDs.
-      const tickets: LemonadeTicket[] = [
+      // has not yet registered with Lemonade. This ticket will still work.
+      const tickets: LemonadeBackendTicket[] = [
         {
           _id: randomUUID(),
+          assigned_email: "unregistered@example.com",
           user_email: "",
           user_name: "",
           user_first_name: "Invited",


### PR DESCRIPTION
This is a tactical fix to do two things:

1) Accept either the `user_email` or `assigned_email` as the ticket email when either is presented by Lemonade
2) Since tickets with an `assigned_email` but no `user_email` represent tickets with no Lemonade user account, and Lemonade check-in requires a user account, all check-ins will be performed locally in the Podbox DB rather than remotely on the Lemonade back-end

In the longer term a two-way sync might be a better option, but this approach minimizes changes ahead of upcoming events.