### PR TITLE
Detailed docs and links in READMEs for POD+GPC

### DIFF
--- a/apps/passport-client/scripts/copy-test-artifacts.sh
+++ b/apps/passport-client/scripts/copy-test-artifacts.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# TODO(POD-P1): Figure out how to build/distribute artifacts to server for prod
-# TODO(POD-P2): Create and distribute real artifacts after trusted setup
-
 set -ex
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/packages/lib/gpc/README.md
+++ b/packages/lib/gpc/README.md
@@ -17,14 +17,111 @@
     <a href="https://npmjs.org/package/@pcd/gpc">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/gpc.svg?style=flat-square" />
     </a>
+<br>
+    <a href="https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b">
+        <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/blob/main/examples/pod-gpc-example/src/gpcExample.ts#L88">
+        <img alt="Tutorial Code" src="https://img.shields.io/badge/Tutorial_Code-blue.svg?style=flat-square">
+    </a>
+    <a href="https://docs.pcd.team/modules/_pcd_gpc.html">
+        <img alt="TypeDoc" src="https://img.shields.io/badge/TypeDoc-purple.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/gpc">
+        <img alt="GitHub" src="https://img.shields.io/badge/GitHub-grey.svg?style=flat-square">
+    </a>
 </p>
 
-# `@pcd/gpc`
+A library for creating and verifying zero-knowledge proofs using General Purpose
+Circuits. For a full introduction, see the [Developer Site](https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b).
 
-Library for configuration and use of GPCs (General Purpose Circuits) on POD
-(Provable Object Data).
+**POD** is a format enabling any app to flexibly create cryptographic data and
+make zero-knowledge proofs about it. A POD could represent your ticket to an
+event, a secure message, a collectible badge, or an item in a role-playing game.
+Using PODs, developers can create ZK-enabled apps without the effort and risk of
+developing their own cryptography.
 
-TODO(POD-P3): Detailed description of the GPC concept and design.
+ZK proofs about PODs use General Purpose Circuits (**GPC**) which can prove many
+different things about a POD without revealing it all. GPCs use human-readable
+configuration and pre-compiled circuits so no knowledge of circuit programming
+is required.
 
-TODO(POD-P3): Introduction to the circuits and helper Typescript code
-in this package, with an example.
+PODs and GPCs can be used in Zupass, or in your own apps without Zupass.
+
+## What is a GPC?
+
+GPCs allow ZK proofs to be created from a simple proof configuration. You can
+configure your proofs using a human-readable (JSON) format, which is used to
+generate the specific circuit inputs needed for the proof.
+
+```TypeScript
+const weaponProofConfig: GPCProofConfig = {
+  pods: {
+    weapon: {
+      entries: {
+        attack: { isRevealed: true },
+        weaponType: { isRevealed: false, isMemberOf: "favoriteWeapons" },
+        owner: { isRevealed: false, isOwnerID: true }
+      }
+    }
+  }
+};
+```
+
+The GPC library has a family of pre-compiled ZK circuits with different sizes
+and capabilities. It will automatically select the right circuit to satisfy the
+needs of each proof at run-time. No setup is required, and you don’t need any
+knowledge of circuit programming (circom, halo2, noir, etc).
+
+GPCs can prove properties of one POD or several PODs together. PODs can be
+proven to be owned by the prover, using their Semaphore identity. A GPC can
+constrain as many named entries as needed, whether revealed or not. For example,
+a proof might constraint two entries to be equal, constrain a third entry to be
+in a list of valid values, and reveal the value of a fourth entry.
+
+## Entry Points
+
+- The [`GPCProofConfig`](https://docs.pcd.team/types/_pcd_gpc.GPCProofConfig.html)
+  type configures a proof. Start there to learn what properties you can
+  prove about a POD.
+- The [`gpcProve`](https://docs.pcd.team/functions/_pcd_gpc.gpcProve.html) and
+  [`gpcVerify`](https://docs.pcd.team/functions/_pcd_gpc.gpcVerify.html)
+  functions allow you to generate and validate GPC proofs.
+- The [`gpcArtifactDownloadURL`](https://docs.pcd.team/functions/_pcd_gpc.gpcArtifactDownloadURL.html)
+  function can help you find the right place to download the necessary binary
+  artifacts (proving key, verification key, witness generator) to perform
+  proof calculations.
+
+For more details on usage, check out the
+[tutorial code](https://github.com/proofcarryingdata/zupass/blob/main/examples/pod-gpc-example/src/gpcExample.ts#L88).
+
+## Related Packages
+
+- For information about making POD objects, see the
+  [`@pcd/pod`](https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/pod)
+  package.
+
+- To interact with GPC proofs in the Zupass app, see the
+  [`@pcd/gpc-pcd`](https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/gpc-pcd)
+  package.
+
+- To find the binaries required to prove and verify, see the
+  [`@pcd/proto-pod-gpc-artifacts`](https://github.com/proofcarryingdata/snark-artifacts/tree/pre-release/packages/proto-pod-gpc)
+  package. Since these artifacts are large and numerous, you generally
+  won't want to depend on this package directly.
+
+## Stability and Security
+
+POD and GPC libraries are experimental and subject to change. We encourage devs
+to try them out and use them for apps, but maybe don’t rely on them for the most
+sensitive use cases yet.
+
+GPC proofs are considered ephemeral (for now), primarily intended for
+transactional use cases. Saved proofs may not be verifiable with future
+versions of code. Library interfaces may also change. Any breaking changes will
+be reflected in the NPM versions using standard semantic versioning.
+
+These libraries should not be considered secure enough for highly-sensitive use
+cases yet. The circuits are experimental and have not been audited. The
+proving/verification keys were generated in good faith by a single author, but
+are not the result of a distributed trusted setup ceremony.

--- a/packages/lib/gpc/src/gpc.ts
+++ b/packages/lib/gpc/src/gpc.ts
@@ -199,6 +199,9 @@ export const GPC_ARTIFACTS_NPM_VERSION = ProtoPODGPC.ARTIFACTS_NPM_VERSION;
 
 /**
  * Possible sources to download GPC artifacts.
+ *
+ * Note that the `zupass` source is not currently usable outside of the
+ * Zupass app itself.
  */
 export type GPCArtifactSource = "zupass" | "github" | "unpkg";
 

--- a/packages/lib/gpcircuits/README.md
+++ b/packages/lib/gpcircuits/README.md
@@ -17,17 +17,86 @@
     <a href="https://npmjs.org/package/@pcd/gpcircuits">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/gpcircuits.svg?style=flat-square" />
     </a>
+<br>
+    <a href="https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b">
+        <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
+    </a>
+    <a href="https://docs.pcd.team/modules/_pcd_gpcircuits.html">
+        <img alt="TypeDoc" src="https://img.shields.io/badge/TypeDoc-purple.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/gpcircuits">
+        <img alt="GitHub" src="https://img.shields.io/badge/GitHub-grey.svg?style=flat-square">
+    </a>
 </p>
 
-# `@pcd/gpcircuits`
+A collection of circom circuits and supporting code for zero-knowledge proofs on
+PODs (Provable Object Data) via the GPC (General Purpose Circuits) framework.
+For a full introduction, see the
+[Developer Site](https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b).
 
-Circom circuits supporting proofs on POD (Provable Object Data) via GPC
-(General Purpose Circuits) framework.
+**POD** is a format enabling any app to flexibly create cryptographic data and
+make zero-knowledge proofs about it. A POD could represent your ticket to an
+event, a secure message, a collectible badge, or an item in a role-playing game.
+Using PODs, developers can create ZK-enabled apps without the effort and risk of
+developing their own cryptography.
 
-TODO(POD-P3): Detailed description of the GPC concept and design.
+ZK proofs about PODs use General Purpose Circuits (**GPC**) which can prove many
+different things about a POD without revealing it all. GPCs use human-readable
+configuration and pre-compiled circuits so no knowledge of circuit programming
+is required.
 
-TODO(POD-P3): Introduction to the circuits and helper Typescript code
-in this package, with an example.
+PODs and GPCs can be used in Zupass, or in your own apps without Zupass.
 
-TODO(POD-P3): List of supported circuits in the family, with available
-paramaters, so users can manually pick a circuit identifier.
+## What's in this package?
+
+This package implements the first prototype family of GPC circuits, named
+`proto-pod-gpc`. The primary use of the circuits in this package is via
+a high-level configuration interpreted by the
+[`@pcd/gpc`](https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/gpc)
+package.
+
+The top level circuit in the family is in
+[`proto-pod-gpc.circom`](https://github.com/proofcarryingdata/zupass/blob/main/packages/lib/gpcircuits/circuits/proto-pod-gpc.circom).
+That circuit is built using a configurable number of different Modules defined
+in the other circom files. If you're a circom developer, you can reuse these
+modules to create your own circuits which prove things about PODs which the
+GPC configuration doesn't yet support.
+
+Pre-compiled artifacts for these circuits at various sizes are published in the
+[`@pcd/proto-pod-gpc-artifacts`](https://github.com/proofcarryingdata/snark-artifacts/tree/pre-release/packages/proto-pod-gpc)
+package. They are stored in a dedicated repo due to their size.
+
+## Related Packages
+
+- For information about making POD objects, see the
+  [`@pcd/pod`](https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/pod)
+  package.
+
+- For information about making proofs about PODs, see the
+  [`@pcd/gpc`](https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/gpc)
+  package.
+
+- To interact with GPC proofs in the Zupass app, see the
+  [`@pcd/gpc-pcd`](https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/gpc-pcd)
+  package.
+
+- To find the binaries required to prove and verify, see the
+  [`@pcd/proto-pod-gpc-artifacts`](https://github.com/proofcarryingdata/snark-artifacts/tree/pre-release/packages/proto-pod-gpc)
+  package. Since these artifacts are large and numerous, you generally
+  won't want to depend on this package directly.
+
+## Stability and Security
+
+POD and GPC libraries are experimental and subject to change. We encourage devs
+to try them out and use them for apps, but maybe don’t rely on them for the most
+sensitive use cases yet.
+
+GPC proofs are considered ephemeral (for now), primarily intended for
+transactional use cases. Saved proofs may not be verifiable with future
+versions of code. Library interfaces may also change. Any breaking changes will
+be reflected in the NPM versions using standard semantic versioning.
+
+These libraries should not be considered secure enough for highly-sensitive use
+cases yet. The circuits are experimental and have not been audited. The
+proving/verification keys were generated in good faith by a single author, but
+are not the result of a distributed trusted setup ceremony.

--- a/packages/lib/gpcircuits/src/proto-pod-gpc.ts
+++ b/packages/lib/gpcircuits/src/proto-pod-gpc.ts
@@ -449,8 +449,6 @@ export class ProtoPODGPC {
     return undefined;
   }
 
-  // TODO(POD-P2): Replace `ProtoPODGPCCircuitParams` with a different type
-  // allowing more flexibility with choices of tuple parameters.
   /**
    * Checks whether a described circuit can meet a required set of parameters.
    * This will be true if each of the circuit's parameters is greater than or

--- a/packages/lib/pod/README.md
+++ b/packages/lib/pod/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
     <a href="https://github.com/proofcarryingdata">
-        <img src="https://img.shields.io/badge/project-PCD-blue.svg?style=flat-square">
+        <img alt="PCD" src="https://img.shields.io/badge/project-PCD-blue.svg?style=flat-square">
     </a>
     <a href="https://github.com/proofcarryingdata/zupass/blob/main/packages/lib/pod/LICENSE">
         <img alt="License" src="https://img.shields.io/badge/license-GPL--3.0-green.svg?style=flat-square">
@@ -17,13 +17,94 @@
     <a href="https://npmjs.org/package/@pcd/pod">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/pod.svg?style=flat-square" />
     </a>
+<br>
+    <a href="https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b">
+        <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/blob/main/examples/pod-gpc-example/src/podExample.ts#L57">
+        <img alt="Tutorial Code" src="https://img.shields.io/badge/Tutorial_Code-blue.svg?style=flat-square">
+    </a>
+    <a href="https://docs.pcd.team/modules/_pcd_pod.html">
+        <img alt="TypeDoc" src="https://img.shields.io/badge/TypeDoc-purple.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/pod">
+        <img alt="GitHub" src="https://img.shields.io/badge/GitHub-grey.svg?style=flat-square">
+    </a>
 </p>
 
-# `@pcd/pod`
+A library for creating and manipulating objects in the Provable Object Data
+format. For a full introduction, see the [Developer Site](https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b).
 
-Library for creating and manipulating objects in the Provable Object Data
-format.
+**POD** is a format enabling any app to flexibly create cryptographic data and
+make zero-knowledge proofs about it. A POD could represent your ticket to an
+event, a secure message, a collectible badge, or an item in a role-playing game.
+Using PODs, developers can create ZK-enabled apps without the effort and risk of
+developing their own cryptography.
 
-TODO(POD-P3): Detailed description of POD concepts an design.
+ZK proofs about PODs use General Purpose Circuits (**GPC**) which can prove many
+different things about a POD without revealing it all. GPCs use human-readable
+configuration and pre-compiled circuits so no knowledge of circuit programming
+is required.
 
-TODO(POD-P3): Intro to the major classes in the package with an example.
+PODs and GPCs can be used in Zupass, or in your own apps without Zupass.
+
+## What is a POD?
+
+For a user, a POD is a piece of cryptographic data attested by some issuing
+authority. For a developer, a POD object is a key-value store which can contain
+any data. The whole POD is signed by an issuer. Apps can verify the signature,
+and trust the authenticity of the values in the POD.
+
+When a POD is issued, its entries (key-value pairs) are hashed as part of a
+Merkle tree. This allows GPCs to selectively prove about individual entries
+without revealing the whole POD.
+
+```TypeScript
+const podSword = POD.sign(
+  {
+    pod_type: { type: "string", value: "item.weapon" },
+    attack: { type: "int", value: 7n },
+    weaponType: { type: "string", value: "sword" },
+    itemSet: { type: "string", value: "celestial" },
+    owner: { type: "cryptographic", value: purchaser.commitment }
+  } satisfies PODEntries,
+  privateKey
+);
+```
+
+## Entry Points
+
+- The [`PODEntries`](https://docs.pcd.team/types/_pcd_pod.PODEntries.html)
+  type represents names and values in a POD. Start there to learn what
+  a POD can represent.
+- The [`POD`](https://docs.pcd.team/classes/_pcd_pod.POD.html) class represents
+  a signed POD, which you can create by signing with your private key, or load
+  with an existing signature.
+- The [`PODContent`](https://docs.pcd.team/classes/_pcd_pod.PODContent.html)
+  class links POD entries together into a Merkle tree and provides Map-like
+  accessors for named values.
+
+For more details on usage, check out the
+[tutorial code](https://github.com/proofcarryingdata/zupass/blob/main/examples/pod-gpc-example/src/podExample.ts#L57).
+
+## Related Packages
+
+- For information about making proofs about PODs, see the
+  [`@pcd/gpc`](https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/gpc)
+  package.
+
+- To interact with PODs in the Zupass app, see the
+  [`@pcd/pod-pcd`](https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/pod-pcd)
+  package.
+
+## Stability and Security
+
+POD and GPC libraries are experimental and subject to change. We encourage devs
+to try them out and use them for apps, but maybe don’t rely on them for the most
+sensitive use cases yet.
+
+The PODs themselves are persistent data, and we expect to maintain
+backward-compatibility when we make changes to the format, but new code may be
+required to handle formar versioning. Library interfaces may also change. Any
+breaking changes will be reflected in the NPM versions using standard semantic
+versioning.

--- a/packages/lib/pod/src/pod.ts
+++ b/packages/lib/pod/src/pod.ts
@@ -15,8 +15,6 @@ import { checkPublicKeyFormat, checkSignatureFormat } from "./podUtil";
  * to produce a root hash called the Content ID, which is then signed.  To
  * create a POD, use one of the static factory methods of this class.
  *
- * TODO(POD-P3): Pointer to more detailed documention elsewhere.
- *
  * Most features depending on the POD entries but not the signature are
  * provided by a PODContent instance available via `pod.content`.
  */

--- a/packages/lib/pod/src/podContent.ts
+++ b/packages/lib/pod/src/podContent.ts
@@ -51,8 +51,6 @@ export type PODEntryCircuitSignals = {
  * to produce a root hash called the Content ID, which is then signed.  To
  * create a POD, use one of the static factory methods of this class.
  *
- * TODO(POD-P3): Pointer to more detailed documention elsewhere.
- *
  * `PODContent` instances are usually contained in a signed `POD` instance.
  */
 export class PODContent {

--- a/packages/pcd/gpc-pcd/README.md
+++ b/packages/pcd/gpc-pcd/README.md
@@ -17,11 +17,66 @@
     <a href="https://npmjs.org/package/@pcd/gpc-pcd">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/gpc-pcd.svg?style=flat-square" />
     </a>
+<br>
+    <a href="https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b">
+        <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/blob/main/examples/pod-gpc-example/src/gpcExample.ts#L376">
+        <img alt="Tutorial Code" src="https://img.shields.io/badge/Tutorial_Code-blue.svg?style=flat-square">
+    </a>
+    <a href="https://docs.pcd.team/modules/_pcd_gpc_pcd.html">
+        <img alt="TypeDoc" src="https://img.shields.io/badge/TypeDoc-purple.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/gpc-pcd">
+        <img alt="GitHub" src="https://img.shields.io/badge/GitHub-grey.svg?style=flat-square">
+    </a>
 </p>
 
-# `@pcd/gpc-pcd`
+A PCD representating a ZK proof about one more POD (Provable Object Data) objects
+using a GPC (General Purpose Circuit). For a full introduction, see the
+[Developer Site](https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b).
 
-PCD representating a ZK proof about one more POD (Provable Object Data) objects
-using a GPC (General Purpose Circuit).
+**POD** is a format enabling any app to flexibly create cryptographic data and
+make zero-knowledge proofs about it. A POD could represent your ticket to an
+event, a secure message, a collectible badge, or an item in a role-playing game.
+Using PODs, developers can create ZK-enabled apps without the effort and risk of
+developing their own cryptography.
 
-TODO(POD-P3): Detailed description of POD concepts an design.
+ZK proofs about PODs use General Purpose Circuits (**GPC**) which can prove many
+different things about a POD without revealing it all. GPCs use human-readable
+configuration and pre-compiled circuits so no knowledge of circuit programming
+is required.
+
+See the [`GPCPCD`](https://docs.pcd.team/classes/_pcd_pod_pcd.PODPCD.html)
+class for more details on the data of a GPC PCD.
+
+## Related Packages
+
+- For information about making POD objects in Zupass, see the
+  [`@pcd/pod-pcd`](https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/pod-pcd)
+  package.
+
+- For information about making proofs about PODs, see the
+  [`@pcd/gpc`](https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/gpc)
+  package.
+
+- To find the binaries required to prove and verify, see the
+  [`@pcd/proto-pod-gpc-artifacts`](https://github.com/proofcarryingdata/snark-artifacts/tree/pre-release/packages/proto-pod-gpc)
+  package. Since these artifacts are large and numerous, you generally
+  won't want to depend on this package directly.
+
+## Stability and Security
+
+POD and GPC libraries are experimental and subject to change. We encourage devs
+to try them out and use them for apps, but maybe don’t rely on them for the most
+sensitive use cases yet.
+
+GPC proofs are considered ephemeral (for now), primarily intended for
+transactional use cases. Saved proofs may not be verifiable with future
+versions of code. Library interfaces may also change. Any breaking changes will
+be reflected in the NPM versions using standard semantic versioning.
+
+These libraries should not be considered secure enough for highly-sensitive use
+cases yet. The circuits are experimental and have not been audited. The
+proving/verification keys were generated in good faith by a single author, but
+are not the result of a distributed trusted setup ceremony.

--- a/packages/pcd/gpc-pcd/README.md
+++ b/packages/pcd/gpc-pcd/README.md
@@ -32,8 +32,8 @@
     </a>
 </p>
 
-A PCD representating a ZK proof about one more POD (Provable Object Data) objects
-using a GPC (General Purpose Circuit). For a full introduction, see the
+A PCD representating a ZK proof about one or more POD (Provable Object Data)
+objects using a GPC (General Purpose Circuit). For a full introduction, see the
 [Developer Site](https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b).
 
 **POD** is a format enabling any app to flexibly create cryptographic data and

--- a/packages/pcd/pod-pcd/README.md
+++ b/packages/pcd/pod-pcd/README.md
@@ -17,10 +17,57 @@
     <a href="https://npmjs.org/package/@pcd/pod-pcd">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/pod-pcd.svg?style=flat-square" />
     </a>
+<br>
+    <a href="https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b">
+        <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/blob/main/examples/pod-gpc-example/src/podExample.ts#L214">
+        <img alt="Tutorial Code" src="https://img.shields.io/badge/Tutorial_Code-blue.svg?style=flat-square">
+    </a>
+    <a href="https://docs.pcd.team/modules/_pcd_pod_pcd.html">
+        <img alt="TypeDoc" src="https://img.shields.io/badge/TypeDoc-purple.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/pod-pcd">
+        <img alt="GitHub" src="https://img.shields.io/badge/GitHub-grey.svg?style=flat-square">
+    </a>
 </p>
 
-# `@pcd/pod-pcd`
+A PCD representating an object in the **POD** (Provable Object Data) format,
+allowing it to be manipulated by generic apps like Zupass.
+For a full introduction, see the [Developer Site](https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b).
 
-PCD representating an object in the Provable Object Data format.
+**POD** is a format enabling any app to flexibly create cryptographic data and
+make zero-knowledge proofs about it. A POD could represent your ticket to an
+event, a secure message, a collectible badge, or an item in a role-playing game.
+Using PODs, developers can create ZK-enabled apps without the effort and risk of
+developing their own cryptography.
 
-TODO(POD-P3): Detailed description of POD concepts an design.
+ZK proofs about PODs use General Purpose Circuits (**GPC**) which can prove many
+different things about a POD without revealing it all. GPCs use human-readable
+configuration and pre-compiled circuits so no knowledge of circuit programming
+is required.
+
+See the [`PODPCD`](https://docs.pcd.team/classes/_pcd_pod_pcd.PODPCD.html)
+class for more details on the data of a POD PCD.
+
+## Related Packages
+
+- For information about making POD objects, see the
+  [`@pcd/pod`](https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/pod)
+  package.
+
+- For information about making proofs about PODs in Zupass, see the
+  [`@pcd/gpc-pcd`](https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/gpc-pcd)
+  package.
+
+## Stability and Security
+
+POD and GPC libraries are experimental and subject to change. We encourage devs
+to try them out and use them for apps, but maybe don’t rely on them for the most
+sensitive use cases yet.
+
+The PODs themselves are persistent data, and we expect to maintain
+backward-compatibility when we make changes to the format, but new code may be
+required to handle formar versioning. Library interfaces may also change. Any
+breaking changes will be reflected in the NPM versions using standard semantic
+versioning.

--- a/packages/ui/gpc-pcd-ui/README.md
+++ b/packages/ui/gpc-pcd-ui/README.md
@@ -17,10 +17,20 @@
     <a href="https://npmjs.org/package/@pcd/gpc-pcd-ui">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/gpc-pcd-ui.svg?style=flat-square" />
     </a>
+<br>
+    <a href="https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b">
+        <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
+    </a>
+    <a href="https://docs.pcd.team/modules/_pcd_gpc_pcd_ui.html">
+        <img alt="TypeDoc" src="https://img.shields.io/badge/TypeDoc-purple.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/tree/main/packages/ui/gpc-pcd-ui">
+        <img alt="GitHub" src="https://img.shields.io/badge/GitHub-grey.svg?style=flat-square">
+    </a>
 </p>
 
-# `@pcd/gpc-pcd-ui`
+This package provides React UI for
+[`@pcd/gpc-pcd`](https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/gpc-pcd).
+See that package for more details on functionality.
 
-UI elements for PCD representating a ZK proof about one more POD (Provable Object Data) objects using a GPC (General Purpose Circuit).
-
-TODO(POD-P3): Detailed description of POD concepts an design.
+For a full introduction, see the [Developer Site](https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b).

--- a/packages/ui/pod-pcd-ui/README.md
+++ b/packages/ui/pod-pcd-ui/README.md
@@ -17,21 +17,20 @@
     <a href="https://npmjs.org/package/@pcd/pod-pcd-ui">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/pod-pcd-ui.svg?style=flat-square" />
     </a>
+<br>
+    <a href="https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b">
+        <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
+    </a>
+    <a href="https://docs.pcd.team/modules/_pcd_pod_pcd_ui.html">
+        <img alt="TypeDoc" src="https://img.shields.io/badge/TypeDoc-purple.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/proofcarryingdata/zupass/tree/main/packages/ui/pod-pcd-ui">
+        <img alt="GitHub" src="https://img.shields.io/badge/GitHub-grey.svg?style=flat-square">
+    </a>
 </p>
 
-| This package provides React UI for `@pcd/pod-pcd` |
-| ------------------------------------------------- |
+This package provides React UI for
+[`@pcd/pod-pcd`](https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/pod-pcd).
+See that package for more details on functionality.
 
-## 🛠 Install
-
-Install the `@pcd/pod-pcd-ui` package with npm:
-
-```bash
-npm i @pcd/pod-pcd-ui
-```
-
-or yarn:
-
-```bash
-yarn add @pcd/pod-pcd-ui
-```
+For a full introduction, see the [Developer Site](https://0xparc.notion.site/POD-GPC-Development-6547d2e60c184ad0984f933672246e0b).


### PR DESCRIPTION
This adds detailed docs to the README files of all POD/GPC related packages.  Most of the text content is borrowed from the developer page in Notion.  The bulk of the changes is creating a set of standard icons and links so that each package links to all of its resources, and also links to related packages.

Note that the README contents also shows upon the TypeDoc site at the top of the package.  That's good because it means no need to duplicate contents in class docs.  It's also why the header icons link to both TypeDoc and GitHub, since we don't know which one the reader may be coming from.
