### PR TITLE
Experiment: Add initialArgs to getProveDisplayOptions

### DIFF
--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -140,7 +140,7 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
       <PCDArgs
         args={args}
         setArgs={setArgs}
-        options={pcdPackage?.getProveDisplayOptions?.()?.defaultArgs}
+        options={pcdPackage?.getProveDisplayOptions?.(args)?.defaultArgs}
       />
 
       {folder && (

--- a/apps/passport-client/components/shared/PCDArgs.tsx
+++ b/apps/passport-client/components/shared/PCDArgs.tsx
@@ -58,7 +58,7 @@ export function PCDArgs<T extends PCDPackage>({
   const [showAll, setShowAll] = useState(false);
   const [visible, hidden] = _.partition(
     Object.entries(args),
-    ([key]) => options?.[key]?.defaultVisible ?? true
+    ([key]) => options?.[key]?.defaultVisible ?? true // ART_DBG: defaultVisble used here
   );
 
   return (
@@ -130,7 +130,7 @@ export function ArgInput<T extends PCDPackage, ArgName extends string>({
   const isValid = useCallback(
     <A extends Argument<ArgumentTypeName, unknown>>(value: RawValueType<A>) =>
       (arg.validatorParams &&
-        defaultArg?.validate?.(value, arg.validatorParams)) ??
+        defaultArg?.validate?.(value, arg.validatorParams)) ?? // ART_DBG: validate used here iff validatorParams is present in input args
       true,
     [defaultArg, arg.validatorParams]
   );
@@ -138,7 +138,7 @@ export function ArgInput<T extends PCDPackage, ArgName extends string>({
   const props = useMemo<ArgInputProps<typeof arg>>(
     () => ({
       // merge arg with default value
-      arg: { displayName: _.startCase(argName), ...(defaultArg || {}), ...arg },
+      arg: { displayName: _.startCase(argName), ...(defaultArg || {}), ...arg }, // ART_DBG: All other fields of defaultArgs get filled in here, then can be overridden by input args
       argName,
       setArg,
       isValid,

--- a/packages/lib/pcd-types/src/pcd.ts
+++ b/packages/lib/pcd-types/src/pcd.ts
@@ -95,7 +95,7 @@ export interface PCDPackage<
    * Given the arguments passed into {@link PCDPackage#prove}, returns options on how
    * to render the Prove Screen for this {@link PCDPackage}.
    */
-  getProveDisplayOptions?: () => ProveDisplayOptions<A>;
+  getProveDisplayOptions?: (initialArgs: A) => ProveDisplayOptions<A>;
 
   /**
    * This is effectively a factory for instances of the {@link PCD} that this {@link PCDPackage}

--- a/packages/pcd/gpc-pcd/src/GPCPCDPackage.ts
+++ b/packages/pcd/gpc-pcd/src/GPCPCDPackage.ts
@@ -244,7 +244,10 @@ export function getDisplayOptions(pcd: GPCPCD): DisplayOptions {
   };
 }
 
-export function getProveDisplayOptions(): ProveDisplayOptions<GPCPCDArgs> {
+export function getProveDisplayOptions(
+  initialArgs: GPCPCDArgs
+): ProveDisplayOptions<GPCPCDArgs> {
+  console.log("[ART_DBG]", Object.keys(initialArgs));
   return {
     defaultArgs: {
       proofConfig: {


### PR DESCRIPTION
Draft to share an idea with @ax0 regarding #1757.

Providing a copy of the input args to getProveDisplayOptions could allow it to set up validators and other parameters for the dynamically-named args introduced in #1757.  It looks like TypeScript is permissive about ignoring args, allowing PCD packages which don't need the new arg to not declare it.

I also put some comments marking my learnings about where the output of getProveDisplayOptions goes in the UI code, in case that's helpful for future investgatations.