### PR TITLE
Reduce modal spacing so logout button is visible

### DIFF
--- a/apps/passport-client/components/modals/InvalidUserModal.tsx
+++ b/apps/passport-client/components/modals/InvalidUserModal.tsx
@@ -28,7 +28,7 @@ export function InvalidUserModal(): JSX.Element {
   return (
     <Container>
       <H2>Invalid Zupass</H2>
-      <Spacer h={24} />
+      <Spacer h={16} />
       <p>Your Zupass is in an invalid state. This can happen when:</p>
       <ul>
         <li>You reset your account on another device.</li>
@@ -53,7 +53,7 @@ export function InvalidUserModal(): JSX.Element {
 }
 
 const Container = styled.div`
-  padding: 24px;
+  padding: 12px;
   p {
     margin-bottom: 8px;
   }

--- a/apps/passport-client/components/modals/Modal.tsx
+++ b/apps/passport-client/components/modals/Modal.tsx
@@ -145,7 +145,7 @@ export function Modal(props: {
             <GrClose style={{ height: "20px", width: "20px", color: "#fff" }} />
           </CircleButton>
         )}
-        <Spacer h={32} />
+        <Spacer h={16} />
         {props.children}
       </ModalWrap>
     </ModalBg>
@@ -168,7 +168,7 @@ const ModalBg = styled.div<{ $fullScreen?: boolean }>`
     $fullScreen
       ? css``
       : css`
-          padding: 32px;
+          padding: 16px 32px;
         `}
 `;
 
@@ -180,7 +180,7 @@ const ModalWrap = styled.div<{ fullScreen?: boolean }>`
   );
   width: 100%;
   max-width: 420px;
-  margin: 64px auto;
+  margin: 8px auto;
   min-height: 480px;
   padding: ${(props): string => (props.fullScreen ? "0" : "12px")};
   border-radius: 12px;


### PR DESCRIPTION
Makes the logout button fit on an iPhone SE:

<img width="771" alt="image" src="https://github.com/proofcarryingdata/zupass/assets/20022/23bf9f07-880f-40a3-8db5-a4ccca6e6a29">
