### PR TITLE
Fix serializing bigint issue

### DIFF
--- a/apps/passport-client/components/screens/AddScreen/JustAddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/JustAddScreen.tsx
@@ -54,9 +54,9 @@ export function JustAddScreen({
       if (isProtocolWorlds) {
         confetti();
         await requestLogToServer(appConfig.zupassServer, "added-tension", {
-          commitment: self.commitment,
+          commitment: self.commitment.toString(),
           email: self.email,
-          pcd,
+          pcd: request.pcd,
           tension: (pcd as EdDSATicketPCD)?.claim?.ticket?.eventName
         });
       }


### PR DESCRIPTION
Fixes issue from #1809 - PCD (and potentially commitment) includes bigints, which are not serializable when sent to the server

<img width="767" alt="Screenshot 2024-06-24 at 12 57 00 PM" src="https://github.com/proofcarryingdata/zupass/assets/36896271/9cf20a2b-9e91-4d41-acb8-7bb9b2798c6b">
