### PR TITLE
Fix build warnings for ZuAuth example

### DIFF
--- a/apps/consumer-server/package.json
+++ b/apps/consumer-server/package.json
@@ -24,7 +24,7 @@
     "@pcd/zuauth": "1.4.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "iron-session": "^8.0.1",
+    "iron-session": "^8.0.2",
     "morgan": "^1.10.0",
     "react": "^18.2.0",
     "ts-node": "^10.9.2"

--- a/examples/zuauth/package.json
+++ b/examples/zuauth/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@pcd/passport-interface": "^0.11.2",
     "@pcd/zuauth": "1.4.2",
-    "iron-session": "^8.0.1",
+    "iron-session": "^8.0.2",
     "next": "^14.1.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@pcd/eslint-config-custom": "0.11.1",
     "@pcd/tsconfig": "0.11.1",
+    "@types/cookie": "^0.6.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/examples/zuauth/src/app/api/login/route.ts
+++ b/examples/zuauth/src/app/api/login/route.ts
@@ -14,6 +14,7 @@ import { NextRequest } from "next/server";
  * event config (public key, event ID, product ID).
  */
 export async function POST(req: NextRequest) {
+  const cookieStore = cookies();
   const body = await req.json();
   if (!body.pcd || !(typeof body.pcd === "string")) {
     console.error(`[ERROR] No PCD specified`);
@@ -21,10 +22,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const session = await getIronSession<SessionData>(
-      cookies() as any,
-      ironOptions
-    );
+    const session = await getIronSession<SessionData>(cookieStore, ironOptions);
     const pcd = await authenticate(body.pcd, session.watermark ?? "", config);
 
     session.user = pcd.claim.partialTicket;

--- a/examples/zuauth/src/app/api/logout/route.ts
+++ b/examples/zuauth/src/app/api/logout/route.ts
@@ -3,11 +3,9 @@ import { getIronSession } from "iron-session";
 import { cookies } from "next/headers";
 
 export async function POST() {
+  const cookieStore = cookies();
   try {
-    const session = await getIronSession<SessionData>(
-      cookies() as any,
-      ironOptions
-    );
+    const session = await getIronSession<SessionData>(cookieStore, ironOptions);
     session.destroy();
 
     return Response.json({

--- a/examples/zuauth/src/app/api/watermark/route.ts
+++ b/examples/zuauth/src/app/api/watermark/route.ts
@@ -10,11 +10,9 @@ import { cookies } from "next/headers";
  * created for our use, and is not being re-used.
  */
 export async function GET() {
+  const cookieStore = cookies();
   try {
-    const session = await getIronSession<SessionData>(
-      cookies() as any,
-      ironOptions
-    );
+    const session = await getIronSession<SessionData>(cookieStore, ironOptions);
     session.watermark = hexToBigInt(
       toHexString(getRandomValues(30))
     ).toString();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6199,6 +6199,11 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
+
 "@types/cookies@*":
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.8.tgz#16fccd6d58513a9833c527701a90cc96d216bc18"
@@ -13287,19 +13292,19 @@ ipaddr.js@^2.0.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.1.0.tgz#2119bc447ff8c257753b196fc5f1ce08a4cdf39f"
   integrity sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==
 
-iron-session@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/iron-session/-/iron-session-8.0.1.tgz#d36d70fac7e96952f126ba4ae09084f9a3410193"
-  integrity sha512-ZQKazQRn/J5YaXY+CQ69V9lx9boh4swl+BgnNC1knxyZgBjhiXuGpY60URRntMPib9QdrsN9qAOTqdMFMbGYXg==
+iron-session@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/iron-session/-/iron-session-8.0.2.tgz#9802e080206a8ba41911b53d29ff7de11161d036"
+  integrity sha512-p4Yf1moQr6gnCcXu5vCaxVKRKDmR9PZcQDfp7ZOgbsSHUsgaNti6OgDB2BdgxC2aS6V/6Hu4O0wYlj92sbdIJg==
   dependencies:
     cookie "0.6.0"
-    iron-webcrypto "1.0.0"
+    iron-webcrypto "1.2.1"
     uncrypto "0.1.3"
 
-iron-webcrypto@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/iron-webcrypto/-/iron-webcrypto-1.0.0.tgz#e3b689c0c61b434a0a4cb82d0aeabbc8b672a867"
-  integrity sha512-anOK1Mktt8U1Xi7fCM3RELTuYbnFikQY5VtrDj7kPgpejV7d43tWKhzgioO0zpkazLEL/j/iayRqnJhrGfqUsg==
+iron-webcrypto@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz#aa60ff2aa10550630f4c0b11fd2442becdb35a6f"
+  integrity sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==
 
 is-absolute@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-766/zuath-build-warning

Fixes a warning that NextJS was giving for the use of `cookies()`. It turns out that the warning only occurs if you call `cookies()` inside a try/catch block.

Also fixed a type mismatch that `iron-session` has with the NextJS cookie store type, by directly depending on `@types/cookie` 0.6.0.