### PR TITLE
Clarify record container argument type

### DIFF
--- a/apps/consumer-client/src/pages/examples/add-pcd.tsx
+++ b/apps/consumer-client/src/pages/examples/add-pcd.tsx
@@ -163,7 +163,7 @@ export default function Page(): JSX.Element {
         />
         <br />
         <button
-          onClick={(): Promise<void> =>
+          onClick={() =>
             addPODPCD(podContent, podFolder.length > 0 ? podFolder : undefined)
           }
         >
@@ -196,7 +196,7 @@ export default function Page(): JSX.Element {
         />
         <br />
         <button
-          onClick={(): Promise<void> =>
+          onClick={() =>
             addPODPCD(
               podContent2,
               podFolder2.length > 0 ? podFolder2 : undefined
@@ -703,7 +703,7 @@ async function addGPCPCD(
           argumentType: ArgumentTypeName.PCD
         }
       },
-      argumentType: ArgumentTypeName.Record
+      argumentType: ArgumentTypeName.RecordContainer
     },
     identity: {
       value: await SemaphoreIdentityPCDPackage.serialize(identityPCD),

--- a/apps/consumer-client/src/pages/examples/gpc-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/gpc-proof.tsx
@@ -196,7 +196,7 @@ export function openGPCPopup(
       userProvided: false
     },
     pods: {
-      argumentType: ArgumentTypeName.Record,
+      argumentType: ArgumentTypeName.RecordContainer,
       value: {
         examplePOD: {
           argumentType: ArgumentTypeName.PCD,

--- a/apps/passport-client/components/shared/PCDArgs.tsx
+++ b/apps/passport-client/components/shared/PCDArgs.tsx
@@ -41,7 +41,9 @@ import { Caption } from "../core";
 import { Chip, ChipsContainer } from "../core/Chip";
 import Select from "./Select";
 
-// Type used in `PCDArgs` for record-flattening process.
+/**
+ * Type used in `PCDArgs` for record container argument flattening process.
+ */
 type FlattenedArgTriple = [
   string | undefined,
   string,
@@ -66,9 +68,10 @@ export function PCDArgs<T extends PCDPackage>({
 }): JSX.Element {
   const [showAll, setShowAll] = useState(false);
 
-  // Flatten record arguments (if any), keeping track of the parent argument to
-  // properly mutate (cf. `setArg`) as well as inheriting argument fields from
-  // the record argument.  Validator parameters are also combined.
+  // Flatten record container arguments (if any), keeping track of the parent
+  // argument to properly mutate (cf. `setArg`) as well as inheriting argument
+  // fields from the record container argument.  Validator parameters are also
+  // combined.
   const flattenedArgs: FlattenedArgTriple[] = Object.entries(args).flatMap(
     ([argName, arg]: [
       string,
@@ -201,7 +204,7 @@ export function ArgInput<T extends PCDPackage, ArgName extends string>({
     [setArgs, parentArgName, argName]
   );
 
-  // Call `validate` appropriately if the argument arises from a record.
+  // Call `validate` appropriately if the argument arises from a record container.
   const isValid = useCallback(
     <A extends Argument<ArgumentTypeName, unknown>>(value: RawValueType<A>) =>
       (arg.validatorParams &&
@@ -213,7 +216,7 @@ export function ArgInput<T extends PCDPackage, ArgName extends string>({
   );
 
   const props = useMemo<ArgInputProps<typeof arg>>(() => {
-    // Qualify argument name if it arises from a record
+    // Qualify argument name if it arises from a record container.
     const qualifiedArgName =
       (parentArgName !== undefined ? `${parentArgName}.` : "") + argName;
     return {
@@ -682,7 +685,7 @@ function ArgContainer({
   );
 }
 
-// Omit Records as they should have been flattened out.
+// Omit record containers as they should have been flattened out.
 const argTypeIcons: Record<PrimitiveArgumentTypeName, JSX.Element> = {
   PCD: <GrDocumentLocked />,
   String: <TbLetterT />,

--- a/examples/pod-gpc-example/src/gpcExample.ts
+++ b/examples/pod-gpc-example/src/gpcExample.ts
@@ -435,7 +435,7 @@ export async function gpcDemo(): Promise<boolean> {
           argumentType: ArgumentTypeName.PCD
         }
       },
-      argumentType: ArgumentTypeName.Record
+      argumentType: ArgumentTypeName.RecordContainer
     },
     identity: {
       value: await SemaphoreIdentityPCDPackage.serialize(identityPCD),

--- a/packages/lib/pcd-types/src/pcd.ts
+++ b/packages/lib/pcd-types/src/pcd.ts
@@ -256,32 +256,33 @@ export enum ArgumentTypeName {
   Object = "Object",
   StringArray = "StringArray",
   PCD = "PCD",
-  Record = "Record",
+  RecordContainer = "RecordContainer",
   ToggleList = "ToggleList",
   Unknown = "Unknown"
 }
 
 /**
- * Argument type names other than the record type.
+ * Primitive argument type names, i.e. names for rgument types other than the record type.
  */
 export type PrimitiveArgumentTypeName = Exclude<
   ArgumentTypeName,
-  ArgumentTypeName.Record
+  ArgumentTypeName.RecordContainer
 >;
 
 /**
- * Non-recursive record argument type.
+ * Non-recursive record container argument type. This should be thought of as a
+ * container of named arguments of a single primitive type.
  */
-export type RecordArgument<
+export type RecordContainerArgument<
   S extends string,
   T extends Argument<PrimitiveArgumentTypeName, unknown>,
   ValidatorParams = Record<string, unknown>
-> = Argument<ArgumentTypeName.Record, Record<S, T>, ValidatorParams>;
-export function isRecordArgument<
+> = Argument<ArgumentTypeName.RecordContainer, Record<S, T>, ValidatorParams>;
+export function isRecordContainerArgument<
   S extends string,
   T extends Argument<PrimitiveArgumentTypeName, unknown>
->(arg: Argument<any, unknown>): arg is RecordArgument<S, T> {
-  return arg.argumentType === ArgumentTypeName.Record;
+>(arg: Argument<any, unknown>): arg is RecordContainerArgument<S, T> {
+  return arg.argumentType === ArgumentTypeName.RecordContainer;
 }
 
 export type StringArgument = Argument<ArgumentTypeName.String, string>;
@@ -399,7 +400,7 @@ export type RawValueType<T extends Argument<any, unknown>> =
  * mapping from record keys to such predicates for the record value type.
  */
 export type ArgumentValidator<T extends Argument<any, unknown>> =
-  T extends RecordArgument<infer S, infer U>
+  T extends RecordContainerArgument<infer S, infer U>
     ? (
         s: S,
         value: RawValueType<U>,

--- a/packages/lib/pcd-types/src/pcd.ts
+++ b/packages/lib/pcd-types/src/pcd.ts
@@ -262,7 +262,7 @@ export enum ArgumentTypeName {
 }
 
 /**
- * Primitive argument type names, i.e. names for rgument types other than the record type.
+ * Primitive argument type names, i.e. names for argument types other than the record container type.
  */
 export type PrimitiveArgumentTypeName = Exclude<
   ArgumentTypeName,

--- a/packages/pcd/gpc-pcd/src/GPCPCD.ts
+++ b/packages/pcd/gpc-pcd/src/GPCPCD.ts
@@ -2,7 +2,7 @@ import { GPCBoundConfig, GPCRevealedClaims } from "@pcd/gpc";
 import {
   PCD,
   PCDArgument,
-  RecordArgument,
+  RecordContainerArgument,
   StringArgument
 } from "@pcd/pcd-types";
 import { PODName } from "@pcd/pod";
@@ -39,10 +39,11 @@ export type GPCPCDInitArgs = {
 };
 
 /**
- * Record argument type encapsulating a record of POD PCD arguments. The POD
- * names used here must correspond to those used in the proof configuration.
+ * Record container argument type encapsulating a record of POD PCD
+ * arguments. The POD names used here must correspond to those used in the proof
+ * configuration.
  */
-export type PODPCDRecordArg = RecordArgument<
+export type PODPCDRecordArg = RecordContainerArgument<
   PODName,
   PCDArgument<PODPCD, PODPCDArgValidatorParams>,
   PODPCDArgValidatorParams
@@ -73,9 +74,9 @@ export type GPCPCDArgs = {
 
   /**
    * POD objects to prove about. Each object is identified by name in the value
-   * underlying this record argument.  These are not revealed by default, but a
-   * redacted version of their entries will become part of the claims of the
-   * resulting proof PCD, as specified by the proof config.
+   * underlying this record container argument.  These are not revealed by
+   * default, but a redacted version of their entries will become part of the
+   * claims of the resulting proof PCD, as specified by the proof config.
    *
    * See {@link GPCProofConfig} and {@link GPCRevealedClaims} for more
    * information.

--- a/packages/pcd/gpc-pcd/src/GPCPCDPackage.ts
+++ b/packages/pcd/gpc-pcd/src/GPCPCDPackage.ts
@@ -271,7 +271,7 @@ export function getProveDisplayOptions(): ProveDisplayOptions<GPCPCDArgs> {
         defaultVisible: true
       },
       pods: {
-        argumentType: ArgumentTypeName.Record,
+        argumentType: ArgumentTypeName.RecordContainer,
         description: "Generate a proof for the selected POD object",
         validate: (
           podName: PODName,

--- a/packages/pcd/gpc-pcd/test/gpc-pcd.spec.ts
+++ b/packages/pcd/gpc-pcd/test/gpc-pcd.spec.ts
@@ -112,7 +112,7 @@ describe("GPCPCD should work", async function () {
             argumentType: ArgumentTypeName.PCD
           }
         },
-        argumentType: ArgumentTypeName.Record
+        argumentType: ArgumentTypeName.RecordContainer
       },
       identity: {
         value: await SemaphoreIdentityPCDPackage.serialize(identityPCD),

--- a/packages/tools/perftest/src/cases/GPCTimer.ts
+++ b/packages/tools/perftest/src/cases/GPCTimer.ts
@@ -70,7 +70,7 @@ async function setupProveArgs(): Promise<GPCPCDArgs> {
           argumentType: ArgumentTypeName.PCD
         }
       },
-      argumentType: ArgumentTypeName.Record
+      argumentType: ArgumentTypeName.RecordContainer
     },
     identity: {
       value: await SemaphoreIdentityPCDPackage.serialize(identityPCD),


### PR DESCRIPTION
This PR addresses the suggestions in #1757, specifically renaming 'record arguments' to 'record container arguments' and making stylistic changes for more clarity and better maintainability.