### PR TITLE
Add eddsa-pubkey type to POD

### DIFF
--- a/packages/lib/pod/src/podCrypto.ts
+++ b/packages/lib/pod/src/podCrypto.ts
@@ -14,7 +14,7 @@ import { BigNumber, leBigIntToBuffer, leBufferToBigInt } from "@zk-kit/utils";
 import { sha256 } from "js-sha256";
 import { poseidon1 } from "poseidon-lite/poseidon1";
 import { poseidon2 } from "poseidon-lite/poseidon2";
-import { PODValue } from "./podTypes";
+import { EDDSA_PUBKEY_TYPE_STRING, PODValue } from "./podTypes";
 import {
   checkPrivateKeyFormat,
   checkPublicKeyFormat,
@@ -40,6 +40,14 @@ export function podIntHash(input: bigint): bigint {
 }
 
 /**
+ * Calculates the appropriate hash for a POD value represented as a string-encoded EdDSA public key,
+ * which could be one of multiple value types (see {@link podValueHash}).
+ */
+export function podEdDSAPublicKeyHash(input: string): bigint {
+  return poseidon2(decodePublicKey(input));
+}
+
+/**
  * Calculates the appropriate hash for a POD entry name.
  */
 export function podNameHash(podName: string): bigint {
@@ -57,8 +65,8 @@ export function podValueHash(podValue: PODValue): bigint {
     case "cryptographic":
       // TODO(POD-P2): Finalize choice of hash for POD cryptographics.
       return podIntHash(podValue.value);
-    case "eddsa-pubkey":
-      return poseidon2(decodePublicKey(podValue.value));
+    case EDDSA_PUBKEY_TYPE_STRING:
+      return podEdDSAPublicKeyHash(podValue.value);
     default:
       throw new TypeError(`Unexpected type in PODValue ${podValue}.`);
   }

--- a/packages/lib/pod/src/podCrypto.ts
+++ b/packages/lib/pod/src/podCrypto.ts
@@ -57,6 +57,8 @@ export function podValueHash(podValue: PODValue): bigint {
     case "cryptographic":
       // TODO(POD-P2): Finalize choice of hash for POD cryptographics.
       return podIntHash(podValue.value);
+    case "eddsa-pubkey":
+      return poseidon2(decodePublicKey(podValue.value));
     default:
       throw new TypeError(`Unexpected type in PODValue ${podValue}.`);
   }

--- a/packages/lib/pod/src/podCrypto.ts
+++ b/packages/lib/pod/src/podCrypto.ts
@@ -40,8 +40,7 @@ export function podIntHash(input: bigint): bigint {
 }
 
 /**
- * Calculates the appropriate hash for a POD value represented as a string-encoded EdDSA public key,
- * which could be one of multiple value types (see {@link podValueHash}).
+ * Calculates the appropriate hash for a POD value represented as a string-encoded EdDSA public key.
  */
 export function podEdDSAPublicKeyHash(input: string): bigint {
   return poseidon2(decodePublicKey(input));

--- a/packages/lib/pod/src/podTypes.ts
+++ b/packages/lib/pod/src/podTypes.ts
@@ -13,6 +13,21 @@ export type PODName = string;
 export const POD_NAME_REGEX = new RegExp(/^[A-Za-z_]\w*$/);
 
 /**
+ * String-encoded POD value type enum.
+ */
+export type POD_VALUE_STRING_TYPE_IDENTIFIER = "eddsa_pubkey" | "string";
+
+/**
+ * Identifier for EdDSA public key string type.
+ */
+export const EDDSA_PUBKEY_TYPE_STRING = "eddsa_pubkey";
+
+/**
+ * Regex matching legal values for types encoded as strings.
+ */
+export const POD_STRING_TYPE_REGEX = new RegExp(/[A-Za-z_]\w*:.*$/);
+
+/**
  * POD value for a user-specififed string.  String values can contain any
  * string.  They are not limited like names.
  */
@@ -69,18 +84,13 @@ export const POD_INT_MIN = 0n;
 export const POD_INT_MAX = (1n << 63n) - 1n;
 
 /**
- * POD value for EddSA (Baby Jubjub) public keys. Such a value is represented as
- * a hex string of the (32-byte) compressed form of the key.
+ * POD value for EdDSA (Baby Jubjub) public keys. Such a value is represented as
+ * a hex string of the (32-byte) encoded form of the key.
  */
 export type PODEdDSAPublicKeyValue = {
-  type: "eddsa-pubkey";
+  type: "eddsa_pubkey";
   value: string;
 };
-
-/**
- * A useful identifier for simplified JSON serialisation of EdDSA public keys.
- */
-export const EDDSA_PUBKEY_PREFIX = "pk";
 
 /**
  * POD values are tagged with their type.  All values contain `type` and `value`

--- a/packages/lib/pod/src/podTypes.ts
+++ b/packages/lib/pod/src/podTypes.ts
@@ -69,10 +69,28 @@ export const POD_INT_MIN = 0n;
 export const POD_INT_MAX = (1n << 63n) - 1n;
 
 /**
+ * POD value for EddSA (Baby Jubjub) public keys. Such a value is represented as
+ * a hex string of the (32-byte) compressed form of the key.
+ */
+export type PODEdDSAPublicKeyValue = {
+  type: "eddsa-pubkey";
+  value: string;
+};
+
+/**
+ * A useful identifier for simplified JSON serialisation of EdDSA public keys.
+ */
+export const EDDSA_PUBKEY_PREFIX = "pk";
+
+/**
  * POD values are tagged with their type.  All values contain `type` and `value`
  * fields, which Typescript separates into distinct types for validation.
  */
-export type PODValue = PODStringValue | PODCryptographicValue | PODIntValue;
+export type PODValue =
+  | PODStringValue
+  | PODCryptographicValue
+  | PODIntValue
+  | PODEdDSAPublicKeyValue;
 
 /**
  * Represents a tuple of POD values as an array.

--- a/packages/lib/pod/src/podTypes.ts
+++ b/packages/lib/pod/src/podTypes.ts
@@ -23,9 +23,10 @@ export type POD_VALUE_STRING_TYPE_IDENTIFIER = "eddsa_pubkey" | "string";
 export const EDDSA_PUBKEY_TYPE_STRING = "eddsa_pubkey";
 
 /**
- * Regex matching legal values for types encoded as strings.
+ * Regex matching legal values for types encoded as strings. This matches
+ * strings of the form `${PODName}:${string}`.
  */
-export const POD_STRING_TYPE_REGEX = new RegExp(/[A-Za-z_]\w*:.*$/);
+export const POD_STRING_TYPE_REGEX = new RegExp(/([A-Za-z_]\w*):(.*)$/);
 
 /**
  * POD value for a user-specififed string.  String values can contain any

--- a/packages/lib/pod/src/podUtil.ts
+++ b/packages/lib/pod/src/podUtil.ts
@@ -428,7 +428,7 @@ export function podValueFromRawValue(rawValue: PODRawValue): PODValue {
       const separatorIndex = rawValue.search(/:/);
       const prefix = rawValue.slice(0, separatorIndex);
       const payload = rawValue.slice(separatorIndex + 1);
-      return prefix === EDDSA_PUBKEY_PREFIX
+      return prefix === EDDSA_PUBKEY_PREFIX && payload.match(PUBLIC_KEY_REGEX)
         ? { type: "eddsa-pubkey", value: payload }
         : prefix === "string"
         ? { type: "string", value: payload }

--- a/packages/lib/pod/test/common.ts
+++ b/packages/lib/pod/test/common.ts
@@ -30,18 +30,19 @@ export const sampleEntries1 = {
   H: { type: "int", value: 8n },
   I: { type: "int", value: 9n },
   J: { type: "int", value: 10n },
+  publicKey: { type: "eddsa-pubkey", value: expectedPublicKey },
   owner: { type: "cryptographic", value: ownerIdentity.commitment }
 } satisfies PODEntries;
 
 // If sample entries or private key change above, this value will need to
 // change.  Test failures will indicate the new value.
 export const expectedContentID1 =
-  21748523748810072846647845097417136490972606253431724953054174411568740252986n;
+  12404785626264207783522278176629851913558812302780179622189407657324290448828n;
 
 // If sample entries or private key change above, this value will need to
 // change.  Test failures will indicate the new value.
 export const expectedSignature1 =
-  "e0031246c8657545c154f407006f6856de2f69acd00f23b637ec23620792f10c7bf70befe45c79acf2a8cbea0eb4ffe1beef30ff23f2623fd5acf51beaa0d905";
+  "64abaf261621e095cda8aaadd6e4bdf6501545e87f6cd923bf7e5e0f7295032b0138ec803350639b0a04de9c26fc2b8232f3f46b5b7486b69e02c4de06398601";
 
 export const sampleEntries2 = {
   attendee: { type: "cryptographic", value: ownerIdentity.commitment },

--- a/packages/lib/pod/test/common.ts
+++ b/packages/lib/pod/test/common.ts
@@ -30,7 +30,7 @@ export const sampleEntries1 = {
   H: { type: "int", value: 8n },
   I: { type: "int", value: 9n },
   J: { type: "int", value: 10n },
-  publicKey: { type: "eddsa-pubkey", value: expectedPublicKey },
+  publicKey: { type: "eddsa_pubkey", value: expectedPublicKey },
   owner: { type: "cryptographic", value: ownerIdentity.commitment }
 } satisfies PODEntries;
 
@@ -86,6 +86,18 @@ export const testIntsToHash = [
   // Max 256-bit 32-byte integer value (too large for a circuit, but hashable
   // after being reduced mod R).
   0xffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffffn
+];
+
+export const testPublicKeysToHash = [
+  "4f5fb4898c477d8c17227ddd81eb597125e4d437489c01a6085b5db54e053b0a",
+  "09ba237eb49e4552da3bf5260f8ca8a9a9055c41aad47ef564de4bb1a5cba619",
+  "ce1c9c187ad59b5a324020ab503e783bc95bc268cb1b03cb5c7be91f1e4e8917",
+  "c2478aa919f5d09a68fe264d9e980b94872d2472cb53f514bfc1b19f3029741f",
+  "bcac8981e8ee8f5d9206f5b74f67b1ce91c6bc18b81d259c7a9526b251e7a39f",
+  "f71b62538fbc40df0d5e5b2034641ae437bdbf06012779590099456cf25b5f8f",
+  "755224af31d5b5e47cc6ca8827b8bf9d2ceba48bf439907abaade0a3269d561b",
+  "f27205e5ceeaad24025652cc9f6f18cee5897266f8c0aac5b702d48e0dea3585",
+  "2af47e1aaf8f0450b9fb2e429042708ec7d173c4ac4329747db1063b78db4e0d"
 ];
 
 export const testPrivateKeys = [

--- a/packages/lib/pod/test/podCrypto.spec.ts
+++ b/packages/lib/pod/test/podCrypto.spec.ts
@@ -71,6 +71,22 @@ describe("podCrypto hashes should work", async function () {
     }
   });
 
+  it("podEdDSAPublicKeyHash should produce expected results", function () {
+    // Here we check that the public key hash is precisely the Poseidon(2) hash
+    // of the public key point as an array of 2 elements and not the string hash
+    // of the string representation.
+    for (const privateKey of testPrivateKeys) {
+      const publicKeyPt = derivePublicKey(privateKey);
+      const encodedPublicKey = encodePublicKey(publicKeyPt);
+      const expectedHash = poseidon2(publicKeyPt);
+      const unexpectedHash = podStringHash(encodedPublicKey);
+      const computedHash = podEdDSAPublicKeyHash(encodedPublicKey);
+
+      expect(computedHash).to.eq(expectedHash);
+      expect(computedHash).to.not.eq(unexpectedHash);
+    }
+  });
+
   it("podIntHash should produce unique repeatable results", function () {
     const seenHashes = new Set();
     for (const i of testIntsToHash) {

--- a/packages/lib/pod/test/podCrypto.spec.ts
+++ b/packages/lib/pod/test/podCrypto.spec.ts
@@ -11,6 +11,7 @@ import { expect } from "chai";
 import "mocha";
 import { poseidon2 } from "poseidon-lite/poseidon2";
 import {
+  EDDSA_PUBKEY_TYPE_STRING,
   PODContent,
   checkPrivateKeyFormat,
   checkPublicKeyFormat,
@@ -21,6 +22,7 @@ import {
   encodePrivateKey,
   encodePublicKey,
   encodeSignature,
+  podEdDSAPublicKeyHash,
   podIntHash,
   podMerkleTreeHash,
   podNameHash,
@@ -40,6 +42,7 @@ import {
   sampleEntries1,
   testIntsToHash,
   testPrivateKeys,
+  testPublicKeysToHash,
   testStringsToHash
 } from "./common";
 
@@ -52,6 +55,18 @@ describe("podCrypto hashes should work", async function () {
       seenHashes.add(h);
 
       const h2 = podStringHash(s);
+      expect(h2).to.eq(h);
+    }
+  });
+
+  it("podEdDSAPublicKeyHash should produce unique repeatable results", function () {
+    const seenHashes = new Set();
+    for (const s of testPublicKeysToHash) {
+      const h = podEdDSAPublicKeyHash(s);
+      expect(seenHashes.has(h)).to.be.false;
+      seenHashes.add(h);
+
+      const h2 = podEdDSAPublicKeyHash(s);
       expect(h2).to.eq(h);
     }
   });
@@ -97,6 +112,14 @@ describe("podCrypto hashes should work", async function () {
       seenHashes.add(h);
 
       const h2 = podValueHash({ type: "string", value: s });
+      expect(h2).to.eq(h);
+    }
+    for (const s of testPublicKeysToHash) {
+      const h = podValueHash({ type: EDDSA_PUBKEY_TYPE_STRING, value: s });
+      expect(seenHashes.has(h)).to.be.false;
+      seenHashes.add(h);
+
+      const h2 = podValueHash({ type: EDDSA_PUBKEY_TYPE_STRING, value: s });
       expect(h2).to.eq(h);
     }
     for (const i of testIntsToHash) {

--- a/packages/pcd/gpc-pcd/src/GPCPCD.ts
+++ b/packages/pcd/gpc-pcd/src/GPCPCD.ts
@@ -49,7 +49,7 @@ export type GPCPCDArgs = {
 
   /**
    * POD objects to prove about.  These are not revealed by default, but
-   * a redacted version of their entries will become part of the clais of the
+   * a redacted version of their entries will become part of the claims of the
    * resulting proof PCD, as specified by the proof config.
    *
    * See {@link GPCProofConfig} and {@link GPCRevealedClaims} for more


### PR DESCRIPTION
Towards https://linear.app/0xparc-pcd/issue/0XP-891/gpc-constraints-on-signing-keys

This PR adds an EdDSA public key type to the POD library. Such values are tagged with `eddsa-pubkey` and encoded as hex strings in compressed format as is done elsewhere. The simplified JSON serialisation adds the prefix `pk:` to distinguish them from strings, which would either be prefixed with `string:` or not follow the public key pattern.