### PR TITLE
More POD arg filtering for GPCPCD prove screen

### DIFF
--- a/apps/consumer-client/src/pages/examples/gpc-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/gpc-proof.tsx
@@ -230,7 +230,8 @@ export function openGPCPopup(
         }
       },
       validatorParams: {
-        proofConfig
+        proofConfig,
+        membershipLists
       }
     },
     identity: {

--- a/packages/lib/gpc/src/gpcSerialize.ts
+++ b/packages/lib/gpc/src/gpcSerialize.ts
@@ -175,7 +175,7 @@ export function podMembershipListsToSimplifiedJSON(
  * instance, small numbers are always annotated as `int`, rather than
  * `cryptographic`.
  *
- * @param serializedMembershipLists a string representation of `PODMembershipLists`
+ * @param simplifiedJSON a string representation of `PODMembershipLists`
  * @returns `PODMembershipLists` deserialized from the string
  * @throws if the serialized form is invalid
  */

--- a/packages/pcd/gpc-pcd/src/GPCPCD.ts
+++ b/packages/pcd/gpc-pcd/src/GPCPCD.ts
@@ -5,7 +5,7 @@ import {
   RecordContainerArgument,
   StringArgument
 } from "@pcd/pcd-types";
-import { PODName } from "@pcd/pod";
+import { PODEntries, PODName } from "@pcd/pod";
 import { PODPCD } from "@pcd/pod-pcd";
 import { SemaphoreIdentityPCD } from "@pcd/semaphore-identity-pcd";
 import { Groth16Proof } from "snarkjs";
@@ -50,11 +50,49 @@ export type PODPCDRecordArg = RecordContainerArgument<
 >;
 
 /**
+ * Type encapsulating prescribed values for PODs to be fed into a GPCPCD,
+ * viz. prescribed POD entries and signers' public keys. At least one of
+ * these must be specified for a given POD, else the POD should be omitted
+ * from the record. These values should be revealed by the underlying GPC
+ * and checked elsewhere in the app using this library.
+ */
+export type GPCPCDPrescribedPODValues = Record<
+  PODName,
+  { entries?: PODEntries; signerPublicKey?: string } & (
+    | { entries: PODEntries }
+    | { signerPublicKey: string }
+  )
+>;
+
+/**
  * Validator parameter type for POD PCD arguments.
  */
 export type PODPCDArgValidatorParams = {
+  /**
+   * Message to display if the POD specified in the config does not match any of
+   * the available POD PCDs.
+   */
   notFoundMessage?: string;
+
+  /**
+   * JSON-serialised proof configuration used to narrow down the selection of
+   * POD PCDs.
+   */
   proofConfig?: string;
+
+  /**
+   * Simplified JSON-serialised membership lists to narrow down the selection of
+   * POD PCDs to those satisfying the list membership check specified in the
+   * proof config (if any).
+   */
+  membershipLists?: string;
+
+  /**
+   * JSON-serialised `GPCPCDPrescribedPODValues`.This is used to
+   * narrow down the selection of POD PCDs to those with entries and signers'
+   * public keys matching these prescribed values.
+   */
+  prescribedValues?: string;
 };
 
 /**

--- a/packages/pcd/gpc-pcd/src/index.ts
+++ b/packages/pcd/gpc-pcd/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./GPCPCD";
 export * from "./GPCPCDPackage";
+export * from "./util";

--- a/packages/pcd/gpc-pcd/src/util.ts
+++ b/packages/pcd/gpc-pcd/src/util.ts
@@ -1,0 +1,147 @@
+import {
+  PODName,
+  PODRawValue,
+  POD_NAME_REGEX,
+  checkPublicKeyFormat,
+  podValueFromRawValue,
+  podValueToRawValue
+} from "@pcd/pod";
+import JSONBig from "json-bigint";
+import { GPCPCDPrescribedPODValues } from "./GPCPCD";
+
+const jsonBigSerializer = JSONBig({
+  useNativeBigInt: true,
+  alwaysParseAsBig: true
+});
+
+/**
+ * Deserializes `GPCPCDPrescribedPODValues` from the simplified format produced by
+ * {@link gpcPCDPrescribedPODValuesToSimplifiedJSON}.  Type information is inferred from
+ * the values in a way which should preserve hashing and circuit behavior, but
+ * isn't guaranteed to be identical to the types before serialization.  For
+ * instance, small numbers are always annotated as `int`, rather than
+ * `cryptographic`.
+ *
+ * @param simplifiedJSON a string representation of `GPCPCDPrescribedPODValues`
+ * @returns `GPCPCDPrescribedPODValues` deserialized from the string
+ * @throws if the serialized form is invalid
+ */
+export function gpcPCDPrescribedPODValuesFromSimplifiedJSON(
+  simplifiedJSON: string
+): GPCPCDPrescribedPODValues {
+  const simplifiedValues = jsonBigSerializer.parse(simplifiedJSON) as Record<
+    PODName,
+    { entries?: Record<PODName, PODRawValue>; signerPublicKey?: string }
+  >;
+
+  // Check shape of deserialised string.
+  if (
+    !(
+      // It is a record whose keys are of the right form.
+      (
+        typeof simplifiedValues === "object" &&
+        Object.keys(simplifiedValues).every(
+          (key) => key.match(POD_NAME_REGEX) !== null
+        ) &&
+        // For each of its values,
+        Object.values(simplifiedValues).every(
+          (podData) =>
+            // we should be dealing with an object
+            typeof podData === "object" &&
+            // containing at least one field,
+            Object.keys(podData).length >= 1 &&
+            // which should be either of 'entries' or 'signerPublicKey',
+            Object.keys(podData).every((key) =>
+              ["entries", "signerPublicKey"].includes(key)
+            ) &&
+            // and the signer's public key is an appropriate string (if
+            // specified),
+            (podData.signerPublicKey === undefined ||
+              (typeof podData.signerPublicKey === "string" &&
+                checkPublicKeyFormat(podData.signerPublicKey) ===
+                  podData.signerPublicKey)) &&
+            // and the entries must form a record mapping strings to raw POD
+            // values.
+            (podData.entries === undefined ||
+              (typeof podData.entries === "object" &&
+                Object.keys(podData.entries).every(
+                  (key) => typeof key === "string"
+                ) &&
+                Object.values(podData.entries).every((value) =>
+                  ["bigint", "string"].includes(typeof value)
+                )))
+        )
+      )
+    )
+  ) {
+    throw new TypeError(
+      `Invalid serialised GPCPCDPrescribedPODValues: ${simplifiedJSON}`
+    );
+  }
+
+  const prescribedValues = Object.fromEntries(
+    Object.entries(simplifiedValues).map(([podName, data]) => [
+      podName,
+      {
+        ...(data.entries !== undefined
+          ? {
+              entries: Object.fromEntries(
+                Object.entries(data.entries).map(([entryName, rawValue]) => [
+                  entryName,
+                  podValueFromRawValue(rawValue)
+                ])
+              )
+            }
+          : {}),
+        ...(data.signerPublicKey !== undefined
+          ? { signerPublicKey: data.signerPublicKey }
+          : {})
+      }
+    ])
+  ) as GPCPCDPrescribedPODValues;
+
+  return prescribedValues;
+}
+
+/**
+ * Serializes `GPCPCDPrescribedPODValues` to a string in a simplified format optimized
+ * for compactness and human readability.  Calling {@link
+ * gpcPCDPrescribedPODValuesFromSimplifiedJSON} will reconstruct
+ * `GPCPCDPrescribedPODValues` whose POD values will contain the same values and
+ * behave the same in hashing and circuits, but the type information may not be
+ * identical.
+ *
+ * @param toSerialize the prescribed values to serialize
+ * @param space pretty-printing configuration, as defined by the corresponding
+ *   argument to JSON.stringify.
+ * @returns a string representation
+ */
+export function gpcPCDPrescribedPODValuesToSimplifiedJSON(
+  toSerialize: GPCPCDPrescribedPODValues,
+  space?: number
+): string {
+  const simplifiedValues: Record<
+    PODName,
+    { entries?: Record<PODName, PODRawValue>; signerPublicKey?: string }
+  > = Object.fromEntries(
+    Object.entries(toSerialize).map(([podName, data]) => [
+      podName,
+      {
+        ...(data.entries !== undefined
+          ? {
+              entries: Object.fromEntries(
+                Object.entries(data.entries).map(([entryName, value]) => [
+                  entryName,
+                  podValueToRawValue(value)
+                ])
+              )
+            }
+          : {}),
+        ...(data.signerPublicKey !== undefined
+          ? { signerPublicKey: data.signerPublicKey }
+          : {})
+      }
+    ])
+  );
+  return jsonBigSerializer.stringify(simplifiedValues, null, space);
+}

--- a/packages/pcd/gpc-pcd/test/gpc-pcd.spec.ts
+++ b/packages/pcd/gpc-pcd/test/gpc-pcd.spec.ts
@@ -14,7 +14,12 @@ import { expect } from "chai";
 import "mocha";
 import path from "path";
 import { v4 as uuid } from "uuid";
-import { GPCPCDArgs, GPCPCDPackage } from "../src";
+import {
+  GPCPCDArgs,
+  GPCPCDPackage,
+  getProveDisplayOptions,
+  gpcPCDPrescribedPODValuesToSimplifiedJSON
+} from "../src";
 
 export const GPC_TEST_ARTIFACTS_PATH = path.join(
   __dirname,
@@ -184,6 +189,227 @@ describe("GPCPCD should work", async function () {
     // Confirms that the code in the repo is compatible with circuit
     // artifacts released on NPM.
     await runGPCPCDTest(GPC_NPM_ARTIFACTS_PATH);
+  });
+});
+
+describe("GPCPCD input POD validator should work", () => {
+  const pod0 = POD.sign(sampleEntries0, privateKey);
+  const podPCD0 = new PODPCD(uuid(), pod0);
+
+  const ticketPOD = POD.sign(sampleEntries1, privateKey);
+  const ticketPODPCD = new PODPCD(uuid(), ticketPOD);
+
+  const proofConfig = serializeGPCProofConfig({
+    pods: {
+      pod0: {
+        entries: {
+          A: { isRevealed: true },
+          H: { isRevealed: true },
+          E: { isRevealed: false, equalsEntry: "pod0.A" },
+          owner: {
+            isRevealed: false,
+            isOwnerID: true,
+            isMemberOf: "admissibleOwners"
+          }
+        }
+      },
+      ticketPOD: {
+        entries: {
+          eventID: {
+            isRevealed: true
+          },
+          ticketID: {
+            isRevealed: false,
+            isMemberOf: "admissibleTickets"
+          }
+        }
+      }
+    },
+    tuples: {
+      pair: { entries: ["pod0.A", "pod0.E"], isMemberOf: "admissiblePairs" }
+    }
+  });
+
+  const unserialisedMembershipLists = {
+    admissibleOwners: [
+      sampleEntries0.F,
+      sampleEntries0.C,
+      sampleEntries0.owner
+    ],
+    admissiblePairs: [
+      [sampleEntries0.D, sampleEntries0.B],
+      [sampleEntries0.A, sampleEntries0.E],
+      [sampleEntries0.owner, sampleEntries0.I],
+      [sampleEntries0.J, sampleEntries0.H]
+    ],
+    admissibleTickets: [
+      sampleEntries0.C,
+      sampleEntries0.owner,
+      sampleEntries1.ticketID
+    ]
+  };
+
+  const membershipLists = podMembershipListsToSimplifiedJSON(
+    unserialisedMembershipLists
+  );
+
+  const defaultArgs = getProveDisplayOptions().defaultArgs;
+
+  if (defaultArgs === undefined) {
+    throw new ReferenceError("Default arguments are undefined.");
+  }
+
+  const validateInputPOD = defaultArgs.pods.validate;
+
+  if (validateInputPOD === undefined) {
+    throw new ReferenceError("Input POD validator is undefined.");
+  }
+
+  it("Should validate an input POD given no parameters", () => {
+    expect(validateInputPOD("pod0", podPCD0, undefined)).to.be.true;
+  });
+
+  it("Should validate input PODs containing entries in a given proof configuration", () => {
+    const params = { proofConfig };
+    expect(validateInputPOD("pod0", podPCD0, params)).to.be.true;
+    expect(validateInputPOD("ticketPOD", ticketPODPCD, params)).to.be.true;
+  });
+
+  it("Should validate input PODs with prescribed entries", () => {
+    const prescribedValues = gpcPCDPrescribedPODValuesToSimplifiedJSON({
+      pod0: {
+        entries: {
+          A: { type: "int", value: 123n },
+          H: { type: "cryptographic", value: 8n }
+        }
+      },
+      ticketPOD: {
+        entries: {
+          eventID: { type: "cryptographic", value: 456n }
+        }
+      }
+    });
+    const params = { proofConfig, prescribedValues };
+    expect(validateInputPOD("pod0", podPCD0, params)).to.be.true;
+    expect(validateInputPOD("ticketPOD", ticketPODPCD, params)).to.be.true;
+  });
+
+  it("Should validate input PODs with prescribed signers' public keys", () => {
+    const prescribedValues = gpcPCDPrescribedPODValuesToSimplifiedJSON({
+      pod0: {
+        signerPublicKey: "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4"
+      },
+      ticketPOD: {
+        signerPublicKey: "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4"
+      }
+    });
+    const params = { proofConfig, prescribedValues };
+    expect(validateInputPOD("pod0", podPCD0, params)).to.be.true;
+    expect(validateInputPOD("ticketPOD", ticketPODPCD, params)).to.be.true;
+  });
+
+  it("Should validate input PODs with entries lying in membership lists", () => {
+    const params = { proofConfig, membershipLists };
+    expect(validateInputPOD("pod0", podPCD0, params)).to.be.true;
+    expect(validateInputPOD("ticketPOD", ticketPODPCD, params)).to.be.true;
+  });
+
+  it("Should validate input PODs with prescribed entries, signers' public keys and list membership requirements", () => {
+    const prescribedValues = gpcPCDPrescribedPODValuesToSimplifiedJSON({
+      pod0: {
+        entries: {
+          A: { type: "int", value: 123n },
+          H: { type: "cryptographic", value: 8n }
+        },
+        signerPublicKey: "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4"
+      },
+      ticketPOD: {
+        entries: {
+          eventID: { type: "cryptographic", value: 456n }
+        },
+        signerPublicKey: "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4"
+      }
+    });
+    const params = { proofConfig, membershipLists, prescribedValues };
+    expect(validateInputPOD("pod0", podPCD0, params)).to.be.true;
+    expect(validateInputPOD("ticketPOD", ticketPODPCD, params)).to.be.true;
+  });
+
+  it("Should not validate an input POD lacking entries in a given proof configuration", () => {
+    const proofConfig = serializeGPCProofConfig({
+      pods: {
+        pod0: {
+          entries: {
+            A: { isRevealed: true },
+            Example: { isRevealed: false, equalsEntry: "pod0.A" },
+            owner: {
+              isRevealed: false,
+              isOwnerID: true,
+              isMemberOf: "admissibleOwners"
+            }
+          }
+        },
+        ticketPOD: {
+          entries: {
+            ticketID: {
+              isRevealed: false,
+              isMemberOf: "admissibleTickets"
+            }
+          }
+        }
+      },
+      tuples: {
+        pair: {
+          entries: ["pod0.A", "pod0.Example"],
+          isMemberOf: "admissiblePairs"
+        }
+      }
+    });
+    expect(validateInputPOD("pod0", podPCD0, { proofConfig })).to.be.false;
+    expect(validateInputPOD("ticketPOD", ticketPODPCD, { proofConfig })).to.be
+      .true;
+  });
+
+  it("Should not validate an input POD violating a list membership requirement", () => {
+    const membershipLists = podMembershipListsToSimplifiedJSON({
+      ...unserialisedMembershipLists,
+      admissibleOwners: [sampleEntries0.C, sampleEntries0.A]
+    });
+    const params = { proofConfig, membershipLists };
+    expect(validateInputPOD("pod0", podPCD0, params)).to.be.false;
+  });
+
+  it("Should not validate an input POD violating a prescribed entry value", () => {
+    const prescribedValues = gpcPCDPrescribedPODValuesToSimplifiedJSON({
+      pod0: {
+        entries: {
+          A: { type: "int", value: 0n },
+          H: { type: "cryptographic", value: 8n }
+        }
+      },
+      ticketPOD: {
+        entries: {
+          eventID: { type: "cryptographic", value: 456n }
+        }
+      }
+    });
+    const params = { proofConfig, prescribedValues };
+    expect(validateInputPOD("pod0", podPCD0, params)).to.be.false;
+    expect(validateInputPOD("ticketPOD", ticketPODPCD, params)).to.be.true;
+  });
+
+  it("Should not validate an input POD violating a prescribed signer's public key", () => {
+    const prescribedValues = gpcPCDPrescribedPODValuesToSimplifiedJSON({
+      pod0: {
+        signerPublicKey: "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4"
+      },
+      ticketPOD: {
+        signerPublicKey: "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ3"
+      }
+    });
+    const params = { proofConfig, prescribedValues };
+    expect(validateInputPOD("pod0", podPCD0, params)).to.be.true;
+    expect(validateInputPOD("ticketPOD", ticketPODPCD, params)).to.be.false;
   });
 });
 

--- a/packages/pcd/gpc-pcd/test/util.spec.ts
+++ b/packages/pcd/gpc-pcd/test/util.spec.ts
@@ -1,0 +1,123 @@
+import { expect } from "chai";
+import JSONBig from "json-bigint";
+import {
+  GPCPCDPrescribedPODValues,
+  gpcPCDPrescribedPODValuesFromSimplifiedJSON,
+  gpcPCDPrescribedPODValuesToSimplifiedJSON
+} from "../src";
+
+const jsonBigSerializer = JSONBig({
+  useNativeBigInt: true,
+  alwaysParseAsBig: true
+});
+
+describe("GPCPCDPrescribedValues serialisation should work", () => {
+  it("Should serialise and deserialise empty object", async function () {
+    const serialised = gpcPCDPrescribedPODValuesToSimplifiedJSON({});
+    const expectedSerialised = "{}";
+    const deserialised =
+      gpcPCDPrescribedPODValuesFromSimplifiedJSON(serialised);
+    expect(serialised).to.eq(expectedSerialised);
+    expect(deserialised).to.deep.eq({});
+  });
+
+  it("Should serialise and deserialise record containing typical POD data", () => {
+    const typicalPrescribedValues: GPCPCDPrescribedPODValues = {
+      pod1: {
+        entries: {
+          ticketID: { type: "int", value: 5558n },
+          eventID: { type: "int", value: 0n }
+        },
+        signerPublicKey: "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4"
+      },
+      pod2: {
+        entries: {
+          hp: { type: "int", value: 55n }
+        }
+      },
+      pod3: {
+        signerPublicKey: "oyL3ppa3qjpSJO+zmTuvDM2eku7O4KKaP2yCCKnoHZo"
+      }
+    };
+
+    const serialised = gpcPCDPrescribedPODValuesToSimplifiedJSON(
+      typicalPrescribedValues
+    );
+
+    const expectedSerialised = jsonBigSerializer.stringify({
+      pod1: {
+        entries: {
+          ticketID: 5558n,
+          eventID: 0n
+        },
+        signerPublicKey: "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4"
+      },
+      pod2: {
+        entries: {
+          hp: 55n
+        }
+      },
+      pod3: {
+        signerPublicKey: "oyL3ppa3qjpSJO+zmTuvDM2eku7O4KKaP2yCCKnoHZo"
+      }
+    });
+
+    const deserialised =
+      gpcPCDPrescribedPODValuesFromSimplifiedJSON(serialised);
+
+    expect(serialised).to.eq(expectedSerialised);
+    expect(deserialised).to.deep.eq(typicalPrescribedValues);
+  });
+
+  it("Should fail to deserialise a string not representing an object", () => {
+    expect(() =>
+      gpcPCDPrescribedPODValuesFromSimplifiedJSON(`"hello"`)
+    ).to.throw(TypeError);
+  });
+
+  it("Should fail to deserialise a record with an invalid POD name", () => {
+    expect(() =>
+      gpcPCDPrescribedPODValuesFromSimplifiedJSON(`{
+        "$notPOD": { "entries": { "entry": 5 } }
+      }`)
+    ).to.throw(TypeError);
+  });
+
+  it("Should fail to deserialise a record with a POD with no data", () => {
+    expect(() =>
+      gpcPCDPrescribedPODValuesFromSimplifiedJSON(`{ "somePOD": {} }`)
+    ).to.throw(TypeError);
+  });
+
+  it("Should fail to deserialise a record with a POD with an unexpected field", () => {
+    expect(() =>
+      gpcPCDPrescribedPODValuesFromSimplifiedJSON(`{
+        "somePOD": { "privateKey": 0 }
+      }`)
+    ).to.throw(TypeError);
+  });
+
+  it("Should fail to deserialise a record with a POD with an invalid entry field", () => {
+    expect(() =>
+      gpcPCDPrescribedPODValuesFromSimplifiedJSON(`{
+        "somePOD": { "entries": 55 }
+      }`)
+    ).to.throw(TypeError);
+  });
+
+  it("Should fail to deserialise a record with a POD with an invalid raw entry value", () => {
+    expect(() =>
+      gpcPCDPrescribedPODValuesFromSimplifiedJSON(`{
+        "somePOD": { "entries": { "entry": {} } }
+      }`)
+    ).to.throw(TypeError);
+  });
+
+  it("Should fail to deserialise a record with a POD with an invalid signer's public key", () => {
+    expect(() =>
+      gpcPCDPrescribedPODValuesFromSimplifiedJSON(`{
+        "somePOD": { "signerPublicKey": "33a" }
+      }`)
+    ).to.throw(TypeError);
+  });
+});


### PR DESCRIPTION
Summary of this PR:
- Additional filtering to GPCPCD's input POD validator, viz.
  - List membership checks for entry values, and
  - Prescribed value checks for entries and signers' public keys.
- Tests

Notably absent are checks for tuples. This will require further changes to the frontend, which this PR does not address.

Marking as draft pending changes to the consumer client.