### PR TITLE
fix one-click login and related issues

### DIFF
--- a/apps/passport-client/components/screens/LoginScreens/OneClickLoginScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/OneClickLoginScreen.tsx
@@ -1,76 +1,8 @@
-import { useCallback, useEffect } from "react";
-import { useParams } from "react-router-dom";
-import { useDispatch, useSelf } from "../../../src/appHooks";
-import { MaybeModal } from "../../modals/Modal";
-import { AppContainer } from "../../shared/AppContainer";
-import { ScreenLoader } from "../../shared/ScreenLoader";
+import { useEffect } from "react";
 
 export function OneClickLoginScreen(): JSX.Element | null {
-  const dispatch = useDispatch();
-  const { email, code, targetFolder } = useParams();
-
-  const self = useSelf();
-
-  const redirectToTargetFolder = useCallback(() => {
-    if (targetFolder) {
-      window.location.hash = `#/?folder=${encodeURIComponent(targetFolder)}`;
-    } else {
-      window.location.hash = "#/";
-    }
-  }, [targetFolder]);
-
-  const handleOneClickLogin = useCallback(async () => {
-    if (!email || !code) {
-      return;
-    }
-    try {
-      await dispatch({
-        type: "one-click-login",
-        email,
-        code,
-        targetFolder
-      });
-    } catch (err) {
-      await dispatch({
-        type: "error",
-        error: {
-          title: "An error occured",
-          message: (err as Error).message || "An error occured"
-        }
-      });
-    }
-  }, [dispatch, email, code, targetFolder]);
-
   useEffect(() => {
-    if (self) {
-      if (email !== self.email) {
-        alert(
-          `You are already logged in as ${self.email}. Please log out and try navigating to the link again.`
-        );
-        window.location.hash = "#/";
-      } else {
-        redirectToTargetFolder();
-      }
-    } else if (!email || !code) {
-      window.location.hash = "#/";
-    } else {
-      handleOneClickLogin();
-    }
-  }, [
-    self,
-    targetFolder,
-    handleOneClickLogin,
-    redirectToTargetFolder,
-    email,
-    code
-  ]);
-
-  return (
-    <>
-      <MaybeModal fullScreen />
-      <AppContainer bg="primary">
-        <ScreenLoader />
-      </AppContainer>
-    </>
-  );
+    window.location.hash = "#/";
+  }, []);
+  return null;
 }

--- a/apps/passport-client/components/screens/LoginScreens/OneClickLoginScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/OneClickLoginScreen.tsx
@@ -1,8 +1,76 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { useDispatch, useSelf } from "../../../src/appHooks";
+import { MaybeModal } from "../../modals/Modal";
+import { AppContainer } from "../../shared/AppContainer";
+import { ScreenLoader } from "../../shared/ScreenLoader";
 
 export function OneClickLoginScreen(): JSX.Element | null {
+  const dispatch = useDispatch();
+  const { email, code, targetFolder } = useParams();
+
+  const self = useSelf();
+
+  const redirectToTargetFolder = useCallback(() => {
+    if (targetFolder) {
+      window.location.hash = `#/?folder=${encodeURIComponent(targetFolder)}`;
+    } else {
+      window.location.hash = "#/";
+    }
+  }, [targetFolder]);
+
+  const handleOneClickLogin = useCallback(async () => {
+    if (!email || !code) {
+      return;
+    }
+    try {
+      await dispatch({
+        type: "one-click-login",
+        email,
+        code,
+        targetFolder
+      });
+    } catch (err) {
+      await dispatch({
+        type: "error",
+        error: {
+          title: "An error occured",
+          message: (err as Error).message || "An error occured"
+        }
+      });
+    }
+  }, [dispatch, email, code, targetFolder]);
+
   useEffect(() => {
-    window.location.hash = "#/";
-  }, []);
-  return null;
+    if (self) {
+      if (email !== self.email) {
+        alert(
+          `You are already logged in as ${self.email}. Please log out and try navigating to the link again.`
+        );
+        window.location.hash = "#/";
+      } else {
+        redirectToTargetFolder();
+      }
+    } else if (!email || !code) {
+      window.location.hash = "#/";
+    } else {
+      handleOneClickLogin();
+    }
+  }, [
+    self,
+    targetFolder,
+    handleOneClickLogin,
+    redirectToTargetFolder,
+    email,
+    code
+  ]);
+
+  return (
+    <>
+      <MaybeModal fullScreen />
+      <AppContainer bg="primary">
+        <ScreenLoader />
+      </AppContainer>
+    </>
+  );
 }

--- a/apps/passport-server/migrations/77_user_backups.sql
+++ b/apps/passport-server/migrations/77_user_backups.sql
@@ -1,0 +1,11 @@
+create table if not exists user_backups (
+  uuid UUID primary key not null,
+  commitment varchar not null,
+  email varchar not null unique,
+  salt varchar,
+  extra_issuance boolean not null default false,
+  encryption_key varchar,
+  terms_agreed int,
+  time_created timestamp not null default now(),
+  time_updated timestamp not null default now()
+);

--- a/apps/passport-server/src/database/queries/saveUser.ts
+++ b/apps/passport-server/src/database/queries/saveUser.ts
@@ -40,7 +40,14 @@ export async function saveUserBackup(
     client,
     `INSERT INTO user_backups (uuid, commitment, email, salt, extra_issuance, encryption_key, terms_agreed)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
-ON CONFLICT (email) DO NOTHING
+ON CONFLICT (email) do update set
+uuid = $1,
+commitment = $2,
+salt = $4,
+extra_issuance = $5,
+encryption_key = $6,
+terms_agreed = $7,
+time_updated = now();
   `,
     [
       user.uuid,

--- a/apps/passport-server/src/database/queries/saveUser.ts
+++ b/apps/passport-server/src/database/queries/saveUser.ts
@@ -1,6 +1,31 @@
 import { Pool } from "postgres-pool";
 import { logger } from "../../util/logger";
+import { UserRow } from "../models";
 import { sqlQuery } from "../sqlQuery";
+
+export async function saveUserBackup(
+  client: Pool,
+  user: UserRow
+): Promise<void> {
+  logger(`saving user backup: ${JSON.stringify(user)}`);
+
+  await sqlQuery(
+    client,
+    `INSERT INTO user_backups (uuid, commitment, email, salt, extra_issuance, encryption_key, terms_agreed)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (email) DO NOTHING
+  `,
+    [
+      user.uuid,
+      user.commitment,
+      user.email,
+      user.salt,
+      user.extra_issuance,
+      user.encryption_key,
+      user.terms_agreed
+    ]
+  );
+}
 
 /**
  * Saves a new user. If a user with the given email already exists, overwrites their

--- a/apps/passport-server/src/database/queries/saveUser.ts
+++ b/apps/passport-server/src/database/queries/saveUser.ts
@@ -9,6 +9,33 @@ export async function saveUserBackup(
 ): Promise<void> {
   logger(`saving user backup: ${JSON.stringify(user)}`);
 
+  // INSERT INTO users (uuid, commitment, email, salt, extra_issuance, encryption_key, terms_agreed, time_created, time_updated)
+  // SELECT uuid, commitment, email, salt, extra_issuance, encryption_key, terms_agreed, time_created, time_updated
+  // FROM user_backups
+  // on conflict (email) do update set
+  // uuid = EXCLUDED.uuid,
+  // commitment = EXCLUDED.commitment,
+  // salt = EXCLUDED.salt,
+  // extra_issuance = EXCLUDED.extra_issuance,
+  // encryption_key = EXCLUDED.encryption_key,
+  // terms_agreed = EXCLUDED.terms_agreed,
+  // time_created = EXCLUDED.time_created,
+  // time_updated = EXCLUDED.time_updated;
+
+  // INSERT INTO users (uuid, commitment, email, salt, extra_issuance, encryption_key, terms_agreed, time_created, time_updated)
+  // SELECT uuid, commitment, email, salt, extra_issuance, encryption_key, terms_agreed, time_created, time_updated
+  // FROM user_backups
+  // where email = 'ivan@0xparc.org'
+  // on conflict (email) do update set
+  // uuid = EXCLUDED.uuid,
+  // commitment = EXCLUDED.commitment,
+  // salt = EXCLUDED.salt,
+  // extra_issuance = EXCLUDED.extra_issuance,
+  // encryption_key = EXCLUDED.encryption_key,
+  // terms_agreed = EXCLUDED.terms_agreed,
+  // time_created = EXCLUDED.time_created,
+  // time_updated = EXCLUDED.time_updated;
+
   await sqlQuery(
     client,
     `INSERT INTO user_backups (uuid, commitment, email, salt, extra_issuance, encryption_key, terms_agreed)

--- a/apps/passport-server/src/services/userService.ts
+++ b/apps/passport-server/src/services/userService.ts
@@ -291,15 +291,6 @@ export class UserService {
       );
     }
 
-    if (!(await this.emailTokenService.checkTokenCorrect(email, token))) {
-      throw new PCDHTTPError(
-        403,
-        autoRegister
-          ? `Invalid link. Please manually create an account with ${email}.`
-          : `Wrong token. If you got more than one email, use the latest one.`
-      );
-    }
-
     const existingUser = await fetchUserByEmail(this.context.dbPool, email);
 
     // Prevent accidental account re-creation/reset for one-click links clicked by existing users
@@ -307,6 +298,15 @@ export class UserService {
       throw new PCDHTTPError(
         403,
         `The email ${email} has already been registered. Please log in instead.`
+      );
+    }
+
+    if (!(await this.emailTokenService.checkTokenCorrect(email, token))) {
+      throw new PCDHTTPError(
+        403,
+        autoRegister
+          ? `Invalid link. Please manually create an account with ${email}.`
+          : `Wrong token. If you got more than one email, use the latest one.`
       );
     }
 

--- a/apps/passport-server/src/services/userService.ts
+++ b/apps/passport-server/src/services/userService.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 import { UserRow } from "../database/models";
 import { agreeTermsAndUnredactTickets } from "../database/queries/devconnect_pretix_tickets/devconnectPretixRedactedTickets";
 import { fetchEncryptedStorage } from "../database/queries/e2ee";
-import { upsertUser } from "../database/queries/saveUser";
+import { saveUserBackup, upsertUser } from "../database/queries/saveUser";
 import {
   deleteUserByEmail,
   fetchUserByCommitment,
@@ -128,8 +128,11 @@ export class UserService {
       const storage = await fetchEncryptedStorage(this.context.dbPool, blobKey);
       if (!storage) {
         logger(
-          `[USER_SERVICE] Deleting user with no storage: ${existingCommitment.email}`
+          `[USER_SERVICE] Deleting user with no storage: ${JSON.stringify(
+            existingCommitment
+          )}`
         );
+        await saveUserBackup(this.context.dbPool, existingCommitment);
         await deleteUserByEmail(this.context.dbPool, existingCommitment.email);
         existingCommitment = null;
       }
@@ -220,8 +223,11 @@ export class UserService {
       const storage = await fetchEncryptedStorage(this.context.dbPool, blobKey);
       if (!storage) {
         logger(
-          `[USER_SERVICE] Deleting user with no storage: ${existingUser.email}`
+          `[USER_SERVICE] Deleting user with no storage: ${JSON.stringify(
+            existingUser
+          )}`
         );
+        await saveUserBackup(this.context.dbPool, existingUser);
         await deleteUserByEmail(this.context.dbPool, existingUser.email);
         existingUser = null;
       }

--- a/apps/passport-server/src/services/userService.ts
+++ b/apps/passport-server/src/services/userService.ts
@@ -275,6 +275,15 @@ export class UserService {
       );
     }
 
+    if (!(await this.emailTokenService.checkTokenCorrect(email, token))) {
+      throw new PCDHTTPError(
+        403,
+        autoRegister
+          ? `Invalid link. Please manually create an account with ${email}.`
+          : `Wrong token. If you got more than one email, use the latest one.`
+      );
+    }
+
     const existingUser = await fetchUserByEmail(this.context.dbPool, email);
 
     // Prevent accidental account re-creation/reset for one-click links clicked by existing users
@@ -282,15 +291,6 @@ export class UserService {
       throw new PCDHTTPError(
         403,
         `The email ${email} has already been registered. Please log in instead.`
-      );
-    }
-
-    if (!(await this.emailTokenService.checkTokenCorrect(email, token))) {
-      throw new PCDHTTPError(
-        403,
-        autoRegister
-          ? `Invalid link. Please manually create an account with ${email}.`
-          : `Wrong token. If you got more than one email, use the latest one.`
       );
     }
 

--- a/apps/passport-server/src/services/userService.ts
+++ b/apps/passport-server/src/services/userService.ts
@@ -123,7 +123,10 @@ export class UserService {
     const newEmailToken =
       await this.emailTokenService.saveNewTokenForEmail(email);
     let existingCommitment = await fetchUserByEmail(this.context.dbPool, email);
-    if (existingCommitment?.encryption_key) {
+    if (
+      existingCommitment?.encryption_key &&
+      process.env.DELETE_MISSING_USERS === "true"
+    ) {
       const blobKey = await getHash(existingCommitment.encryption_key);
       const storage = await fetchEncryptedStorage(this.context.dbPool, blobKey);
       if (!storage) {
@@ -218,7 +221,10 @@ export class UserService {
     }
 
     let existingUser = await fetchUserByEmail(this.context.dbPool, email);
-    if (existingUser?.encryption_key) {
+    if (
+      existingUser?.encryption_key &&
+      process.env.DELETE_MISSING_USERS === "true"
+    ) {
       const blobKey = await getHash(existingUser.encryption_key);
       const storage = await fetchEncryptedStorage(this.context.dbPool, blobKey);
       if (!storage) {

--- a/apps/passport-server/src/services/userService.ts
+++ b/apps/passport-server/src/services/userService.ts
@@ -127,6 +127,9 @@ export class UserService {
       const blobKey = await getHash(existingCommitment.encryption_key);
       const storage = await fetchEncryptedStorage(this.context.dbPool, blobKey);
       if (!storage) {
+        logger(
+          `[USER_SERVICE] Deleting user with no storage: ${existingCommitment.email}`
+        );
         await deleteUserByEmail(this.context.dbPool, existingCommitment.email);
         existingCommitment = null;
       }
@@ -216,6 +219,9 @@ export class UserService {
       const blobKey = await getHash(existingUser.encryption_key);
       const storage = await fetchEncryptedStorage(this.context.dbPool, blobKey);
       if (!storage) {
+        logger(
+          `[USER_SERVICE] Deleting user with no storage: ${existingUser.email}`
+        );
         await deleteUserByEmail(this.context.dbPool, existingUser.email);
         existingUser = null;
       }

--- a/turbo.json
+++ b/turbo.json
@@ -220,6 +220,7 @@
     "GPC_ARTIFACTS_CONFIG_OVERRIDE",
     "ZUPOLL_API_KEY",
     "VOUCHER_API_KEY",
+    "DELETE_MISSING_USERS",
     "//// add env vars above this line ////"
   ]
 }


### PR DESCRIPTION
### fix confirmed works for acct. w/out password
- create account 
- copy/paste blob key from network tab
- log out
- delete blob key
- attempt logging in again
- resulting situation prior to fixes in this PR
  <img width="200" alt="Screenshot 2024-05-31 at 5 44 38 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/4cdacf37-597e-4e8a-9f97-64f5efd8952f">
- resulting situation after this PR (success)
  <img width="200" alt="Screenshot 2024-05-31 at 5 46 06 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/15147c07-b0f6-4c12-bf8e-d986791c0abf">

### fix confirmed works for acct. w/ password
- create account 
- copy/paste blob key from network tab
- set password
- log out
- the case when user HAS set a password is actually robust to this problem, in that it presents to user as 'password incorrect', at which point they can click 'forgot password' and proceed.

### fix compatible for one click w/ and w/out password

- tested both an acct with and w/out password whose blob was deleted
- in case w/out password, one click account creation succeeds
- in case w/ password, prompts for password, but all passwords incorrect, which is resolveable via password reset
 
  

