### PR TITLE
various app copy changes

### DIFF
--- a/apps/passport-client/components/modals/InvalidUserModal.tsx
+++ b/apps/passport-client/components/modals/InvalidUserModal.tsx
@@ -27,20 +27,22 @@ export function InvalidUserModal(): JSX.Element {
 
   return (
     <Container>
-      <H2>Invalid Zupass</H2>
+      <H2>Session Expired</H2>
       <Spacer h={16} />
-      <p>Your Zupass is in an invalid state. This can happen when:</p>
-      <ul>
-        <li>You reset your account on another device.</li>
-        <li>Zupass application state becomes corrupted on this device.</li>
-      </ul>
-      <p>To resolve this, we recommend you either:</p>
+
+      <p>
+        Your session has expired. This can happen when you reset your account on
+        a different device.
+      </p>
+      <Spacer h={16} />
+      <p> To resolve, we recommend you either:</p>
       <ul>
         <li>Reload this page.</li>
         <li>
           Export your account data, log out of this account, and log in again.
         </li>
       </ul>
+      <Spacer h={16} />
       <p>
         If this issue persists, please contact us at <SupportLink />.
       </p>

--- a/apps/passport-client/components/screens/HomeScreen/HomeScreen.tsx
+++ b/apps/passport-client/components/screens/HomeScreen/HomeScreen.tsx
@@ -217,7 +217,7 @@ export function HomeScreenImpl(): JSX.Element | null {
               {pcdsInFolder.length > 0 ? (
                 <PCDCardList pcds={pcdsInFolder} />
               ) : loadedIssuedPCDs ? (
-                <NoPcdsContainer>This folder has no PCDs</NoPcdsContainer>
+                <NoPcdsContainer>This folder is empty</NoPcdsContainer>
               ) : (
                 <RippleLoader />
               )}


### PR DESCRIPTION
Invalid Zupass screen is now

<img width="425" alt="Screenshot 2024-06-06 at 9 24 18 AM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/8b0f86ae-a5dd-4603-8978-0182b42ad60a">

This folder has no PCDs -> This folder is empty