### PR TITLE
Alternate interface for checking signer of email credentials

### DIFF
--- a/apps/passport-server/test/generic-issuance/credentialSubservice.spec.ts
+++ b/apps/passport-server/test/generic-issuance/credentialSubservice.spec.ts
@@ -180,10 +180,19 @@ describe("generic issuance - credential subservice", function () {
       }
     }
 
+    for (const [key, credential] of Object.entries(badCredentials)) {
+      try {
+        await credentialSubservice.verifyAndExpectZupassEmail(credential);
+        assert(false, `${key} did not throw exception during verification`);
+      } catch (e) {
+        expect(e instanceof VerificationError).to.be.true;
+      }
+    }
+
     // Calling `verify` on a credential containing an Email PCD not from
-    // Zupass will succeed (assuming credential is otherwise valid).
-    // To check if the Email PCD is from Zupass, call
-    // verifyAndExpectZupassEmail() as shown above
+    // Zupass (without the optional isTrustedEmailPCDSigner) will succeed
+    // (assuming credential is otherwise valid).  To check if the Email PCD is
+    // from Zupass, call verifyAndExpectZupassEmail() as shown above
     expect(
       isEqualEdDSAPublicKey(
         // Verify will return a VerifiedCredential containing an


### PR DESCRIPTION
I started out just trying to update the documentation, but then decided to experiment with how to change the interface so it's harder to forget to check the signing key on the email PCD.  @robknight let me know if you think is a good direction to go.

I updated the PODBox code to use the new optional arg.  It should be backward-compatible for any callers who aren't doing so, though I think it would be good to update ZuAuth to use the new arg as well so it becomes an example of proper usage.
