### PR TITLE
Use unpadded base64 instead of base64url

### DIFF
--- a/apps/consumer-client/src/pages/examples/add-pcd.tsx
+++ b/apps/consumer-client/src/pages/examples/add-pcd.tsx
@@ -56,12 +56,13 @@ import { sendZupassRequest } from "../../util";
 export default function Page(): JSX.Element {
   const [signedMessage, setSignedMessage] = useState("1");
   const [folder, setFolder] = useState("");
-  const [podContent, setPodContent] = useState(EXAMPLE_POD_CONTENT);
+  const [podContent, setPODContent] = useState(EXAMPLE_POD_CONTENT);
   const [gpcConfig, setGPCConfig] = useState(EXAMPLE_GPC_CONFIG);
   const [membershipLists, setMembershipLists] = useState(
     EXAMPLE_MEMBERSHIP_LISTS
   );
-  const [podFolder, setPodFolder] = useState("Test PODs");
+  const [podFolder, setPODFolder] = useState("Test PODs");
+  const [gpcFolder, setGPCFolder] = useState("Test GPCs");
 
   return (
     <div>
@@ -141,19 +142,22 @@ export default function Page(): JSX.Element {
         <br />
         <br />
         <button onClick={addEdDSAPCD}>add a new EdDSA signature proof</button>
+      </ExampleContainer>
+      <ExampleContainer>
+        POD + GPC Examples
         <br />
         <br />
         POD content to sign: <br />
         <button
           onClick={() => {
-            setPodContent(EXAMPLE_POD_CONTENT);
+            setPODContent(EXAMPLE_POD_CONTENT);
           }}
         >
           basic example
         </button>
         <button
           onClick={() => {
-            setPodContent(EXAMPLE_POD_CONTENT_WITH_DISPLAY);
+            setPODContent(EXAMPLE_POD_CONTENT_WITH_DISPLAY);
           }}
         >
           zupass card example
@@ -164,9 +168,29 @@ export default function Page(): JSX.Element {
           rows={15}
           value={podContent}
           onChange={(e): void => {
-            setPodContent(e.target.value);
+            setPODContent(e.target.value);
           }}
         />
+        <br />
+        <label>
+          Folder to add POD to:
+          <input
+            type="text"
+            value={podFolder}
+            placeholder="Enter folder name..."
+            style={{ marginLeft: "16px" }}
+            onChange={(e): void => {
+              setPODFolder(e.target.value);
+            }}
+          />
+        </label>
+        <button
+          onClick={(): Promise<void> =>
+            addPODPCD(podContent, podFolder.length > 0 ? podFolder : undefined)
+          }
+        >
+          add a new POD to Zupass
+        </button>
         <br />
         GPC Proof config: <br />
         <textarea
@@ -189,32 +213,25 @@ export default function Page(): JSX.Element {
         />
         <br />
         <label>
-          Folder to add POD/GPC to:
+          Folder to add GPC to:
           <input
             type="text"
-            value={podFolder}
+            value={gpcFolder}
             placeholder="Enter folder name..."
             style={{ marginLeft: "16px" }}
             onChange={(e): void => {
-              setPodFolder(e.target.value);
+              setGPCFolder(e.target.value);
             }}
           />
         </label>
         <br />
         <button
           onClick={(): Promise<void> =>
-            addPODPCD(podContent, podFolder.length > 0 ? podFolder : undefined)
-          }
-        >
-          add a new POD to Zupass
-        </button>
-        <button
-          onClick={(): Promise<void> =>
             addGPCPCD(
               podContent,
               gpcConfig,
               membershipLists,
-              podFolder.length > 0 ? podFolder : undefined
+              gpcFolder.length > 0 ? gpcFolder : undefined
             )
           }
         >

--- a/packages/lib/pod/src/podCrypto.ts
+++ b/packages/lib/pod/src/podCrypto.ts
@@ -86,15 +86,16 @@ export function podMerkleTreeHash(left: bigint, right: bigint): bigint {
 
 /**
  * Encodes a private key to a string.  The input must be 32 bytes.  The output
- * is represented as URL-safe Base64 by default.
+ * is represented as unpadded Base64 by default.
  *
  * @param rawPrivateKey the private key bytes
- * @param encoding one of the supported encodings to use
+ * @param encoding one of the supported encodings to use, as per
+ *   {@link encodeBytes}.
  * @throws TypeError if the size of the buffer is incorrect.
  */
 export function encodePrivateKey(
   rawPrivateKey: Uint8Array,
-  encoding: CryptoBytesEncoding = "base64url"
+  encoding: CryptoBytesEncoding = "base64"
 ): string {
   if (!((rawPrivateKey as unknown) instanceof Uint8Array)) {
     throw TypeError("Private key must be Buffer or Uint8Array.");
@@ -107,7 +108,7 @@ export function encodePrivateKey(
 
 /**
  * Decodes a private key's bytes from a string.  The input must be 32 bytes,
- * represented as hex, Base64, or URL-safe Base64.  Base64 padding is optional.
+ * represented as hex or Base64.  Base64 padding is optional.
  *
  * @param privateKey the private key string to decode
  * @throws TypeError if the private key format is incorrect.
@@ -123,14 +124,14 @@ export function decodePrivateKey(privateKey: string): Buffer {
 
 /**
  * Encodes an EdDSA public key into a compact string represenation.  The output
- * is 32 bytes, represented as URL-safe Base64 by default.
+ * is 32 bytes, represented as unpadded Base64 by default.
  *
  * @param rawPublicKey the EdDSA public key to encode
  * @param encoding one of the supported encodings to use
  */
 export function encodePublicKey(
   rawPublicKey: Point<BigNumber>,
-  encoding: CryptoBytesEncoding = "base64url"
+  encoding: CryptoBytesEncoding = "base64"
 ): string {
   return encodeBytes(
     leBigIntToBuffer(packPublicKey(rawPublicKey), 32),
@@ -140,8 +141,7 @@ export function encodePublicKey(
 
 /**
  * Decodes a public key packed by {@encodePublicKey}.  The input must be
- * 32 bytes, represented as hex, Base64, or URL-safe Base64.  Base64 padding is
- * optional.
+ * 32 bytes, represented as hex or Base64.  Base64 padding is optional.
  *
  * @param publicKey the public key string to decode
  * @throws TypeError if the public key format is incorrect.
@@ -165,22 +165,21 @@ export function decodePublicKey(publicKey: string): Point<bigint> {
 
 /**
  * Encodes an EdDSA signature into a compact string representation.
- * The output is represented in URL-safe Base64 by default.
+ * The output is represented in unpadded Base64 by default.
  *
  * @param rawSignature the EdDSA signature to encode
  * @param encoding one of the supported encodings to use
  */
 export function encodeSignature(
   rawSignature: Signature,
-  encoding: CryptoBytesEncoding = "base64url"
+  encoding: CryptoBytesEncoding = "base64"
 ): string {
   return encodeBytes(packSignature(rawSignature), encoding);
 }
 
 /**
  * Decodes a signature produced by {@link encodeSignature}.  The input must be
- * 64 bytes, represented as hex, Base64, or URL-safe Base64.  Base64 padding is
- * optional.
+ * 64 bytes, represented as hex or Base64.  Base64 padding is optional.
  *
  * @param encodedSignature the signature string to decode
  * @throws TypeError if the signature format is incorrect
@@ -203,7 +202,7 @@ export function decodeSignature(encodedSignature: string): Signature<bigint> {
  * @param privateKey the signer's private key, which is 32 bytes encoded as
  *   per {@link encodePrivateKey}.
  * @returns The signature as well as the signer's public key for inclusion
- *   in the POD.  The signature is 64 bytes represented in URL-safe Base64.
+ *   in the POD.  The signature is 64 bytes represented in unpadded Base64.
  * @throws TypeError if any of the individual arguments is incorrectly formatted
  */
 export function signPODRoot(
@@ -230,9 +229,9 @@ export function signPODRoot(
  *
  * @param root the root hash (content ID) of the POD.
  * @param signature the signature in packed form, which is 64 bytes represented
- *   in URL-safe Base64.
+ *   in hex or Base64.  Base64 padding is optional.
  * @param publicKey the signer's public key in packed form, which is 32 bytes
- *   represented in URL-safe Base64.
+ *   represented in hex or Base64.  Base64 padding is optional.
  * @returns `true` if the signature is valid
  * @throws TypeError if any of the individual arguments incorrectly formatted
  */

--- a/packages/lib/pod/test/common.ts
+++ b/packages/lib/pod/test/common.ts
@@ -15,7 +15,7 @@ export const expectedPublicKeyPoint = [
 
 export const expectedPublicKeyHex =
   "c433f7a696b7aa3a5224efb3993baf0ccd9e92eecee0c29a3f6c8208a9e81d9e";
-export const expectedPublicKey = "xDP3ppa3qjpSJO-zmTuvDM2eku7O4MKaP2yCCKnoHZ4";
+export const expectedPublicKey = "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4";
 
 export const ownerIdentity = new Identity(
   '["329061722381819402313027227353491409557029289040211387019699013780657641967", "99353161014976810914716773124042455250852206298527174581112949561812190422"]'
@@ -46,7 +46,7 @@ export const expectedContentID1 =
 export const expectedSignature1Hex =
   "64abaf261621e095cda8aaadd6e4bdf6501545e87f6cd923bf7e5e0f7295032b0138ec803350639b0a04de9c26fc2b8232f3f46b5b7486b69e02c4de06398601";
 export const expectedSignature1 =
-  "ZKuvJhYh4JXNqKqt1uS99lAVReh_bNkjv35eD3KVAysBOOyAM1BjmwoE3pwm_CuCMvP0a1t0hraeAsTeBjmGAQ";
+  "ZKuvJhYh4JXNqKqt1uS99lAVReh/bNkjv35eD3KVAysBOOyAM1BjmwoE3pwm/CuCMvP0a1t0hraeAsTeBjmGAQ";
 
 export const sampleEntries2 = {
   attendee: { type: "cryptographic", value: ownerIdentity.commitment },
@@ -64,7 +64,7 @@ export const expectedContentID2 =
 export const expectedSignature2Hex =
   "4febca252ff7e55c29bbada47b8b4b32f667e1270eb77f3a9b0f8ee73bebe689eb89d8ff85c4abd22bf32da15ad7f7fbf2c7e7b1d40ade685cb39c990f9f8b00";
 export const expectedSignature2 =
-  "T-vKJS_35Vwpu62ke4tLMvZn4ScOt386mw-O5zvr5onridj_hcSr0ivzLaFa1_f78sfnsdQK3mhcs5yZD5-LAA";
+  "T+vKJS/35Vwpu62ke4tLMvZn4ScOt386mw+O5zvr5onridj/hcSr0ivzLaFa1/f78sfnsdQK3mhcs5yZD5+LAA";
 
 export const testStringsToHash = [
   "",
@@ -159,45 +159,22 @@ export const testPrivateKeysBase64 = [
   "V5QnFjAO3EQu7inyDWcdx7wSo1h88Lh5qPUGHjgxbrs"
 ];
 
-// All the same keys above in base64url with padding.
-export const testPrivateKeysBase64urlpad = [
-  "AAECAwQFBgcICQABAgMEBQYHCAkAAQIDBAUGBwgJAAE=",
-  "ABEiM0RVZneImaq7zN3u_wARIjNEVWZ3iJmqu8zd7v8=",
-  "_-7dzLuqmYh3ZlVEMyIRAP_u3cy7qpmId2ZVRDMiEQA=",
-  "T3ClvQ4tLE_jP4HhVBzZOJDnSuoORdzhXoJ5rQCiP-U=",
-  "M9ZA-Vdld0H8AnezqKt-8iovWmsDjV9A3CmPGoENz-s=",
-  "sHOAQ8svPZjLWRD69mhhoSzXeG4hNPrxWsQvOfIJnU8=",
-  "QoBZoSREunMghMkvvKHq9pBmN25UX6S6Z4DEFCnSc3A=",
-  "4i-x6-f1MyxlmYgQMlb9v-kUUqwzfrC2A_tg5UdS5KI=",
-  "iWSS2vRAGZzvUKpLs2R6HxLLbOXlON4ivGNU9-eFtAI=",
-  "Kk1flerJ5MHjat_ayTw-fbbZR2wIh8X4T3p6k-e-v6w=",
-  "6NdvoIgadPy31yIqoaxUYTcxSsVZ0_9cEmDR4VHuZvE=",
-  "GVezUlTqulLuwIAj5oycYUmoYBC25WNzZoQf8PnhBx8=",
-  "V5QnFjAO3EQu7inyDWcdx7wSo1h88Lh5qPUGHjgxbrs="
-];
-
-// All the same keys above in base64url without padding.
-export const testPrivateKeysBase64url = [
-  "AAECAwQFBgcICQABAgMEBQYHCAkAAQIDBAUGBwgJAAE",
-  "ABEiM0RVZneImaq7zN3u_wARIjNEVWZ3iJmqu8zd7v8",
-  "_-7dzLuqmYh3ZlVEMyIRAP_u3cy7qpmId2ZVRDMiEQA",
-  "T3ClvQ4tLE_jP4HhVBzZOJDnSuoORdzhXoJ5rQCiP-U",
-  "M9ZA-Vdld0H8AnezqKt-8iovWmsDjV9A3CmPGoENz-s",
-  "sHOAQ8svPZjLWRD69mhhoSzXeG4hNPrxWsQvOfIJnU8",
-  "QoBZoSREunMghMkvvKHq9pBmN25UX6S6Z4DEFCnSc3A",
-  "4i-x6-f1MyxlmYgQMlb9v-kUUqwzfrC2A_tg5UdS5KI",
-  "iWSS2vRAGZzvUKpLs2R6HxLLbOXlON4ivGNU9-eFtAI",
-  "Kk1flerJ5MHjat_ayTw-fbbZR2wIh8X4T3p6k-e-v6w",
-  "6NdvoIgadPy31yIqoaxUYTcxSsVZ0_9cEmDR4VHuZvE",
-  "GVezUlTqulLuwIAj5oycYUmoYBC25WNzZoQf8PnhBx8",
-  "V5QnFjAO3EQu7inyDWcdx7wSo1h88Lh5qPUGHjgxbrs"
-];
-
-export const testPrivateKeys = testPrivateKeysBase64url;
+export const testPrivateKeys = testPrivateKeysBase64;
 
 export const testPrivateKeysAllFormats = testPrivateKeysHex.concat(
   testPrivateKeysBase64pad,
-  testPrivateKeysBase64,
-  testPrivateKeysBase64urlpad,
-  testPrivateKeysBase64url
+  testPrivateKeysBase64
 );
+
+/**
+ * Strip trailing `=` padding from Base64.
+ *
+ * Intentionally distinct from podUtil's stripBase64Padding, to avoid testing
+ * code against itself.
+ */
+export function stripB64(encoded: string): string {
+  while (encoded.endsWith("=")) {
+    encoded = encoded.slice(0, encoded.length - 1);
+  }
+  return encoded;
+}

--- a/packages/lib/pod/test/podCrypto.spec.ts
+++ b/packages/lib/pod/test/podCrypto.spec.ts
@@ -45,11 +45,11 @@ import {
   privateKey,
   privateKeyHex,
   sampleEntries1,
+  stripB64,
   testIntsToHash,
   testPrivateKeys,
   testPrivateKeysAllFormats,
-  testPrivateKeysBase64pad,
-  testPrivateKeysBase64url,
+  testPrivateKeysBase64,
   testPrivateKeysHex,
   testPublicKeysToHash,
   testStringsToHash
@@ -197,7 +197,7 @@ describe("podCrypto encoding/decoding should work", async function () {
       expect(encoded).to.have.length(43);
       checkPrivateKeyFormat(encoded);
       expect(encoded).to.eq(
-        testPrivateKeysBase64url[i % testPrivateKeysBase64url.length]
+        testPrivateKeysBase64[i % testPrivateKeysBase64.length]
       );
     }
   });
@@ -212,7 +212,7 @@ describe("podCrypto encoding/decoding should work", async function () {
       }
       const encoded = encodePrivateKey(asUint8Array);
       expect(encoded).to.eq(
-        testPrivateKeysBase64url[i % testPrivateKeysBase64url.length]
+        testPrivateKeysBase64[i % testPrivateKeysBase64.length]
       );
     }
   });
@@ -232,18 +232,11 @@ describe("podCrypto encoding/decoding should work", async function () {
       checkPrivateKeyFormat(encodedHex);
 
       const encodedBase64 = encodePrivateKey(decoded, "base64");
-      expect(encodedBase64).to.eq(testPrivateKeysBase64pad[i]);
+      expect(encodedBase64).to.eq(testPrivateKeysBase64[i]);
       expect(decodePrivateKey(encodedBase64)).to.deep.eq(
         decodePrivateKey(testPrivateKey)
       );
       checkPrivateKeyFormat(encodedBase64);
-
-      const encodedBase64URL = encodePrivateKey(decoded, "base64url");
-      expect(encodedBase64URL).to.eq(testPrivateKeysBase64url[i]);
-      expect(decodePrivateKey(encodedBase64URL)).to.deep.eq(
-        decodePrivateKey(testPrivateKey)
-      );
-      checkPrivateKeyFormat(encodedBase64URL);
     }
   });
 
@@ -316,7 +309,7 @@ describe("podCrypto encoding/decoding should work", async function () {
       const decodedPrivateKey = decodePrivateKey(testPrivateKey);
       const rawPublicKey = derivePublicKey(decodedPrivateKey);
 
-      for (const encoding of ["hex", "base64", "base64url"]) {
+      for (const encoding of ["hex", "base64"]) {
         const encoded = encodePublicKey(
           rawPublicKey,
           encoding as CryptoBytesEncoding
@@ -402,7 +395,7 @@ describe("podCrypto encoding/decoding should work", async function () {
       const message = podIntHash(testIntsToHash[0]);
       const rawSig = signMessage(decodePrivateKey(testPrivateKey), message);
 
-      for (const encoding of ["hex", "base64", "base64url"]) {
+      for (const encoding of ["hex", "base64"]) {
         const encoded = encodeSignature(
           rawSig,
           encoding as CryptoBytesEncoding
@@ -462,27 +455,27 @@ describe("podCrypto encoding/decoding should work", async function () {
   });
 
   it("double-check expected values vs. hex originals", function () {
-    expect(Buffer.from(privateKeyHex, "hex").toString("base64url")).to.eq(
-      privateKey
-    );
+    expect(
+      stripB64(Buffer.from(privateKeyHex, "hex").toString("base64"))
+    ).to.eq(privateKey);
     expect(encodePrivateKey(decodePrivateKey(privateKeyHex))).to.eq(privateKey);
 
     expect(
-      Buffer.from(expectedPublicKeyHex, "hex").toString("base64url")
+      stripB64(Buffer.from(expectedPublicKeyHex, "hex").toString("base64"))
     ).to.eq(expectedPublicKey);
     expect(encodePublicKey(decodePublicKey(expectedPublicKeyHex))).to.eq(
       expectedPublicKey
     );
 
     expect(
-      Buffer.from(expectedSignature1Hex, "hex").toString("base64url")
+      stripB64(Buffer.from(expectedSignature1Hex, "hex").toString("base64"))
     ).to.eq(expectedSignature1);
     expect(encodeSignature(decodeSignature(expectedSignature1Hex))).to.eq(
       expectedSignature1
     );
 
     expect(
-      Buffer.from(expectedSignature2Hex, "hex").toString("base64url")
+      stripB64(Buffer.from(expectedSignature2Hex, "hex").toString("base64"))
     ).to.eq(expectedSignature2);
     expect(encodeSignature(decodeSignature(expectedSignature2Hex))).to.eq(
       expectedSignature2
@@ -610,7 +603,7 @@ describe("podCrypto use of zk-kit should be compatible with EdDSAPCD", async fun
     );
 
     // EdDSAPCD represents its signatures in hex, not Base64.
-    const hexSignature = Buffer.from(signature, "base64url").toString("hex");
+    const hexSignature = Buffer.from(signature, "base64").toString("hex");
 
     expect(stringifiedPublicKey).to.deep.eq(pcd.claim.publicKey);
     expect(hexSignature).to.deep.eq(pcd.proof.signature);

--- a/packages/lib/pod/test/podUtil.spec.ts
+++ b/packages/lib/pod/test/podUtil.spec.ts
@@ -59,7 +59,7 @@ describe("podUtil input checkers should work", async function () {
       undefined as unknown as string,
       123 as unknown as string,
       123n as unknown as string,
-      Buffer.from(privateKey, "base64url") as unknown as string,
+      Buffer.from(privateKey, "base64") as unknown as string,
       "=V5QnFjAO3EQu7inyDWcdx7wSo1h88Lh5qPUGHjgxbrs",
       "V5QnFjAO3EQu7inyDWcdx7wSo1h88Lh5qPUGHjgxbrs====="
     ];
@@ -94,7 +94,7 @@ describe("podUtil input checkers should work", async function () {
       undefined as unknown as string,
       123 as unknown as string,
       123n as unknown as string,
-      Buffer.from(expectedPublicKey, "base64url") as unknown as string,
+      Buffer.from(expectedPublicKey, "base64") as unknown as string,
       "=V5QnFjAO3EQu7inyDWcdx7wSo1h88Lh5qPUGHjgxbrs",
       "V5QnFjAO3EQu7inyDWcdx7wSo1h88Lh5qPUGHjgxbrs====="
     ];

--- a/packages/pcd/pod-pcd/test/PODPCD.spec.ts
+++ b/packages/pcd/pod-pcd/test/PODPCD.spec.ts
@@ -8,7 +8,7 @@ import { PODPCD, PODPCDPackage, prove } from "../src";
 // Key borrowed from https://github.com/iden3/circomlibjs/blob/4f094c5be05c1f0210924a3ab204d8fd8da69f49/test/eddsa.js#L103
 export const privateKey = "AAECAwQFBgcICQABAgMEBQYHCAkAAQIDBAUGBwgJAAE"; // hex 0001020304050607080900010203040506070809000102030405060708090001
 
-export const expectedPublicKey = "xDP3ppa3qjpSJO-zmTuvDM2eku7O4MKaP2yCCKnoHZ4";
+export const expectedPublicKey = "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4";
 
 export const sampleEntries = {
   E: { type: "cryptographic", value: 123n },


### PR DESCRIPTION
The `base64url` encoding turns out not to be supported by the polyfilled Buffer implementation we use in a browser, or even the one in the "buffer" package, so I'm getting rid of it.  Instead I'm manually stripping padding off of base64, which is what I cared about from base64url anyway.  Note that decoding always accepts unpadded input regardless.

Tested all of the POD operations in consumer-client this time to be sure encoding and decoding work as expected.

Flagging @robknight to review since he reviewed the original version.
CC @ichub since this fixes the issue you ran into in passport-client.
CC @ax0 in case this impacts your ongoing work.  Note that our default test private key conveniently contains none of the characters which differ between base64 and base64url, so copies of it around our codebase don't need to be updated.