### PR TITLE
Disable warning about STRITCH_LICENSE_KEY in dev mode

### DIFF
--- a/apps/passport-client/src/appConfig.ts
+++ b/apps/passport-client/src/appConfig.ts
@@ -37,6 +37,7 @@ if (
 
 if (
   (!process.env.STRICH_LICENSE_KEY || process.env.STRICH_LICENSE_KEY === "") &&
+  process.env.NODE_ENV === "production" &&
   global.window &&
   !!global.window.alert
 ) {


### PR DESCRIPTION
There's a fallback to the old (non-licensed) scanner, so this should be optional in dev mode.