### PR TITLE
Fixes broken doc site build

### DIFF
--- a/packages/tools/perftest/package.json
+++ b/packages/tools/perftest/package.json
@@ -5,7 +5,7 @@
   "license": "GPL-3.0-or-later",
   "scripts": {
     "start": "yarn ts-node src/index.ts",
-    "lint": "eslint \"**/*.ts{,x}\"",
+    "lint": "tsc --noEmit && eslint \"**/*.ts{,x}\"",
     "clean": "rm -rf dist node_modules *.tsbuildinfo"
   },
   "dependencies": {

--- a/packages/tools/perftest/package.json
+++ b/packages/tools/perftest/package.json
@@ -5,7 +5,8 @@
   "license": "GPL-3.0-or-later",
   "scripts": {
     "start": "yarn ts-node src/index.ts",
-    "lint": "tsc --noEmit && eslint \"**/*.ts{,x}\"",
+    "build": "tsc --noEmit",
+    "lint": "eslint \"**/*.ts{,x}\"",
     "clean": "rm -rf dist node_modules *.tsbuildinfo"
   },
   "dependencies": {

--- a/packages/tools/perftest/src/cases/GPCTimer.ts
+++ b/packages/tools/perftest/src/cases/GPCTimer.ts
@@ -82,6 +82,9 @@ async function setupProveArgs(): Promise<GPCPCDArgs> {
     id: {
       argumentType: ArgumentTypeName.String,
       value: uuid()
+    },
+    membershipLists: {
+      argumentType: ArgumentTypeName.String
     }
   } satisfies GPCPCDArgs;
 }


### PR DESCRIPTION
The docs site is failing to build as, due to a type change, code in the perftest package fails typechecking.

This was not causing a CI failure, because it doesn't get type-checked in the `build` phase (it has no `build` command) nor in the `lint` phase. I've added `tsc --noEmit` to the `lint` command (similar to what we do in `passport-client`) to ensure type-checking of this package during CI.