### PR TITLE
Debug config for tests in current file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,23 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "args": [
+        "-r",
+        "ts-node/register",
+        "--config",
+        "${workspaceFolder}/.mocharc.js",
+        "--no-timeouts",
+        "--exit",
+        "${file}"
+      ],
+      "cwd": "${fileDirname}",
+      "internalConsoleOptions": "openOnSessionStart",
+      "name": "TS Mocha Test (Current File)",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "request": "launch",
+      "type": "node"
+    },
+    {
       "type": "node",
       "request": "attach",
       "name": "Attach to Mocha test",


### PR DESCRIPTION
Adds a new VSCode debug configuration to launch unit tests from the currently open file.

This works on most but not all of the tests in the repo.  The passport-server tests in particular don't work.  See below for more details if you want to help fix it.

To use this:
- Open VSCode workspace, and open the test file you want to run (wherever the cursor is determines the file to run)
- Place breakpoints in the left margin if desired
- Click the "Run & Debug" icon on the left to open the debug pane (left side of the screen)
- In the dropdown at the top of the debug pane, select "TS Mocha Test (Current File)"
- Click the play button to launch tests

The remaining issue in passport-server tests seems to have to do with type definitions for some Chai add-ons.  It might occur everywhere those add-ons are used, or it might be specific to the fact that passport-server builds an app rather tha a library.  Here's the error when I try to run `lemonadePipeline.spec.ts`:

```
/Users/artwyman/.nvm/versions/node/v20.6.1/bin/node ./../../../../../../node_modules/mocha/bin/_mocha -r ts-node/register --config /Users/artwyman/dev/zupass/.mocharc.js --no-timeouts --exit /Users/artwyman/dev/zupass/apps/passport-server/test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts

TSError: ⨯ Unable to compile TypeScript:
../../../util/mockApis.ts(34,24): error TS2339: Property 'spy' does not exist on type 'ChaiStatic'.
../../../util/mockApis.ts(35,10): error TS2339: Property 'spy' does not exist on type 'ChaiStatic'.

    at createTSError (/Users/artwyman/dev/zupass/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/Users/artwyman/dev/zupass/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/Users/artwyman/dev/zupass/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/Users/artwyman/dev/zupass/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/Users/artwyman/dev/zupass/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/artwyman/dev/zupass/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Function.Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.<anonymous> (/Users/artwyman/dev/zupass/apps/passport-server/test/util/startTestingApplication.ts:3:1)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module.m._compile (/Users/artwyman/dev/zupass/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/artwyman/dev/zupass/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Function.Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.<anonymous> (/Users/artwyman/dev/zupass/apps/passport-server/test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts:50:1)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module.m._compile (/Users/artwyman/dev/zupass/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/artwyman/dev/zupass/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Function.Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.exports.requireOrImport (/Users/artwyman/dev/zupass/node_modules/mocha/lib/nodejs/esm-utils.js:53:16)
    at async Object.exports.loadFilesAsync (/Users/artwyman/dev/zupass/node_modules/mocha/lib/nodejs/esm-utils.js:100:20)
    at async singleRun (/Users/artwyman/dev/zupass/node_modules/mocha/lib/cli/run-helpers.js:125:3)
    at async Object.exports.handler (/Users/artwyman/dev/zupass/node_modules/mocha/lib/cli/run.js:370:5)
Process exited with code 1
```

I welcome suggestions on how to fix this final issue, but I think this config is useful for the tests where it works.
