### PR TITLE
fix copy of zupoll summer config name to not say member resident and just say resident

### DIFF
--- a/packages/lib/zupoll-shared/src/configs/2024_0xparc_summer.ts
+++ b/packages/lib/zupoll-shared/src/configs/2024_0xparc_summer.ts
@@ -6,7 +6,7 @@ export function make0xpSummer(
   ZUPASS_SERVER_URL: string
 ): LoginConfig[] {
   const PARC_SUMMER_CONFIG_ID = "0xPARC Summer";
-  const PARC_SUMMER_CONFIG_NAME = "0xPARC Summer Member";
+  const PARC_SUMMER_CONFIG_NAME = "0xPARC Summer";
   const PARC_SUMMER_RESIDENTS_NAME = "All Polls";
   const PARC_SUMMER_RESIDENTS_DESCRIPTION =
     "Polls created by someone at 0xPARC Summer";


### PR DESCRIPTION
fixes this
<img width="356" alt="Screenshot 2024-05-31 at 11 59 34 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/3e3154be-efca-46ae-8046-4d7754f896c5">
