### PR TITLE
display pipeline atoms a json stringified array in pipeline data view in podbox

### DIFF
--- a/apps/generic-issuance-client/src/pages/pipeline/DetailsSections/PipelineLatestDataSection.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/DetailsSections/PipelineLatestDataSection.tsx
@@ -18,9 +18,8 @@ export function PipelineLatestDataSection({
 }): ReactNode {
   const [maximized, setMaximized] = useState(false);
   const stringifiedValue = useMemo(() => {
-    return (
-      latestAtoms?.map((log) => JSON.stringify(log, null, 2)).join("\n\n") ?? ""
-    );
+    if (!latestAtoms) return "";
+    return JSON.stringify(latestAtoms, null, 2);
   }, [latestAtoms]);
 
   if (!latestAtoms || !lastLoad) {


### PR DESCRIPTION
fixes https://linear.app/0xparc-pcd/issue/0XP-943/data-view-in-podbox-should-be-a-json-array-not-a-bunch-of-new-line

#### before
<img width="456" alt="Screenshot 2024-06-18 at 4 41 53 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/a4c28221-690b-4ca5-8060-e35c86c8c8bc">


#### after
<img width="445" alt="Screenshot 2024-06-18 at 4 41 36 PM" src="https://github.com/proofcarryingdata/zupass/assets/2636237/830394ef-1018-40fa-acf7-7d7e2299f454">


