### PR TITLE
prevent paused pipelines from issuing any command

### DIFF
--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -791,6 +791,10 @@ export class LemonadePipeline implements BasePipeline {
         throw new Error("missing credential pcd");
       }
 
+      if (this.definition.options.paused) {
+        return { actions: [] };
+      }
+
       const { email, semaphoreId } =
         await this.credentialSubservice.verifyAndExpectZupassEmail(req.pcd);
 

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -944,6 +944,10 @@ export class PretixPipeline implements BasePipeline {
         throw new Error("missing credential pcd");
       }
 
+      if (this.definition.options.paused) {
+        return { actions: [] };
+      }
+
       const { email, semaphoreId } =
         await this.credentialSubservice.verifyAndExpectZupassEmail(req.pcd);
 


### PR DESCRIPTION
note: this is a change mostly to simplify logic that already works properly.

my understanding of `paused` pipelines is that they are by definition not `loaded`, meaning that the `issue` capability does not issue the `DeleteAllInFolder` command. 

https://github.com/proofcarryingdata/zupass/blob/ivan/pause-pipelines/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts#L825-L831

To add an extra layer of safety to this behavior, I've updated the pipeline `issue` functions to always return an empty array of `actions` for `paused` pipelines, so that:
- people who have received tickets from the pipeline will explicitly *not* have their event-specific folder updated by the feed polling mechanism
- and so that new users who don't have PCDs in the given folder just don't get anything.

I think this change is the final thing blocking me from being 100% comfortable with `pause`ing the ETH Berlin pipeline in production.