### PR TITLE
Issue arbitrary PODs from the CSV pipeline

### DIFF
--- a/apps/generic-issuance-client/src/pages/SamplePipelines.ts
+++ b/apps/generic-issuance-client/src/pages/SamplePipelines.ts
@@ -81,7 +81,8 @@ export const SAMPLE_CSV_PODS = `
 
 email,title,description,imageUrl
 mail@robknight.org.uk,Testing,A test POD,https://images.unsplash.com/photo-1495615080073-6b89c9839ce0?q=80&w=400&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
-
+richard@0xparc.org,Testing,A test POD,https://images.unsplash.com/photo-1495615080073-6b89c9839ce0?q=80&w=400&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
+ivan@0xparc.org,Testing,A test POD,https://images.unsplash.com/photo-1495615080073-6b89c9839ce0?q=80&w=400&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
 
 `
   .split("\n")

--- a/apps/generic-issuance-client/src/pages/SamplePipelines.ts
+++ b/apps/generic-issuance-client/src/pages/SamplePipelines.ts
@@ -77,6 +77,17 @@ America,GA,Richard,richard@pcd.team,https://upload.wikimedia.org/wikipedia/commo
   .filter((l) => l.length > 0)
   .join("\n");
 
+export const SAMPLE_CSV_PODS = `
+
+email,title,description,imageUrl
+mail@robknight.org.uk,Testing,A test POD,https://images.unsplash.com/photo-1495615080073-6b89c9839ce0?q=80&w=400&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
+
+
+`
+  .split("\n")
+  .filter((l) => l.length > 0)
+  .join("\n");
+
 export function getSampleCSVData(
   outputType = CSVPipelineOutputType.Message
 ): string {
@@ -86,6 +97,8 @@ export function getSampleCSVData(
     case CSVPipelineOutputType.Ticket:
     case CSVPipelineOutputType.PODTicket:
       return SAMPLE_CSV_EDDSA_TICKET;
+    case CSVPipelineOutputType.POD:
+      return SAMPLE_CSV_PODS;
     default:
       return "not implemented";
   }
@@ -100,6 +113,8 @@ export function getSampleFeedOptions(
     case CSVPipelineOutputType.Ticket:
     case CSVPipelineOutputType.PODTicket:
       return TICKET_FEED_OPTS;
+    case CSVPipelineOutputType.POD:
+      return POD_FEED_OPTS;
     default:
       throw new Error("not implemented");
   }
@@ -117,6 +132,13 @@ export const TICKET_FEED_OPTS = {
   feedDisplayName: "eth_denver_tickets.csv",
   feedDescription: "eth_denver_tickets",
   feedFolder: "EthDenver"
+} satisfies FeedIssuanceOptions;
+
+export const POD_FEED_OPTS = {
+  feedId: "0",
+  feedDisplayName: "pods.csv",
+  feedDescription: "CSV pods",
+  feedFolder: "CSV PODs"
 } satisfies FeedIssuanceOptions;
 
 export const SAMPLE_CSV_PIPELINE = JSON.stringify(

--- a/apps/generic-issuance-client/src/pages/create-pipeline/pipeline-builders/CSVPipelineBuilder.tsx
+++ b/apps/generic-issuance-client/src/pages/create-pipeline/pipeline-builders/CSVPipelineBuilder.tsx
@@ -139,12 +139,21 @@ export default function CSVPipelineBuilder(
                     podOutput:
                       outputType === CSVPipelineOutputType.POD
                         ? {
+                            /**
+                             * The keys used here are the names of POD entries,
+                             * and are arbitrary. Fields can be freely added,
+                             * removed, and renamed.
+                             */
                             owner: {
                               type: "cryptographic",
+                              // Shows how a value can be sourced from the
+                              // user's auth credential.
                               source: { type: "credentialSemaphoreID" }
                             },
                             zupass_title: {
                               type: "string",
+                              // Shows how a value can be sourced from the CSV
+                              // input.
                               source: { type: "input", name: "title" }
                             },
                             zupass_description: {
@@ -157,6 +166,8 @@ export default function CSVPipelineBuilder(
                             },
                             zupass_display: {
                               type: "string",
+                              // Shows how a value can be specified in
+                              // configuration.
                               source: {
                                 type: "configured",
                                 value: "collectable"

--- a/apps/generic-issuance-client/src/pages/create-pipeline/pipeline-builders/CSVPipelineBuilder.tsx
+++ b/apps/generic-issuance-client/src/pages/create-pipeline/pipeline-builders/CSVPipelineBuilder.tsx
@@ -131,7 +131,39 @@ export default function CSVPipelineBuilder(
                     name: feedOptions.feedFolder,
                     csv,
                     feedOptions,
-                    outputType
+                    outputType,
+                    match:
+                      outputType === CSVPipelineOutputType.POD
+                        ? { type: "email", inputField: "email" }
+                        : undefined,
+                    podOutput:
+                      outputType === CSVPipelineOutputType.POD
+                        ? {
+                            owner: {
+                              type: "cryptographic",
+                              source: { type: "credentialSemaphoreID" }
+                            },
+                            zupass_title: {
+                              type: "string",
+                              source: { type: "input", name: "title" }
+                            },
+                            zupass_description: {
+                              type: "string",
+                              source: { type: "input", name: "description" }
+                            },
+                            zupass_image_url: {
+                              type: "string",
+                              source: { type: "input", name: "imageUrl" }
+                            },
+                            zupass_display: {
+                              type: "string",
+                              source: {
+                                type: "configured",
+                                value: "collectable"
+                              }
+                            }
+                          }
+                        : undefined
                   }
                 } satisfies Partial<CSVPipelineDefinition>)
               )

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
@@ -58,8 +58,6 @@ export class CSVPipeline implements BasePipeline {
   private definition: CSVPipelineDefinition;
   private credentialSubservice: CredentialSubservice;
 
-  private titleRow: string[] = [];
-
   public get id(): string {
     return this.definition.id;
   }
@@ -117,11 +115,6 @@ export class CSVPipeline implements BasePipeline {
         }
       }
 
-      const columnMapping = new Map<string, number>();
-      for (let i = 0; i < this.titleRow.length; i++) {
-        columnMapping.set(this.titleRow[i], i);
-      }
-
       // TODO: cache these
       const somePCDs = await Promise.all(
         atoms.map(async (atom: CSVAtom) =>
@@ -135,7 +128,6 @@ export class CSVPipeline implements BasePipeline {
               pipelineId: this.id,
               issueToUnmatchedEmail:
                 this.definition.options.issueToUnmatchedEmail,
-              columnMapping,
               podOutput: this.definition.options.podOutput,
               matchConfig: this.definition.options.match
             }
@@ -336,7 +328,6 @@ export async function makeCSVPCD(
     issueToUnmatchedEmail?: boolean;
     podOutput?: CSVPipelinePODEntryOptions;
     matchConfig?: CSVPipelineMatchConfig;
-    columnMapping: Map<string, number>;
   }
 ): Promise<SerializedPCD | undefined> {
   return traced("makeCSVPCD", "makeCSVPCD", async (span) => {

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
@@ -1,7 +1,9 @@
 import { getEdDSAPublicKey } from "@pcd/eddsa-pcd";
 import {
   CSVPipelineDefinition,
+  CSVPipelineMatchConfig,
   CSVPipelineOutputType,
+  CSVPipelinePODEntryOptions,
   PipelineEdDSATicketZuAuthConfig,
   PipelineLoadSummary,
   PipelineLog,
@@ -12,6 +14,7 @@ import {
 } from "@pcd/passport-interface";
 import { PCDActionType } from "@pcd/pcd-collection";
 import { SerializedPCD } from "@pcd/pcd-types";
+import { assertUnreachable } from "@pcd/util";
 import { parse } from "csv-parse";
 import { v4 as uuid } from "uuid";
 import {
@@ -30,6 +33,7 @@ import { CredentialSubservice } from "../../subservices/CredentialSubservice";
 import { BasePipelineCapability } from "../../types";
 import { makePLogErr, makePLogInfo } from "../logging";
 import { BasePipeline, Pipeline } from "../types";
+import { makeGenericPODPCD } from "./makeGenericPODPCD";
 import { makeMessagePCD } from "./makeMessagePCD";
 import { makePODTicketPCD } from "./makePODTicketPCD";
 import {
@@ -42,7 +46,7 @@ const LOG_NAME = "CSVPipeline";
 const LOG_TAG = `[${LOG_NAME}]`;
 
 export interface CSVAtom extends PipelineAtom {
-  row: string[];
+  row: Record<string, string>;
 }
 
 export class CSVPipeline implements BasePipeline {
@@ -53,6 +57,8 @@ export class CSVPipeline implements BasePipeline {
   private db: IPipelineAtomDB<CSVAtom>;
   private definition: CSVPipelineDefinition;
   private credentialSubservice: CredentialSubservice;
+
+  private titleRow: string[] = [];
 
   public get id(): string {
     return this.definition.id;
@@ -111,6 +117,11 @@ export class CSVPipeline implements BasePipeline {
         }
       }
 
+      const columnMapping = new Map<string, number>();
+      for (let i = 0; i < this.titleRow.length; i++) {
+        columnMapping.set(this.titleRow[i], i);
+      }
+
       // TODO: cache these
       const somePCDs = await Promise.all(
         atoms.map(async (atom: CSVAtom) =>
@@ -123,7 +134,10 @@ export class CSVPipeline implements BasePipeline {
               eddsaPrivateKey: this.eddsaPrivateKey,
               pipelineId: this.id,
               issueToUnmatchedEmail:
-                this.definition.options.issueToUnmatchedEmail
+                this.definition.options.issueToUnmatchedEmail,
+              columnMapping,
+              podOutput: this.definition.options.podOutput,
+              matchConfig: this.definition.options.match
             }
           )
         )
@@ -166,8 +180,6 @@ export class CSVPipeline implements BasePipeline {
 
       try {
         const parsedCSV = await parseCSV(this.definition.options.csv);
-        const titleRow = parsedCSV.shift();
-        logs.push(makePLogInfo(`skipped title row '${titleRow}'`));
         const atoms = parsedCSV.map((row) => {
           return {
             id: uuid(),
@@ -282,13 +294,13 @@ export class CSVPipeline implements BasePipeline {
   }
 }
 
-export function parseCSV(csv: string): Promise<string[][]> {
+export function parseCSV(csv: string): Promise<Record<string, string>[]> {
   return traced("parseCSV", "parseCSV", async (span) => {
-    return new Promise<string[][]>((resolve, reject) => {
+    return new Promise<Record<string, string>[]>((resolve, reject) => {
       span?.setAttribute("text_length", csv.length);
 
-      const parser = parse();
-      const records: string[][] = [];
+      const parser = parse({ columns: true });
+      const records: Record<string, string>[] = [];
 
       parser.on("readable", function () {
         let record;
@@ -314,7 +326,7 @@ export function parseCSV(csv: string): Promise<string[][]> {
 }
 
 export async function makeCSVPCD(
-  inputRow: string[],
+  inputRow: Record<string, string>,
   type: CSVPipelineOutputType,
   opts: {
     requesterEmail?: string;
@@ -322,6 +334,9 @@ export async function makeCSVPCD(
     eddsaPrivateKey: string;
     pipelineId: string;
     issueToUnmatchedEmail?: boolean;
+    podOutput?: CSVPipelinePODEntryOptions;
+    matchConfig?: CSVPipelineMatchConfig;
+    columnMapping: Map<string, number>;
   }
 ): Promise<SerializedPCD | undefined> {
   return traced("makeCSVPCD", "makeCSVPCD", async (span) => {
@@ -348,10 +363,25 @@ export async function makeCSVPCD(
           opts.pipelineId,
           opts.issueToUnmatchedEmail
         );
+      case CSVPipelineOutputType.POD:
+        if (!opts.podOutput) {
+          throw new Error("Missing POD output configuration");
+        }
+
+        return makeGenericPODPCD(
+          inputRow,
+          opts.eddsaPrivateKey,
+          opts.requesterEmail,
+          opts.requesterSemaphoreId,
+          opts.pipelineId,
+          opts.issueToUnmatchedEmail,
+          opts.podOutput,
+          opts.matchConfig
+        );
       default:
         // will not compile in case we add a new output type
         // if you've added another type, plz add an impl here XD
-        return null as never;
+        assertUnreachable(type);
     }
   });
 }

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makeGenericPODPCD.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makeGenericPODPCD.ts
@@ -23,28 +23,41 @@ export async function makeGenericPODPCD(
       return undefined;
     }
 
+    // PODs can be issued either to anyone who makes a request, OR to anyone
+    // whose credential matches some of the values contained in the POD.
+    // To issue to anyone, `issueToUnmatchedEmail` must be enabled. If it is
+    // not, then some `matchConfig` must be specified.
     if (issueToUnmatchedEmail !== true && !matchConfig) {
       throw new Error("No configuration for matching requests to CSV data");
     }
 
     if (!issueToUnmatchedEmail) {
+      // If we are matching the user by comparing their email to some value in
+      // the CSV input data:
       if (matchConfig?.type === "email") {
         const emailColumnName = matchConfig.inputField;
+        // Check if the column exists
         if (!(emailColumnName in inputRow)) {
           throw new Error(
             `Could not find column "${emailColumnName}" in CSV input data, could not match against user email address`
           );
         }
+        // If the value does not match, no POD is issued
         if (inputRow[emailColumnName] !== requesterEmail) {
           return undefined;
         }
-      } else if (matchConfig?.type === "semaphoreID") {
+      }
+      // If we are matching the user by comparing their Semaphore ID to some
+      // value in the CSV input data:
+      else if (matchConfig?.type === "semaphoreID") {
         const semaphoreIDColumnName = matchConfig.inputField;
+        // Check if the column exists
         if (!(semaphoreIDColumnName in inputRow)) {
           throw new Error(
             `Could not find column "${semaphoreIDColumnName}" in CSV input data, could not match against user Semaphore ID`
           );
         }
+        // If the value does not match, no POD is issued
         if (inputRow[semaphoreIDColumnName] !== requesterSemaphoreId) {
           return undefined;
         }
@@ -53,29 +66,39 @@ export async function makeGenericPODPCD(
 
     const entries: PODEntries = {};
 
+    // Iterate over configured POD entries
     for (const [name, entryConfig] of Object.entries(output)) {
       switch (entryConfig.source.type) {
+        // This entry is populated from configuration
         case "configured":
           /* @todo non-string values */
           entries[name] = { type: "string", value: entryConfig.source.value };
           break;
+        // This entry is populated by the email from the user's credential
         case "credentialEmail":
           entries[name] = { type: "string", value: requesterEmail };
           break;
+        // This entry is populated by the Semaphore ID from the user's
+        // credential
         case "credentialSemaphoreID":
           entries[name] = {
             type: "cryptographic",
             value: BigInt(requesterSemaphoreId)
           };
           break;
+        // This entry is populated by some value from the CSV input.
         case "input":
           const columnName = entryConfig.source.name;
+          // Check if the configured column exists.
           if (!(columnName in inputRow)) {
             throw new Error(
               `Could not find column "${entryConfig.source.name}" in CSV data, required by output field ${name}`
             );
           }
           const value = inputRow[columnName];
+          // Create a POD entry with the appropriate type and value.
+          // This could perhaps use some more validation, possibly based on the
+          // work done in PODTicketPCD on Zod validation for POD entries.
           if (entryConfig.type === "cryptographic") {
             entries[name] = {
               type: "cryptographic",

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makeGenericPODPCD.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makeGenericPODPCD.ts
@@ -1,0 +1,118 @@
+import {
+  CSVPipelineMatchConfig,
+  CSVPipelinePODEntryOptions
+} from "@pcd/passport-interface";
+import { ArgumentTypeName, SerializedPCD } from "@pcd/pcd-types";
+import { PODEntries } from "@pcd/pod";
+import { PODPCD, PODPCDPackage } from "@pcd/pod-pcd";
+import { v5 as uuidv5 } from "uuid";
+import { traced } from "../../../telemetryService";
+
+export async function makeGenericPODPCD(
+  inputRow: Record<string, string>,
+  eddsaPrivateKey: string,
+  requesterEmail: string | undefined,
+  requesterSemaphoreId: string | undefined,
+  pipelineId: string,
+  issueToUnmatchedEmail: boolean | undefined,
+  output: CSVPipelinePODEntryOptions,
+  matchConfig?: CSVPipelineMatchConfig
+): Promise<SerializedPCD<PODPCD> | undefined> {
+  return traced("", "makeGenericPODPCD", async () => {
+    if (!requesterEmail || !requesterSemaphoreId) {
+      return undefined;
+    }
+
+    if (issueToUnmatchedEmail !== true && !matchConfig) {
+      throw new Error("No configuration for matching requests to CSV data");
+    }
+
+    if (!issueToUnmatchedEmail) {
+      if (matchConfig?.type === "email") {
+        const emailColumnName = matchConfig.inputField;
+        if (!(emailColumnName in inputRow)) {
+          throw new Error(
+            `Could not find column "${emailColumnName}" in CSV input data, could not match against user email address`
+          );
+        }
+        if (inputRow[emailColumnName] !== requesterEmail) {
+          return undefined;
+        }
+      } else if (matchConfig?.type === "semaphoreID") {
+        const semaphoreIDColumnName = matchConfig.inputField;
+        if (!(semaphoreIDColumnName in inputRow)) {
+          throw new Error(
+            `Could not find column "${semaphoreIDColumnName}" in CSV input data, could not match against user Semaphore ID`
+          );
+        }
+        if (inputRow[semaphoreIDColumnName] !== requesterSemaphoreId) {
+          return undefined;
+        }
+      }
+    }
+
+    const entries: PODEntries = {};
+
+    for (const [name, entryConfig] of Object.entries(output)) {
+      switch (entryConfig.source.type) {
+        case "configured":
+          /* @todo non-string values */
+          entries[name] = { type: "string", value: entryConfig.source.value };
+          break;
+        case "credentialEmail":
+          entries[name] = { type: "string", value: requesterEmail };
+          break;
+        case "credentialSemaphoreID":
+          entries[name] = {
+            type: "cryptographic",
+            value: BigInt(requesterSemaphoreId)
+          };
+          break;
+        case "input":
+          const columnName = entryConfig.source.name;
+          if (!(columnName in inputRow)) {
+            throw new Error(
+              `Could not find column "${entryConfig.source.name}" in CSV data, required by output field ${name}`
+            );
+          }
+          const value = inputRow[columnName];
+          if (entryConfig.type === "cryptographic") {
+            entries[name] = {
+              type: "cryptographic",
+              value: BigInt(value)
+            };
+          } else if (entryConfig.type === "int") {
+            entries[name] = {
+              type: "int",
+              value: BigInt(value)
+            };
+          } else {
+            entries[name] = {
+              type: "string",
+              value
+            };
+          }
+          break;
+      }
+    }
+
+    const pcd = await PODPCDPackage.prove({
+      entries: {
+        value: entries,
+        argumentType: ArgumentTypeName.Object
+      },
+      privateKey: {
+        value: eddsaPrivateKey,
+        argumentType: ArgumentTypeName.String
+      },
+      id: {
+        value: uuidv5(Object.values(inputRow).join(","), pipelineId),
+        argumentType: ArgumentTypeName.String
+      }
+    });
+
+    const serialized = await PODPCDPackage.serialize(pcd);
+
+    return serialized;
+  });
+}

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makeMessagePCD.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makeMessagePCD.ts
@@ -13,7 +13,7 @@ import { traced } from "../../../telemetryService";
  * - `message`: markdown-formatted announcement. can include images, links, etc.
  */
 export async function makeMessagePCD(
-  csvRow: string[],
+  csvRow: Record<string, string>,
   eddsaPrivateKey: string
 ): Promise<SerializedPCD> {
   return traced("", "makeMarkdownPCD", async () => {
@@ -29,8 +29,8 @@ export async function makeMessagePCD(
       message: {
         argumentType: ArgumentTypeName.Object,
         value: {
-          displayName: csvRow[0],
-          mdBody: csvRow[1]
+          displayName: csvRow.Title,
+          mdBody: csvRow.Message
         }
       }
     });

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makePODTicketPCD.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makePODTicketPCD.ts
@@ -4,7 +4,7 @@ import { traced } from "../../../telemetryService";
 import { rowToTicket } from "./makeTicketPCD";
 
 export async function makePODTicketPCD(
-  inputRow: string[],
+  inputRow: Record<string, string>,
   eddsaPrivateKey: string,
   requesterEmail: string | undefined,
   requesterSemaphoreId: string | undefined,

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makeTicketPCD.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/makeTicketPCD.ts
@@ -10,7 +10,7 @@ import { traced } from "../../../telemetryService";
 
 export function summarizeEventAndProductIds(
   pipelineId: string,
-  ticketRows: string[][]
+  ticketRows: Record<string, string>[]
 ): string {
   const tickets = ticketRows
     .map((r) => rowToTicket(r, "", pipelineId))
@@ -29,17 +29,17 @@ export function summarizeEventAndProductIds(
 }
 
 export function rowToTicket(
-  row: string[],
+  row: Record<string, string>,
   attendeeSemaphoreId: string,
   pipelineId: string
 ): ITicketData | undefined {
   try {
-    const eventName: string = row[0];
-    const ticketName: string = row[1];
-    const attendeeName: string = row[2];
-    const attendeeEmail: string = row[3];
-    const imageUrl: string = row[4];
-    const id: string = row[5] ?? "";
+    const eventName: string = row.eventName;
+    const ticketName: string = row.ticketName;
+    const attendeeName: string = row.attendeeName;
+    const attendeeEmail: string = row.attendeeEmail;
+    const imageUrl: string = row.imageUrl;
+    const id: string = row.id ?? "";
 
     const eventId: string = uuidv5(`${eventName}-${ticketName}`, pipelineId);
     const productId: string = uuidv5(`product-${eventId}`, pipelineId);
@@ -81,7 +81,7 @@ export function rowToTicket(
 }
 
 export async function makeTicketPCD(
-  inputRow: string[],
+  inputRow: Record<string, string>,
   eddsaPrivateKey: string,
   requesterEmail: string | undefined,
   requesterSemaphoreId: string | undefined,

--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -499,12 +499,46 @@ export enum CSVPipelineOutputType {
    */
   Message = "EdDSAMessage",
   Ticket = "EdDSATicket",
-  PODTicket = "PODTicketPCD"
+  PODTicket = "PODTicketPCD",
+  POD = "PODPCD"
 }
+
+const CSVPipelinePODEntrySchema = z.object({
+  type: z.enum(["string", "int", "cryptographic"]).optional(),
+  source: z.discriminatedUnion("type", [
+    z.object({ type: z.literal("input"), name: z.string() }),
+    z.object({ type: z.literal("credentialSemaphoreID") }),
+    z.object({ type: z.literal("credentialEmail") }),
+    z.object({ type: z.literal("configured"), value: z.string() })
+  ])
+});
+
+export type CSVPipelinePODEntry = z.infer<typeof CSVPipelinePODEntrySchema>;
+export type CSVPipelinePODEntryOptions = Record<string, CSVPipelinePODEntry>;
+
+const MatchOptionSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("semaphoreID"), inputField: z.string() }),
+  z.object({ type: z.literal("email"), inputField: z.string() })
+]);
+
+export type CSVPipelineMatchConfig = z.infer<typeof MatchOptionSchema>;
 
 const CSVPipelineOptionsSchema = BasePipelineOptionsSchema.extend({
   csv: z.string(),
   outputType: z.nativeEnum(CSVPipelineOutputType).optional(),
+  // For generic POD output, we don't know the format of the input CSV in
+  // advance, so we need to be able to configure which field from the input
+  // CSV to use for matching against the user's Semaphore ID/email.
+  match: MatchOptionSchema.optional(),
+  // For generic POD output, we want to be able to choose the field names,
+  // types, and so on. If "POD" output type is selected, use this
+  // configuration to do that mapping.
+  /**
+   * @TODO Refactor this into a new pipeline that does not have so much cruft
+   * (PODTicketPCD issuance, Message PCDs). Generic POD issuance deserves to be
+   * done properly, and hacking around that other stuff will become painful.
+   */
+  podOutput: z.record(z.string(), CSVPipelinePODEntrySchema).optional(),
   feedOptions: FeedIssuanceOptionsSchema,
   issueToUnmatchedEmail: z.boolean().optional()
 });


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-981/issue-arbitrary-pods-from-csv-pipeline

Allows the CSV pipeline to issue arbitrary PODs. This is done by adding a new output type (`POD`) to the CSV pipeline, and by adding two new configuration groups. These are:

`match`: used to determine which field in the input CSV contains either an email address or Semaphore ID, which can be matched against the credential submitted when requesting the feed. This is optional and can be omitted if the existing `issueToUnmatchedEmail` setting is enabled.

`podOutput`: used to determine which entries the issued PODs will contain, with source values provided by either:
- mapping from a column in the uploaded CSV
- mapping from the authentication credential payload (email and Semaphore ID)
- constant configured value (e.g. to set the `zupass_display` field to a constant value like `"collectable"` for all PODs issued on the pipeline

This is intended to support the issuance of PODs for internal testing/demo purposes, and could be extended and refactored to provide more features and greater usability for external users.