### PR TITLE
less annoying log out interaction

### DIFF
--- a/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
@@ -8,7 +8,12 @@ import {
   useState
 } from "react";
 import { appConfig } from "../../../src/appConfig";
-import { useDispatch, useQuery, useSelf } from "../../../src/appHooks";
+import {
+  useDispatch,
+  useQuery,
+  useSelf,
+  useStateContext
+} from "../../../src/appHooks";
 import {
   pendingRequestKeys,
   setPendingAddRequest,
@@ -28,11 +33,13 @@ import {
   Spacer,
   TextCenter
 } from "../../core";
+import { RippleLoader } from "../../core/RippleLoader";
 import { AppContainer } from "../../shared/AppContainer";
 import { InlineError } from "../../shared/InlineError";
 
 export function LoginScreen(): JSX.Element {
   const dispatch = useDispatch();
+  const state = useStateContext().getState();
   const [error, setError] = useState<string | undefined>();
   const query = useQuery();
   const redirectedFromAction = query?.get("redirectedFromAction") === "true";
@@ -129,7 +136,17 @@ export function LoginScreen(): JSX.Element {
   return (
     <AppContainer bg="primary">
       <Spacer h={64} />
-      {redirectedFromAction ? (
+      {state.loggingOut ? (
+        <>
+          <TextCenter>
+            <H1>ZUPASS</H1>
+            <Spacer h={24} />
+            Logging you out...
+            <Spacer h={8} />
+            <RippleLoader />
+          </TextCenter>
+        </>
+      ) : redirectedFromAction ? (
         <>
           <TextCenter>
             <H2>ZUPASS</H2>
@@ -149,30 +166,32 @@ export function LoginScreen(): JSX.Element {
         </>
       )}
 
-      <Spacer h={24} />
-
-      <CenterColumn>
-        <form onSubmit={onGenPass}>
-          <BigInput
-            autoCapitalize="off"
-            autoCorrect="off"
-            type="text"
-            autoFocus
-            placeholder="email address"
-            value={email}
-            onChange={useCallback(
-              (e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value),
-              [setEmail]
-            )}
-          />
-          <InlineError error={error} />
-          <Spacer h={8} />
-          <Button style="primary" type="submit">
-            Continue
-          </Button>
-        </form>
-      </CenterColumn>
-      <Spacer h={64} />
+      {!state.loggingOut && (
+        <>
+          <Spacer h={24} />
+          <CenterColumn>
+            <form onSubmit={onGenPass}>
+              <BigInput
+                autoCapitalize="off"
+                autoCorrect="off"
+                type="text"
+                autoFocus
+                placeholder="email address"
+                value={email}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setEmail(e.target.value)
+                }
+              />
+              <InlineError error={error} />
+              <Spacer h={8} />
+              <Button style="primary" type="submit">
+                Continue
+              </Button>
+            </form>
+          </CenterColumn>
+          <Spacer h={64} />
+        </>
+      )}
     </AppContainer>
   );
 }

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -680,15 +680,17 @@ async function resetPassport(state: AppState, update: ZuUpdate): Promise<void> {
   // Clear in-memory state
   update({
     self: undefined,
+    loggingOut: true,
     modal: {
       modalType: "none"
     }
   });
-  notifyLogoutToOtherTabs();
 
   setTimeout(() => {
     window.location.reload();
   }, 1);
+
+  notifyLogoutToOtherTabs();
 }
 
 async function addPCDs(

--- a/apps/passport-client/src/state.ts
+++ b/apps/passport-client/src/state.ts
@@ -44,6 +44,11 @@ export interface AppState {
   // User metadata.
   self?: User;
 
+  // if the client is in the process of logging out,
+  // shows alternate UI on the login page to prevent
+  // user confusion
+  loggingOut?: boolean;
+
   // If set, shows an error popover.
   error?: AppError;
 


### PR DESCRIPTION
fixes: https://linear.app/0xparc-pcd/issue/0XP-965/logout-interaction-in-zupass-client-is-annoying

#### before
note how the page reloads **after** you log out, interrupting your interaction with the email address input

https://github.com/proofcarryingdata/zupass/assets/2636237/9c575a85-00db-4188-aa20-8c786a0a931f

#### after
now the login page is aware that there is an impending reload, and prevents you from interacting with anything until the logout is fully completed

https://github.com/proofcarryingdata/zupass/assets/2636237/85bd5d87-e0c5-4f4f-9ee7-2c467acdeabf

*timings exaggerated for effect*
