### PR TITLE
Remove dependency of dev server on gen-test-artifacts

### DIFF
--- a/apps/consumer-client/.env.example
+++ b/apps/consumer-client/.env.example
@@ -5,7 +5,21 @@ ZUPASS_SERVER_URL_CONSUMER=
 
 # Specifies how to download artifacts for GPC proofs.  See the function
 # parseGPCArtifactsConfig in @pcd/client-shared for info on the format.
+# An empty string means to use defaults, which for this app is to download
+# the latest stable version from NPM.
+# Common examples values are below.
 GPC_ARTIFACTS_CONFIG_OVERRIDE=
+
+# Use this value to use locally-built artifacts, loaded into the Zupass server
+# by the gen-test-artifacts command.  This only works for localhost dev mode.
+# If you use this, remember to manually run `yarn gen-test-artifacts` on the
+# passport-client package.
 #GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "zupass", "stability": "test", "version": ""}
+
+# Use this value to download from GitHub.  Fill in the "version" field with the
+# git revision (commit hash or tag) you want to use.
 #GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "github", "stability": "test", "version": "@pcd/proto-pod-gpc-artifacts@0.0.2"}
+
+# Use this value to download from NPM using unpkg.  Fill in the "version" field
+# with the NPM version number.
 #GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "unpkg", "stability": "test", "version": "0.0.2"}

--- a/apps/passport-client/.env.example
+++ b/apps/passport-client/.env.example
@@ -24,7 +24,21 @@ SHOW_POD_TICKET_PCDS=""
 
 # Specifies how to download artifacts for GPC proofs.  See the function
 # parseGPCArtifactsConfig in @pcd/client-shared for info on the format.
+# An empty string means to use defaults, which for this app is to use
+# artifacts from the Zupass server, fetched from NPM by the build.ts script.
+# Common examples values are below.
 GPC_ARTIFACTS_CONFIG_OVERRIDE=
+
+# Use this value to use locally-built artifacts, loaded into the Zupass server
+# by the gen-test-artifacts command.  This only works for localhost dev mode.
+# If you use this, remember to manually run `yarn gen-test-artifacts` on the
+# passport-client package.
 #GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "zupass", "stability": "test", "version": ""}
+
+# Use this value to download from GitHub.  Fill in the "version" field with the
+# git revision (commit hash or tag) you want to use.
 #GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "github", "stability": "test", "version": "@pcd/proto-pod-gpc-artifacts@0.0.2"}
+
+# Use this value to download from NPM using unpkg.  Fill in the "version" field
+# with the NPM version number.
 #GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "unpkg", "stability": "test", "version": "0.0.2"}

--- a/apps/passport-client/turbo.json
+++ b/apps/passport-client/turbo.json
@@ -41,7 +41,6 @@
       "cache": true
     },
     "dev": {
-      "dependsOn": ["gen-test-artifacts"],
       "cache": false,
       "persistent": true
     }

--- a/packages/lib/gpcircuits/circuits/proto-pod-gpc.circom
+++ b/packages/lib/gpcircuits/circuits/proto-pod-gpc.circom
@@ -267,5 +267,4 @@ template ProtoPODGPC (
 
     // Catch-all for logic global to the circuit, not tied to any of the other modules above.
     GlobalModule()(globalWatermark);
-    globalWatermark === 0;
 }

--- a/packages/lib/gpcircuits/circuits/proto-pod-gpc.circom
+++ b/packages/lib/gpcircuits/circuits/proto-pod-gpc.circom
@@ -267,4 +267,5 @@ template ProtoPODGPC (
 
     // Catch-all for logic global to the circuit, not tied to any of the other modules above.
     GlobalModule()(globalWatermark);
+    globalWatermark === 0;
 }


### PR DESCRIPTION
Waiting for circuit generation to start the dev server is now unnecessary for most use cases, and it wastes people's time every time they change branches or pull updated code.  In order to use these artifacts at all, you need to be doing active circuit development, and you need to change the `GPC_ARTIFACTS_CONFIG_OVERRIDE` variable in your server .env file(s) to enable this.

This is a quick-and dirty fix, removing the automatic dependency on generation.  I also documented the env vars and added a note about the need for manual generation.  I don't expect anyone to notice this note, but it's a stopgap until I can come up with a better solution.

Attn: @ax0 who's the other person likely to be affected by the need to generate manually currently.