### PR TITLE
add multi-zk-ticket proof request support to zupass

### DIFF
--- a/apps/consumer-client/src/main.tsx
+++ b/apps/consumer-client/src/main.tsx
@@ -6,6 +6,7 @@ import AddPCD from "./pages/examples/add-pcd";
 import GetWithoutProving from "./pages/examples/get-without-proving";
 import GPCProof from "./pages/examples/gpc-proof";
 import GroupProof from "./pages/examples/group-proof";
+import MultiZkEDdSAEventTicketProof from "./pages/examples/multi-zk-eddsa-event-ticket-proof";
 import SignatureProof from "./pages/examples/signature-proof";
 import ZkEDdSAEventTicketProof from "./pages/examples/zk-eddsa-event-ticket-proof";
 import ZkEDdSAFrogProof from "./pages/examples/zk-eddsa-frog-proof";
@@ -24,6 +25,10 @@ const router = createHashRouter([
   {
     path: "examples/zk-eddsa-event-ticket-proof",
     element: <ZkEDdSAEventTicketProof />
+  },
+  {
+    path: "examples/multi-zk-eddsa-event-ticket-proof",
+    element: <MultiZkEDdSAEventTicketProof />
   },
   {
     path: "examples/zuauth",

--- a/apps/consumer-client/src/pages/Home.tsx
+++ b/apps/consumer-client/src/pages/Home.tsx
@@ -35,6 +35,11 @@ function Page(): JSX.Element {
             </Link>
           </li>
           <li>
+            <Link to="/examples/multi-zk-eddsa-event-ticket-proof">
+              Prove and Get multiple ZKEdDSA Event Ticket Proofs from Zupass
+            </Link>
+          </li>
+          <li>
             <Link to="/examples/zuauth">ZuAuth authentication of tickets</Link>
           </li>
           <li>

--- a/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
@@ -86,7 +86,6 @@ export default function Page(): JSX.Element {
     ]
   );
 
-  // Populate PCD from either client-side or server-side proving using the Zupass popup
   const [_pcdStr, _pendingPCDStr, multiPCDs] = useZupassPopupMessages();
 
   return (
@@ -95,8 +94,8 @@ export default function Page(): JSX.Element {
       <h2>Multiple ZKEdDSA Event Ticket Proofs</h2>
       <p>
         This page shows a working example of an integration with Zupass which
-        requests and verifies that the user has an EdDSA-signed ticket to one of
-        a list of valid events.
+        requests and verifies that the user has one or more EdDSA-signed tickets
+        to one of a list of valid events.
       </p>
       <p>
         The underlying PCD that this example uses is{" "}
@@ -123,7 +122,7 @@ export default function Page(): JSX.Element {
             )
           }
         >
-          Request Zupass Event Ticket Proof
+          Request Zupass Event Ticket Proofs
         </button>
         <br />
         Valid event ids, comma separated (or empty for no validation):

--- a/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
@@ -86,7 +86,7 @@ export default function Page(): JSX.Element {
   );
 
   // Populate PCD from either client-side or server-side proving using the Zupass popup
-  const [_pcdStr, _pendingPCDStr, multiPCDStr] = useZupassPopupMessages();
+  const [_pcdStr, _pendingPCDStr, multiPCDStrs] = useZupassPopupMessages();
 
   const [valid, setValid] = useState<boolean | undefined>();
   const onVerified = (valid: boolean): void => {
@@ -94,7 +94,7 @@ export default function Page(): JSX.Element {
   };
 
   const { pcd } = useZKEdDSAEventTicketProof(
-    multiPCDStr[0] ?? "",
+    multiPCDStrs[0] ? JSON.stringify(multiPCDStrs[0]) : "",
     onVerified,
     fieldsToReveal,
     watermark,
@@ -447,12 +447,19 @@ export function openZKEdDSAEventTicketPopup(
 
   const proofUrl = constructZupassPcdGetRequestUrl<
     typeof ZKEdDSAEventTicketPCDPackage
-  >(urlToZupassWebsite, popupUrl, ZKEdDSAEventTicketPCDPackage.name, args, {
-    genericProveScreen: true,
-    title: "ZKEdDSA Proof",
-    description: "zkeddsa ticket pcd request",
-    multi: true
-  });
+  >(
+    urlToZupassWebsite,
+    popupUrl,
+    ZKEdDSAEventTicketPCDPackage.name,
+    args,
+    {
+      genericProveScreen: true,
+      title: "ZKEdDSA Proof",
+      description: "zkeddsa ticket pcd request",
+      multi: true
+    },
+    true
+  );
 
   openZupassPopup(popupUrl, proofUrl);
 }

--- a/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
@@ -1,0 +1,536 @@
+import { EdDSATicketPCDPackage } from "@pcd/eddsa-ticket-pcd";
+import {
+  constructZupassPcdGetRequestUrl,
+  openZupassPopup,
+  useSerializedPCD,
+  useZupassPopupMessages
+} from "@pcd/passport-interface";
+import { ArgumentTypeName } from "@pcd/pcd-types";
+import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
+import { generateSnarkMessageHash } from "@pcd/util";
+import {
+  EdDSATicketFieldsToReveal,
+  ZKEdDSAEventTicketPCD,
+  ZKEdDSAEventTicketPCDArgs,
+  ZKEdDSAEventTicketPCDPackage
+} from "@pcd/zk-eddsa-event-ticket-pcd";
+import { useEffect, useMemo, useState } from "react";
+import { CodeLink, CollapsableCode, HomeLink } from "../../components/Core";
+import { ExampleContainer } from "../../components/ExamplePage";
+import { ZUPASS_URL } from "../../constants";
+
+export default function Page(): JSX.Element {
+  const watermark = generateSnarkMessageHash(
+    "consumer-client zk-eddsa-event-ticket-pcd challenge"
+  );
+  const externalNullifier =
+    generateSnarkMessageHash("consumer-client").toString();
+
+  const [revealTicketId, setRevealTicketId] = useState(false);
+  const [revealEventId, setRevealEventId] = useState(true);
+  const [revealProductId, setRevealProductId] = useState(true);
+  const [revealTimestampConsumed, setRevealTimestampConsumed] = useState(false);
+  const [revealTimestampSigned, setRevealTimestampSigned] = useState(false);
+  const [revealAttendeeSemaphoreId, setRevealAttendeeSemaphoreId] =
+    useState(false);
+  const [revealIsConsumed, setRevealIsConsumed] = useState(false);
+  const [revealIsRevoked, setRevealIsRevoked] = useState(false);
+  const [revealAttendeeEmail, setRevealAttendeeEmail] = useState(false);
+  const [revealAttendeeName, setRevealAttendeeName] = useState(false);
+  const [revealFieldsUserProvided, setRevealFieldsUserProvided] =
+    useState(false);
+  const [validEventIdsInput, setValidEventIdsInput] = useState("");
+  const [validDisplayEventIdsInput, setDisplayValidEventIdsInput] =
+    useState("");
+  const [validDisplayProductIdsInput, setDisplayValidProductIdsInput] =
+    useState("");
+
+  const validEventIds = validEventIdsInput
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+  const displayValidEventIds = validDisplayEventIdsInput
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+  const displayValidProductIds = validDisplayProductIdsInput
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+
+  const fieldsToReveal: EdDSATicketFieldsToReveal = useMemo(
+    () => ({
+      revealTicketId,
+      revealEventId,
+      revealProductId,
+      revealTimestampConsumed,
+      revealTimestampSigned,
+      revealAttendeeSemaphoreId,
+      revealIsConsumed,
+      revealIsRevoked,
+      revealAttendeeEmail,
+      revealAttendeeName
+    }),
+    [
+      revealTicketId,
+      revealEventId,
+      revealProductId,
+      revealTimestampConsumed,
+      revealTimestampSigned,
+      revealAttendeeSemaphoreId,
+      revealIsConsumed,
+      revealIsRevoked,
+      revealAttendeeEmail,
+      revealAttendeeName
+    ]
+  );
+
+  // Populate PCD from either client-side or server-side proving using the Zupass popup
+  const [pcdStr] = useZupassPopupMessages();
+
+  const [valid, setValid] = useState<boolean | undefined>();
+  const onVerified = (valid: boolean): void => {
+    setValid(valid);
+  };
+
+  const { pcd } = useZKEdDSAEventTicketProof(
+    pcdStr,
+    onVerified,
+    fieldsToReveal,
+    watermark,
+    externalNullifier
+  );
+
+  return (
+    <>
+      <HomeLink />
+      <h2>ZKEdDSA Event Ticket Proof</h2>
+      <p>
+        This page shows a working example of an integration with Zupass which
+        requests and verifies that the user has an EdDSA-signed ticket to one of
+        a list of valid events.
+      </p>
+      <p>
+        The underlying PCD that this example uses is{" "}
+        <code>ZKEdDSAEventTicketPCD</code>. You can find more documentation
+        regarding this PCD{" "}
+        <CodeLink file="/tree/main/packages/pcd/zk-eddsa-event-ticket-pcd">
+          here on GitHub
+        </CodeLink>{" "}
+        .
+      </p>
+      <ExampleContainer>
+        <button
+          onClick={(): void =>
+            openZKEdDSAEventTicketPopup(
+              ZUPASS_URL,
+              window.location.origin + "#/popup",
+              fieldsToReveal,
+              revealFieldsUserProvided,
+              watermark,
+              validEventIds,
+              displayValidEventIds,
+              displayValidProductIds,
+              externalNullifier
+            )
+          }
+          disabled={valid}
+        >
+          Request Zupass Event Ticket Proof
+        </button>
+        <br />
+        Valid event ids, comma separated (or empty for no validation):
+        <textarea
+          cols={45}
+          rows={12}
+          value={validEventIdsInput}
+          onChange={(e): void => {
+            setValidEventIdsInput(e.target.value);
+          }}
+        />
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealTicketId}
+            onChange={(): void => {
+              setRevealTicketId((checked) => !checked);
+            }}
+          />
+          request ticketId?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealEventId}
+            onChange={(): void => {
+              setRevealEventId((checked) => !checked);
+            }}
+          />
+          request eventId?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealProductId}
+            onChange={(): void => {
+              setRevealProductId((checked) => !checked);
+            }}
+          />
+          request productId?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealTimestampConsumed}
+            onChange={(): void => {
+              setRevealTimestampConsumed((checked) => !checked);
+            }}
+          />
+          request timestampConsumed?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealTimestampSigned}
+            onChange={(): void => {
+              setRevealTimestampSigned((checked) => !checked);
+            }}
+          />
+          request timestampSigned?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealAttendeeSemaphoreId}
+            onChange={(): void => {
+              setRevealAttendeeSemaphoreId((checked) => !checked);
+            }}
+          />
+          request attendeeSemaphoreId?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealIsConsumed}
+            onChange={(): void => {
+              setRevealIsConsumed((checked) => !checked);
+            }}
+          />
+          request isConsumed?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealIsRevoked}
+            onChange={(): void => {
+              setRevealIsRevoked((checked) => !checked);
+            }}
+          />
+          request isRevoked?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealAttendeeEmail}
+            onChange={(): void => {
+              setRevealAttendeeEmail((checked) => !checked);
+            }}
+          />
+          request attendeeEmail?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealAttendeeName}
+            onChange={(): void => {
+              setRevealAttendeeName((checked) => !checked);
+            }}
+          />
+          request attendeeName?
+        </label>
+        <br />
+        <label>
+          <input
+            type="checkbox"
+            checked={revealFieldsUserProvided}
+            onChange={(): void => {
+              setRevealFieldsUserProvided((checked) => !checked);
+            }}
+          />
+          allow reveal fields customization?
+        </label>
+        <br />
+        [Prove Screen Only]
+        <br />
+        Valid event ids, comma separated (or empty for no validation):
+        <textarea
+          cols={45}
+          rows={12}
+          value={validDisplayEventIdsInput}
+          onChange={(e): void => {
+            setDisplayValidEventIdsInput(e.target.value);
+          }}
+        />
+        <br />
+        Valid product ids, comma separated (or empty for no validation):
+        <textarea
+          cols={45}
+          rows={12}
+          value={validDisplayProductIdsInput}
+          onChange={(e): void => {
+            setDisplayValidProductIdsInput(e.target.value);
+          }}
+        />
+        <br />
+        {!!pcd && (
+          <>
+            <p>Got Zupass ZKEdDSA Event Ticket Proof from Zupass</p>
+            <CollapsableCode code={JSON.stringify(pcd, null, 2)} />
+            {valid === undefined && <p>❓ Proof verifying</p>}
+            {valid === false && <p>❌ Proof is invalid</p>}
+            {valid === true && (
+              <>
+                <p>✅ Proof is valid</p>
+                <p>{`Ticket ID: ${
+                  pcd.claim.partialTicket.ticketId !== undefined
+                    ? pcd.claim.partialTicket.ticketId
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Event ID: ${
+                  pcd.claim.partialTicket.eventId !== undefined
+                    ? pcd.claim.partialTicket.eventId
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Valid Event IDs: ${
+                  pcd.claim.validEventIds !== undefined
+                    ? "[" + pcd.claim.validEventIds.join(", ") + "]"
+                    : "UNCHECKED"
+                }`}</p>
+                <p>{`Product ID: ${
+                  pcd.claim.partialTicket.productId !== undefined
+                    ? pcd.claim.partialTicket.productId
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Timestamp Consumed: ${
+                  // timestampConsumed can be 0, which is falsey
+                  // so test for undefined
+                  pcd.claim.partialTicket.timestampConsumed !== undefined
+                    ? pcd.claim.partialTicket.timestampConsumed
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Timestamp Signed: ${
+                  pcd.claim.partialTicket.timestampSigned !== undefined
+                    ? pcd.claim.partialTicket.timestampSigned
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Semaphore ID: ${
+                  pcd.claim.partialTicket.attendeeSemaphoreId !== undefined
+                    ? pcd.claim.partialTicket.attendeeSemaphoreId
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Is Consumed?: ${
+                  // isConsumed can be true, false, or undefined
+                  // undefined means it is not revealed in this PCD
+                  pcd.claim.partialTicket.isConsumed !== undefined
+                    ? pcd.claim.partialTicket.isConsumed
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Is Revoked?: ${
+                  // isRevoked can be true, false, or undefined
+                  // undefined means it is not revealed in this PCD
+                  pcd.claim.partialTicket.isRevoked !== undefined
+                    ? pcd.claim.partialTicket.isRevoked
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Attendee Email: ${
+                  // attendeeEmail can be true, false, or undefined
+                  // undefined means it is not revealed in this PCD
+                  pcd.claim.partialTicket.attendeeEmail !== undefined
+                    ? pcd.claim.partialTicket.attendeeEmail
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Attendee Name: ${
+                  // attendeeName can be true, false, or undefined
+                  // undefined means it is not revealed in this PCD
+                  pcd.claim.partialTicket.attendeeName !== undefined
+                    ? pcd.claim.partialTicket.attendeeName
+                    : "HIDDEN"
+                }`}</p>
+                <p>{`Signer: ${pcd.claim.signer}`}</p>
+                <p>{`Watermark: ${pcd.claim.watermark}`}</p>
+                {pcd.claim.externalNullifier && (
+                  <p>{`External Nullifier: ${pcd.claim.externalNullifier}`}</p>
+                )}
+                {pcd.claim.nullifierHash && (
+                  <p>{`Nullifier Hash: ${pcd.claim.nullifierHash}`}</p>
+                )}
+              </>
+            )}
+          </>
+        )}
+        {valid && <p>Welcome, anon</p>}
+      </ExampleContainer>
+    </>
+  );
+}
+
+/**
+ * Opens a Zupass popup to prove a prove a ZKEdDSATicketPCD.
+ *
+ * @param urlToZupassWebsite URL of the Zupass website
+ * @param popupUrl Route where the useZupassPopupSetup hook is being served from
+ * @param fieldsToReveal Ticket data fields that site is requesting for user to reveal
+ * @param fieldsToRevealUserProvided Whether the user can customize the fields to reveal
+ * @param watermark Challenge to watermark this proof to
+ * @param externalNullifier Optional unique identifier for this ZKEdDSAEventTicketPCD
+ */
+export function openZKEdDSAEventTicketPopup(
+  urlToZupassWebsite: string,
+  popupUrl: string,
+  fieldsToReveal: EdDSATicketFieldsToReveal,
+  fieldsToRevealUserProvided: boolean,
+  watermark: bigint,
+  validEventIds: string[],
+  displayValidEventIds: string[],
+  displayValidProductIds: string[],
+  externalNullifier?: string
+): void {
+  const args: ZKEdDSAEventTicketPCDArgs = {
+    ticket: {
+      argumentType: ArgumentTypeName.PCD,
+      pcdType: EdDSATicketPCDPackage.name,
+      value: undefined,
+      userProvided: true,
+      validatorParams: {
+        eventIds: displayValidEventIds,
+        productIds: displayValidProductIds,
+        notFoundMessage: "No eligible PCDs found"
+      }
+    },
+    identity: {
+      argumentType: ArgumentTypeName.PCD,
+      pcdType: SemaphoreIdentityPCDPackage.name,
+      value: undefined,
+      userProvided: true
+    },
+    validEventIds: {
+      argumentType: ArgumentTypeName.StringArray,
+      value: validEventIds.length !== 0 ? validEventIds : undefined,
+      userProvided: false
+    },
+    fieldsToReveal: {
+      argumentType: ArgumentTypeName.ToggleList,
+      value: fieldsToReveal,
+      userProvided: fieldsToRevealUserProvided
+    },
+    externalNullifier: {
+      argumentType: ArgumentTypeName.BigInt,
+      value: externalNullifier,
+      userProvided: false
+    },
+    watermark: {
+      argumentType: ArgumentTypeName.BigInt,
+      value: watermark.toString(),
+      userProvided: false
+    }
+  };
+
+  const proofUrl = constructZupassPcdGetRequestUrl<
+    typeof ZKEdDSAEventTicketPCDPackage
+  >(urlToZupassWebsite, popupUrl, ZKEdDSAEventTicketPCDPackage.name, args, {
+    genericProveScreen: true,
+    title: "ZKEdDSA Proof",
+    description: "zkeddsa ticket pcd request"
+  });
+
+  openZupassPopup(popupUrl, proofUrl);
+}
+
+/**
+ * React hook which can be used on 3rd party application websites that
+ * parses and verifies a PCD representing a ZKEdDSA ticket proof.
+ */
+function useZKEdDSAEventTicketProof(
+  pcdStr: string,
+  onVerified: (valid: boolean) => void,
+  fieldsToReveal: EdDSATicketFieldsToReveal,
+  watermark: bigint,
+  externalNullifier?: string
+): { pcd: ZKEdDSAEventTicketPCD | undefined; error: Error | undefined } {
+  const [error, _setError] = useState<Error | undefined>();
+  const zkEdDSAEventTicketPCD = useSerializedPCD(
+    ZKEdDSAEventTicketPCDPackage,
+    pcdStr
+  );
+
+  useEffect(() => {
+    if (zkEdDSAEventTicketPCD) {
+      verifyProof(
+        zkEdDSAEventTicketPCD,
+        fieldsToReveal,
+        watermark,
+        externalNullifier
+      ).then(onVerified);
+    }
+  }, [
+    zkEdDSAEventTicketPCD,
+    fieldsToReveal,
+    watermark,
+    externalNullifier,
+    onVerified
+  ]);
+
+  return {
+    pcd: zkEdDSAEventTicketPCD,
+    error
+  };
+}
+
+async function verifyProof(
+  pcd: ZKEdDSAEventTicketPCD,
+  fieldsToReveal: EdDSATicketFieldsToReveal,
+  watermark: bigint,
+  externalNullifier?: string
+): Promise<boolean> {
+  const { verify } = ZKEdDSAEventTicketPCDPackage;
+  const verified = await verify(pcd);
+  if (!verified) return false;
+
+  // verify the claim is for the correct fields requested, watermark, and externalNullifier
+  const sameExternalNullifier =
+    pcd.claim.externalNullifier === externalNullifier ||
+    (!pcd.claim.externalNullifier && !externalNullifier);
+
+  const sameWatermark = pcd.claim.watermark === watermark.toString();
+
+  const pTicket = pcd.claim.partialTicket;
+  const samefieldsToReveal =
+    Object.prototype.hasOwnProperty.call(pTicket, "ticketId") ===
+      fieldsToReveal.revealTicketId &&
+    Object.prototype.hasOwnProperty.call(pTicket, "eventId") ===
+      fieldsToReveal.revealEventId &&
+    Object.prototype.hasOwnProperty.call(pTicket, "productId") ===
+      fieldsToReveal.revealProductId;
+  Object.prototype.hasOwnProperty.call(pTicket, "timestampConsumed") ===
+    fieldsToReveal.revealTimestampConsumed &&
+    Object.prototype.hasOwnProperty.call(pTicket, "timestampSigned") ===
+      fieldsToReveal.revealTimestampSigned &&
+    Object.prototype.hasOwnProperty.call(pTicket, "attendeeSemaphoreId") ===
+      fieldsToReveal.revealAttendeeSemaphoreId &&
+    Object.prototype.hasOwnProperty.call(pTicket, "isConsumed") ===
+      fieldsToReveal.revealIsConsumed &&
+    Object.prototype.hasOwnProperty.call(pTicket, "isRevoked") ===
+      fieldsToReveal.revealIsRevoked;
+
+  return sameExternalNullifier && sameWatermark && samefieldsToReveal;
+}

--- a/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
@@ -104,7 +104,7 @@ export default function Page(): JSX.Element {
   return (
     <>
       <HomeLink />
-      <h2>ZKEdDSA Event Ticket Proof</h2>
+      <h2>Multiple ZKEdDSA Event Ticket Proofs</h2>
       <p>
         This page shows a working example of an integration with Zupass which
         requests and verifies that the user has an EdDSA-signed ticket to one of

--- a/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
@@ -433,6 +433,7 @@ export function openZKEdDSAEventTicketPopup(
       pcdType: EdDSATicketPCDPackage.name,
       value: undefined,
       userProvided: true,
+      displayName: "Ticket(s)",
       validatorParams: {
         eventIds: displayValidEventIds,
         productIds: displayValidProductIds,

--- a/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/multi-zk-eddsa-event-ticket-proof.tsx
@@ -86,7 +86,7 @@ export default function Page(): JSX.Element {
   );
 
   // Populate PCD from either client-side or server-side proving using the Zupass popup
-  const [pcdStr] = useZupassPopupMessages();
+  const [_pcdStr, _pendingPCDStr, multiPCDStr] = useZupassPopupMessages();
 
   const [valid, setValid] = useState<boolean | undefined>();
   const onVerified = (valid: boolean): void => {
@@ -94,7 +94,7 @@ export default function Page(): JSX.Element {
   };
 
   const { pcd } = useZKEdDSAEventTicketProof(
-    pcdStr,
+    multiPCDStr[0] ?? "",
     onVerified,
     fieldsToReveal,
     watermark,
@@ -450,7 +450,8 @@ export function openZKEdDSAEventTicketPopup(
   >(urlToZupassWebsite, popupUrl, ZKEdDSAEventTicketPCDPackage.name, args, {
     genericProveScreen: true,
     title: "ZKEdDSA Proof",
-    description: "zkeddsa ticket pcd request"
+    description: "zkeddsa ticket pcd request",
+    multi: true
   });
 
   openZupassPopup(popupUrl, proofUrl);

--- a/apps/passport-client/components/core/ProgressBar.tsx
+++ b/apps/passport-client/components/core/ProgressBar.tsx
@@ -1,0 +1,93 @@
+import { ReactNode } from "react";
+import styled from "styled-components";
+
+export function ProgressBar({
+  label,
+  doneLabel,
+  fractionCompleted
+}: {
+  label?: string;
+  doneLabel?: string;
+  fractionCompleted: number;
+}): ReactNode {
+  const displayPercent = Math.floor(fractionCompleted * 100) + "%";
+  let renderedLabel =
+    label === undefined ? displayPercent : `${label} ${displayPercent}`;
+  if (fractionCompleted === 1) {
+    renderedLabel = doneLabel ?? "Complete";
+  }
+
+  return (
+    <ProgressBarContainer>
+      <LabelContainerContainer>
+        <ProgressIndicator
+          style={{
+            width: displayPercent
+          }}
+        />
+        <LabelContainer>{renderedLabel}</LabelContainer>
+      </LabelContainerContainer>
+    </ProgressBarContainer>
+  );
+}
+
+const ProgressBarContainer = styled.div`
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.1);
+  border: 1px solid white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  position: relative;
+  height: 75px;
+  overflow: hidden;
+`;
+
+const MIN_PROGRESS_WIDTH = "5%";
+const ProgressIndicator = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  min-width: ${MIN_PROGRESS_WIDTH};
+  width: ${MIN_PROGRESS_WIDTH};
+  height: 100%;
+  background-color: #34a12a;
+  z-index: 4;
+  transition: width 200ms;
+
+  @keyframes color-change {
+    0% {
+      background-color: #34a12a;
+    }
+    50% {
+      background-color: #59aa52;
+    }
+    100% {
+      background-color: #34a12a;
+    }
+  }
+
+  animation: color-change 1s infinite;
+`;
+
+const LabelContainerContainer = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const LabelContainer = styled.div`
+  background-color: var(--bg-dark-primary);
+  border: 1px solid white;
+  padding: 2px 20px;
+  display: inline-block;
+  border-radius: 4px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 5;
+`;

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
@@ -3,6 +3,7 @@ import {
   PCDRequestType,
   PendingPCD,
   postPendingPCDMessage,
+  postSerializedMultiPCDMessage,
   postSerializedPCDMessage
 } from "@pcd/passport-interface";
 import { PCD, SerializedPCD } from "@pcd/pcd-types";
@@ -37,7 +38,8 @@ export function GenericProveScreen({
     (
       _pcd: PCD,
       serialized: SerializedPCD | undefined,
-      pendingPCD: PendingPCD | undefined
+      pendingPCD: PendingPCD | undefined,
+      multiplePCDs?: SerializedPCD[]
     ) => {
       if (pendingPCD) {
         if (window.opener && req.postMessage) {
@@ -45,6 +47,12 @@ export function GenericProveScreen({
           window.close();
         }
         safeRedirectPending(req.returnUrl, pendingPCD);
+      } else if (multiplePCDs !== undefined) {
+        if (window.opener && req.postMessage) {
+          postSerializedMultiPCDMessage(window.opener, multiplePCDs);
+          window.close();
+        }
+        safeRedirect(req.returnUrl, undefined, multiplePCDs);
       } else {
         if (window.opener && req.postMessage) {
           if (serialized) {

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -211,6 +211,7 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
         args={args}
         setArgs={setArgs}
         options={pcdPackage?.getProveDisplayOptions?.()?.defaultArgs}
+        proveOptions={options}
       />
 
       {folder && (

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -108,6 +108,9 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
       }
 
       onProve(undefined, undefined, pendingPCDResult.value);
+    }
+    if (options?.multi) {
+      alert("multi proof");
     } else {
       try {
         if (!pcdPackage) {
@@ -129,7 +132,7 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
         setProving(false);
       }
     }
-  }, [options?.proveOnServer, pcdType, args, onProve, pcdPackage]);
+  }, [options, pcdType, args, onProve, pcdPackage]);
 
   return (
     <Container>

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -69,8 +69,13 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
   const pcdPackage = pcds.getPackage<T>(pcdType);
 
   useEffect(() => {
+    if (options?.multi && !isZKEdDSAEventTicketPCDPackage(pcdPackage)) {
+      setError("multi-proofs are only supported for ZKEdDSAEventTicketPCD");
+      return;
+    }
+
     setError(undefined);
-  }, [args]);
+  }, [args, options, pcdPackage]);
 
   const isProveReady = useMemo(
     () =>

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -16,6 +16,7 @@ import {
   SemaphoreSignaturePCDTypeName
 } from "@pcd/semaphore-signature-pcd";
 import { getErrorMessage } from "@pcd/util";
+import { isZKEdDSAEventTicketPCDPackage } from "@pcd/zk-eddsa-event-ticket-pcd";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";
@@ -57,6 +58,23 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
   const [error, setError] = useState<string | undefined>();
   const [proving, setProving] = useState(false);
   const pcdPackage = pcds.getPackage<T>(pcdType);
+
+  const _relevantPCDs = useMemo(() => {
+    if (isZKEdDSAEventTicketPCDPackage(pcdPackage)) {
+      const ticketValidation =
+        pcdPackage?.getProveDisplayOptions?.()?.defaultArgs?.["ticket"];
+
+      if (ticketValidation) {
+        const relevantPCDs = pcds.getAll().filter((p) => {
+          const ticketArg = args["ticket"];
+          return ticketValidation.validate(p, ticketArg.validatorParams);
+        });
+
+        console.log(relevantPCDs);
+      }
+    }
+    return [];
+  }, [args, pcdPackage, pcds]);
 
   useEffect(() => {
     setError(undefined);

--- a/apps/passport-client/src/passportRequest.ts
+++ b/apps/passport-client/src/passportRequest.ts
@@ -51,7 +51,8 @@ export function safeRedirectPending(
 // Redirects to the returnUrl with the serialized PCD in the query string.
 export function safeRedirect(
   returnUrl: string,
-  serializedPCD?: SerializedPCD
+  serializedPCD?: SerializedPCD,
+  multiplePCDs?: SerializedPCD[]
 ): void {
   validateReturnUrl(returnUrl);
   const hasQuery = returnUrl.includes("?");
@@ -60,6 +61,9 @@ export function safeRedirect(
   if (serializedPCD) {
     const encPCD = encodeURIComponent(JSON.stringify(serializedPCD));
     window.location.href = `${returnUrl}${queryMarker}proof=${encPCD}&finished=true`;
+  } else if (multiplePCDs) {
+    const encPCDs = encodeURIComponent(JSON.stringify(multiplePCDs));
+    window.location.href = `${returnUrl}${queryMarker}multi-pcd=${encPCDs}&finished=true`;
   } else {
     window.location.href = `${returnUrl}${queryMarker}finished=true`;
   }

--- a/packages/lib/passport-interface/src/PassportInterface.ts
+++ b/packages/lib/passport-interface/src/PassportInterface.ts
@@ -26,6 +26,7 @@ export interface ProveOptions {
   debug?: boolean;
   proveOnServer?: boolean;
   signIn?: boolean;
+  multi?: boolean;
 }
 
 /**

--- a/packages/lib/passport-interface/src/PassportInterface.ts
+++ b/packages/lib/passport-interface/src/PassportInterface.ts
@@ -153,6 +153,13 @@ export function postSerializedPCDMessage(
   window.postMessage({ encodedPCD: JSON.stringify(serialized) }, "*");
 }
 
+export function postSerializedMultiPCDMessage(
+  window: Window,
+  pcds: SerializedPCD[]
+): void {
+  window.postMessage({ multiplePCDs: JSON.stringify(pcds) }, "*");
+}
+
 export function postPendingPCDMessage(
   window: Window,
   pending: PendingPCD

--- a/packages/lib/passport-interface/src/PassportPopup/core.ts
+++ b/packages/lib/passport-interface/src/PassportPopup/core.ts
@@ -148,6 +148,12 @@ export function receiveZupassPopupMessage(
           pendingPcdStr: ev.data.encodedPendingPCD
         });
         window.removeEventListener("message", receiveMessage);
+      } else if (ev.data.multiplePCDs) {
+        resolve({
+          type: "multi-pcd",
+          pcds: JSON.parse(ev.data.multiplePCDs)
+        });
+        window.removeEventListener("message", receiveMessage);
       }
     };
     window.addEventListener("message", receiveMessage, {

--- a/packages/lib/passport-interface/src/PassportPopup/core.ts
+++ b/packages/lib/passport-interface/src/PassportPopup/core.ts
@@ -1,3 +1,5 @@
+import { SerializedPCD } from "@pcd/pcd-types";
+
 /*
  * Call this function on a dedicated /popup page in your app to integrate your
  * app with the Zupass proving/auth popup flow. The popup flow is optional,
@@ -119,7 +121,7 @@ export type PopupMessageResult =
       type: "pcd";
       pcdStr: string;
     }
-  | { type: "multi-pcd"; pcds: string[] }
+  | { type: "multi-pcd"; pcds: SerializedPCD[] }
   | {
       // We got a pending PCD back
       type: "pendingPcd";

--- a/packages/lib/passport-interface/src/PassportPopup/core.ts
+++ b/packages/lib/passport-interface/src/PassportPopup/core.ts
@@ -119,6 +119,7 @@ export type PopupMessageResult =
       type: "pcd";
       pcdStr: string;
     }
+  | { type: "multi-pcd"; pcds: string[] }
   | {
       // We got a pending PCD back
       type: "pendingPcd";

--- a/packages/lib/passport-interface/src/PassportPopup/react.ts
+++ b/packages/lib/passport-interface/src/PassportPopup/react.ts
@@ -1,10 +1,11 @@
+import { SerializedPCD } from "@pcd/pcd-types";
 import { useEffect, useState } from "react";
 import { receiveZupassPopupMessage, zupassPopupSetup } from "./core";
 
 export type ReceivedZupassResponse = [
   string, // single PCD serialized to string
   string, // pending PCD (proven on server) serialized to string
-  string[] // multiple PCDs proven at once, all serialized to strings in an array
+  SerializedPCD[] // multiple PCDs proven at once, all serialized to strings in an array
 ];
 
 /**
@@ -13,7 +14,7 @@ export type ReceivedZupassResponse = [
  */
 export function useZupassPopupMessages(): ReceivedZupassResponse {
   const [pcdStr, setPCDStr] = useState("");
-  const [multiPcdStrs, setMultiPcdStrs] = useState<string[]>([]);
+  const [multiPcdStrs, setMultiPcdStrs] = useState<SerializedPCD[]>([]);
   const [pendingPCDStr, setPendingPCDStr] = useState("");
 
   // Listen for PCDs coming back from the Zupass popup

--- a/packages/lib/passport-interface/src/PassportPopup/react.ts
+++ b/packages/lib/passport-interface/src/PassportPopup/react.ts
@@ -1,12 +1,19 @@
 import { useEffect, useState } from "react";
 import { receiveZupassPopupMessage, zupassPopupSetup } from "./core";
 
+export type ReceivedZupassResponse = [
+  string, // single PCD serialized to string
+  string, // pending PCD (proven on server) serialized to string
+  string[] // multiple PCDs proven at once, all serialized in an array
+];
+
 /**
  * React hook that listens for PCDs and PendingPCDs from a Zupass popup window.
  * A thin wrapper around {@link receiveZupassPopupMessage}.
  */
-export function useZupassPopupMessages(): [string, string] {
+export function useZupassPopupMessages(): ReceivedZupassResponse {
   const [pcdStr, setPCDStr] = useState("");
+  const [multiPcdStrs, setMultiPcdStrs] = useState<string[]>([]);
   const [pendingPCDStr, setPendingPCDStr] = useState("");
 
   // Listen for PCDs coming back from the Zupass popup
@@ -17,6 +24,8 @@ export function useZupassPopupMessages(): [string, string] {
         setPCDStr(result.pcdStr);
       } else if (result.type === "pendingPcd") {
         setPendingPCDStr(result.pendingPcdStr);
+      } else if (result.type === "multi-pcd") {
+        setMultiPcdStrs(result.pcds);
       }
     });
     return () => {
@@ -26,7 +35,7 @@ export function useZupassPopupMessages(): [string, string] {
     };
   }, []);
 
-  return [pcdStr, pendingPCDStr];
+  return [pcdStr, pendingPCDStr, multiPcdStrs];
 }
 
 /**

--- a/packages/lib/passport-interface/src/PassportPopup/react.ts
+++ b/packages/lib/passport-interface/src/PassportPopup/react.ts
@@ -4,7 +4,7 @@ import { receiveZupassPopupMessage, zupassPopupSetup } from "./core";
 export type ReceivedZupassResponse = [
   string, // single PCD serialized to string
   string, // pending PCD (proven on server) serialized to string
-  string[] // multiple PCDs proven at once, all serialized in an array
+  string[] // multiple PCDs proven at once, all serialized to strings in an array
 ];
 
 /**

--- a/packages/pcd/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCDPackage.ts
+++ b/packages/pcd/zk-eddsa-event-ticket-pcd/src/ZKEdDSAEventTicketPCDPackage.ts
@@ -607,3 +607,9 @@ export const ZKEdDSAEventTicketPCDPackage: PCDPackage<
   serialize,
   deserialize
 };
+
+export function isZKEdDSAEventTicketPCDPackage(
+  p: PCDPackage | undefined
+): p is typeof ZKEdDSAEventTicketPCDPackage {
+  return p?.name === ZKEdDSAEventTicketPCDTypeName;
+}


### PR DESCRIPTION
*screen recording of e2e demonstration working properly*

https://github.com/proofcarryingdata/zupass/assets/2636237/be27e79e-557d-4f23-83c0-ea1e328f819d

you can try the example e2e flow yourself at https://consumer-client-staging-ivan.onrender.com/#/examples/multi-zk-eddsa-event-ticket-proof

*multi-ticket proof w/out restrictions*
<img width="543" alt="Screenshot 2024-06-08 at 5 59 29 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/3c8fa127-5301-47c2-86f9-9476467b8614">

*multi-ticket proof restricted to just edge esmeralda tickets*
<img width="504" alt="Screenshot 2024-06-08 at 6 05 48 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/8734d2c5-2012-4f69-952e-b32ac7dee4ed">

*restricted to an event that the user does not have a ticket to*
<img width="508" alt="Screenshot 2024-06-08 at 6 06 48 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/5f9b52eb-9176-43c3-a683-88ec1f1cf3cc">

*consumer client end-to-end example can request and validate multiple proofs*
<img width="665" alt="Screenshot 2024-06-08 at 6 07 45 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/13da52b6-b41b-492a-82a5-7c5c2c61e81d">


