### PR TITLE
More POD UI tweaks

### DIFF
--- a/packages/lib/passport-ui/src/HiddenText.tsx
+++ b/packages/lib/passport-ui/src/HiddenText.tsx
@@ -1,7 +1,13 @@
 import { useCallback, useState } from "react";
 import styled from "./StyledWrapper";
 
-export function HiddenText({ text }: { text: string }): JSX.Element {
+export function HiddenText({
+  text,
+  style
+}: {
+  text: string;
+  style?: React.CSSProperties;
+}): JSX.Element {
   const [visible, setVisible] = useState(false);
 
   const onRevealClick = useCallback(() => {
@@ -9,7 +15,7 @@ export function HiddenText({ text }: { text: string }): JSX.Element {
   }, []);
 
   if (visible) {
-    return <TextContainer>{text}</TextContainer>;
+    return <TextContainer style={style}>{text}</TextContainer>;
   }
 
   return (

--- a/packages/ui/pod-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/pod-pcd-ui/src/CardBody.tsx
@@ -44,6 +44,15 @@ function PODPCDCardBody({ pcd }: { pcd: PODPCD }): JSX.Element {
       break;
   }
 
+  const sigButtonColor: React.CSSProperties = {};
+  if (sigStatus > 0) {
+    sigButtonColor.color = "white";
+    sigButtonColor.background = "green";
+  } else if (sigStatus < 0) {
+    sigButtonColor.color = "white";
+    sigButtonColor.background = "var(--danger)";
+  }
+
   return (
     <Container>
       {content}
@@ -63,9 +72,7 @@ function PODPCDCardBody({ pcd }: { pcd: PODPCD }): JSX.Element {
       )}
 
       <Button
-        style={
-          sigStatus === 0 ? "primary" : sigStatus > 0 ? "secondary" : "danger"
-        }
+        style="primary"
         size="small"
         onClick={async (): Promise<void> => {
           setError(undefined);
@@ -73,7 +80,7 @@ function PODPCDCardBody({ pcd }: { pcd: PODPCD }): JSX.Element {
           setError(sigResult.errorMessage);
           setSigStatus(sigResult.isValid ? 1 : -1);
         }}
-        styles={{ float: "right" }}
+        styles={{ float: "right", ...sigButtonColor }}
       >
         {sigStatus === 0
           ? "Check signature"

--- a/packages/ui/pod-pcd-ui/src/renderers/DefaultPODPCDCardBody.tsx
+++ b/packages/ui/pod-pcd-ui/src/renderers/DefaultPODPCDCardBody.tsx
@@ -12,12 +12,17 @@ export function DefaultPODPCDCardBody({ pcd }: { pcd: PODPCD }): JSX.Element {
       </p>
       <Separator />
       <FieldLabel>POD Entries</FieldLabel>
-      <pre>{podEntriesToSimplifiedJSON(pcd.claim.entries, 2)}</pre>
+      <pre style={{ overflowX: "auto" }}>
+        {podEntriesToSimplifiedJSON(pcd.claim.entries, 2)}
+      </pre>
       <Spacer h={8} />
       <FieldLabel>EdDSA Public Key</FieldLabel>
-      <HiddenText text={pcd.claim.signerPublicKey} />
+      <HiddenText
+        text={pcd.claim.signerPublicKey}
+        style={{ overflowX: "auto" }}
+      />
       <FieldLabel>EdDSA Signature</FieldLabel>
-      <HiddenText text={pcd.proof.signature} />
+      <HiddenText text={pcd.proof.signature} style={{ overflowX: "auto" }} />
     </Container>
   );
 }

--- a/packages/ui/pod-pcd-ui/src/renderers/DefaultPODPCDCardBody.tsx
+++ b/packages/ui/pod-pcd-ui/src/renderers/DefaultPODPCDCardBody.tsx
@@ -1,4 +1,10 @@
-import { FieldLabel, HiddenText, Separator, Spacer } from "@pcd/passport-ui";
+import {
+  FieldLabel,
+  HiddenText,
+  Separator,
+  Spacer,
+  TextContainer
+} from "@pcd/passport-ui";
 import { podEntriesToSimplifiedJSON } from "@pcd/pod";
 import { PODPCD } from "@pcd/pod-pcd";
 import { Container } from "../shared";
@@ -12,9 +18,9 @@ export function DefaultPODPCDCardBody({ pcd }: { pcd: PODPCD }): JSX.Element {
       </p>
       <Separator />
       <FieldLabel>POD Entries</FieldLabel>
-      <pre style={{ overflowX: "auto" }}>
-        {podEntriesToSimplifiedJSON(pcd.claim.entries, 2)}
-      </pre>
+      <TextContainer style={{ overflowX: "auto" }}>
+        <pre>{podEntriesToSimplifiedJSON(pcd.claim.entries, 2)}</pre>
+      </TextContainer>
       <Spacer h={8} />
       <FieldLabel>EdDSA Public Key</FieldLabel>
       <HiddenText


### PR DESCRIPTION
Improvements after suggestions from @lermchair
- Add horizontal scrolling for POD entries, key, signature
- Also add a text container to make the truncation and scrolling seem more obvious
- Make valid signature button green
