### PR TITLE
Add "pod_" prefix to types in raw value encoding

### DIFF
--- a/packages/lib/pod/src/podTypes.ts
+++ b/packages/lib/pod/src/podTypes.ts
@@ -25,7 +25,7 @@ export const EDDSA_PUBKEY_TYPE_STRING = "eddsa_pubkey";
 /**
  * Regex matching legal values for types encoded as strings by
  * {@link podValueToRawValue}. This matches strings of the form
- * `${PODName}:${string}`.
+ * `pod_${PODName}:${string}`.
  */
 export const POD_STRING_TYPE_REGEX = new RegExp(/pod_([A-Za-z_]\w*):(.*)$/);
 

--- a/packages/lib/pod/src/podTypes.ts
+++ b/packages/lib/pod/src/podTypes.ts
@@ -23,10 +23,11 @@ export type POD_VALUE_STRING_TYPE_IDENTIFIER = "eddsa_pubkey" | "string";
 export const EDDSA_PUBKEY_TYPE_STRING = "eddsa_pubkey";
 
 /**
- * Regex matching legal values for types encoded as strings. This matches
- * strings of the form `${PODName}:${string}`.
+ * Regex matching legal values for types encoded as strings by
+ * {@link podValueToRawValue}. This matches strings of the form
+ * `${PODName}:${string}`.
  */
-export const POD_STRING_TYPE_REGEX = new RegExp(/([A-Za-z_]\w*):(.*)$/);
+export const POD_STRING_TYPE_REGEX = new RegExp(/pod_([A-Za-z_]\w*):(.*)$/);
 
 /**
  * POD value for a user-specififed string.  String values can contain any

--- a/packages/lib/pod/src/podUtil.ts
+++ b/packages/lib/pod/src/podUtil.ts
@@ -426,12 +426,12 @@ export function deserializePODEntries(serializedEntries: string): PODEntries {
  */
 export function podValueToRawValue(podValue: PODValue): PODRawValue {
   if (podValue.type === EDDSA_PUBKEY_TYPE_STRING) {
-    return `${EDDSA_PUBKEY_TYPE_STRING}:${podValue.value}`;
+    return `pod_${EDDSA_PUBKEY_TYPE_STRING}:${podValue.value}`;
   } else if (
     podValue.type === "string" &&
     podValue.value.match(POD_STRING_TYPE_REGEX)
   ) {
-    return `string:${podValue.value}`;
+    return `pod_string:${podValue.value}`;
   } else {
     return podValue.value;
   }


### PR DESCRIPTION
Resolves https://linear.app/0xparc-pcd/issue/0XP-928/pod-value-type-prefixes-collide-with-urls

Using `${type}:value` as a prefix, and checking for unknown types, has the unfortunate property of colliding with URLs, because "https:" isn't a known POD type.  This is going to be error-prone for devs using simplified JSON encoding.

I thought about alternate special characters, but I think the most reliable way to ensure people don't accidentally run into a POD-related field when they're not doing POD-related stuff is to add a `pod_` prefix, like we do with PODNames.  The format is now `pod_${type}:value`.