### PR TITLE
Editing of CSV data in Podbox UI

### DIFF
--- a/apps/generic-issuance-client/package.json
+++ b/apps/generic-issuance-client/package.json
@@ -26,6 +26,7 @@
     "@stytch/vanilla-js": "^4.4.2",
     "@tanstack/react-table": "^8.11.8",
     "csv-parse": "^5.5.3",
+    "csv-stringify": "^6.5.0",
     "dotenv": "^16.4.1",
     "email-validator": "^2.0.4",
     "framer-motion": "^11.0.3",

--- a/apps/generic-issuance-client/src/pages/create-pipeline/pipeline-builders/CSVPipelineBuilder.tsx
+++ b/apps/generic-issuance-client/src/pages/create-pipeline/pipeline-builders/CSVPipelineBuilder.tsx
@@ -64,7 +64,11 @@ export default function CSVPipelineBuilder(
                 />
               )}
               {previewType !== undefined && (
-                <CSVPreview csv={csv} previewType={previewType} />
+                <CSVPreview
+                  csv={csv}
+                  previewType={previewType}
+                  onChange={setCsv}
+                />
               )}
             </Box>
           </Card>

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/CSVPreview.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/CSVPreview.tsx
@@ -3,10 +3,12 @@ import { CSVSheetPreview } from "./CSVSheetPreview";
 
 export function CSVPreview({
   csv,
-  previewType
+  previewType,
+  onChange
 }: {
   csv: string;
   previewType?: PreviewType;
+  onChange?: (newCsv: string) => void;
 }): ReactNode {
   if (!previewType) {
     return null;
@@ -14,7 +16,7 @@ export function CSVPreview({
 
   switch (previewType) {
     case PreviewType.CSVSheet:
-      return <CSVSheetPreview csv={csv} />;
+      return <CSVSheetPreview csv={csv} onChange={onChange} />;
     default:
       return null as never;
   }

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/CSVPreviewEditWrapper.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/CSVPreviewEditWrapper.tsx
@@ -2,7 +2,7 @@ import { Alert, AlertIcon } from "@chakra-ui/react";
 import { ReactNode } from "react";
 import { CSVPreview, PreviewType } from "./CSVPreview";
 
-export function CSVPreviewWrapper({
+export function CSVPreviewEditWrapper({
   pipelineDefinitionText,
   previewType,
   onChange

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/CSVPreviewWrapper.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/CSVPreviewWrapper.tsx
@@ -1,0 +1,34 @@
+import { Alert, AlertIcon } from "@chakra-ui/react";
+import { ReactNode } from "react";
+import { CSVPreview, PreviewType } from "./CSVPreview";
+
+export function CSVPreviewWrapper({
+  pipelineDefinitionText,
+  previewType,
+  onChange
+}: {
+  pipelineDefinitionText: string;
+  previewType?: PreviewType;
+  onChange?: (newCsv: string) => void;
+}): ReactNode {
+  let csv: string = "";
+  let error = false;
+  try {
+    const data = JSON.parse(pipelineDefinitionText);
+    csv = data.options.csv;
+  } catch (e) {
+    error = true;
+  }
+
+  if (error) {
+    return (
+      <Alert status="error">
+        <AlertIcon />
+        The pipeline is not configured correctly. Switch back to Configuration
+        view to ensure that the configuration is valid.
+      </Alert>
+    );
+  }
+
+  return <CSVPreview csv={csv} previewType={previewType} onChange={onChange} />;
+}

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/CSVSheetPreview.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/CSVSheetPreview.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useEffect, useState } from "react";
 // eslint-disable-next-line import/no-named-as-default
 import { stringify } from "csv-stringify/sync";
-import { Mode, Spreadsheet } from "react-spreadsheet";
+import { Matrix, Mode, Spreadsheet } from "react-spreadsheet";
 import styled from "styled-components";
 import { parseCSV } from "./parseCSV";
 
@@ -30,7 +30,7 @@ export function CSVSheetPreview({
       });
   }, [csv]);
 
-  const [data, setData] = useState<{ value: string }[][]>([]);
+  const [data, setData] = useState<Matrix<{ value: string }>>([]);
 
   if (parseError) {
     return <Container>{parseError.message}</Container>;
@@ -48,15 +48,17 @@ export function CSVSheetPreview({
                 // does not get lost. The data in the table does not include
                 // this row, so we have to manually include it from the initial
                 // parse of the CSV file.
-                [parsed[0], ...data.map((row) => row.map(({ value }) => value))]
+                [
+                  parsed[0],
+                  ...data.map((row) => row.map((cell) => cell?.value ?? ""))
+                ]
               );
               onChange(newCsv);
             }
           }
         }}
         onChange={(data): void => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          setData(data as any);
+          setData(data);
         }}
         darkMode={true}
         data={data}

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/PipelineEditSection.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/PipelineEditSection.tsx
@@ -5,6 +5,7 @@ import {
   PipelineInfoResponseValue,
   isCSVPipelineDefinition
 } from "@pcd/passport-interface";
+import { getErrorMessage } from "@pcd/util";
 import { ReactNode, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import {
@@ -127,7 +128,16 @@ export function PipelineEditSection({
                           );
                         }
                       } catch (e) {
-                        console.log(e);
+                        // We should only have caught an exception here if the
+                        // JSON.parse() above failed.
+                        // But, if the JSON string in `editorValue` doesn't
+                        // parse then we would not be showing the CSV editor.
+                        // Errors here might happen if we change something
+                        // about how the `editorValue` text is managed.
+                        console.error(
+                          "Error when updating CSV data: ",
+                          getErrorMessage(e)
+                        );
                       }
                     }}
                   />

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/PipelineEditSection.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/PipelineEditSection.tsx
@@ -14,7 +14,8 @@ import {
 import { Maximizer } from "../../../components/Maximizer";
 import { useViewingPipelineDefinition } from "../../../helpers/Context";
 import { stringifyAndFormat } from "../../../helpers/util";
-import { CSVPreview, PreviewType } from "./CSVPreview";
+import { PreviewType } from "./CSVPreview";
+import { CSVPreviewWrapper } from "./CSVPreviewWrapper";
 import { PipelineActions } from "./PipelineActions";
 import { SinglePipelineTable } from "./SinglePipelineTable";
 
@@ -72,7 +73,7 @@ export function PipelineEditSection({
           maximized={editorMaximized}
           setMaximized={setEditorMaximized}
         >
-          <Tabs style={{ height: "100%" }}>
+          <Tabs isLazy style={{ height: "100%" }}>
             {isCSVPipelineDefinition(pipeline) && (
               <TabList>
                 <Tab>Configuration</Tab>
@@ -113,9 +114,9 @@ export function PipelineEditSection({
               </TabPanel>
               {isCSVPipelineDefinition(pipeline) && (
                 <TabPanel style={{ height: "100%", overflowY: "scroll" }}>
-                  <CSVPreview
+                  <CSVPreviewWrapper
                     previewType={PreviewType.CSVSheet}
-                    csv={pipeline.options.csv}
+                    pipelineDefinitionText={editorValue}
                     onChange={(newCsv: string) => {
                       try {
                         const pipelineContent = JSON.parse(editorValue);

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/PipelineEditSection.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/PipelineEditSection.tsx
@@ -1,8 +1,9 @@
-import { Box } from "@chakra-ui/react";
+import { Box, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
 import {
   GenericIssuanceSelfResponseValue,
   PipelineDefinition,
-  PipelineInfoResponseValue
+  PipelineInfoResponseValue,
+  isCSVPipelineDefinition
 } from "@pcd/passport-interface";
 import { ReactNode, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
@@ -13,6 +14,7 @@ import {
 import { Maximizer } from "../../../components/Maximizer";
 import { useViewingPipelineDefinition } from "../../../helpers/Context";
 import { stringifyAndFormat } from "../../../helpers/util";
+import { CSVPreview, PreviewType } from "./CSVPreview";
 import { PipelineActions } from "./PipelineActions";
 import { SinglePipelineTable } from "./SinglePipelineTable";
 
@@ -70,30 +72,68 @@ export function PipelineEditSection({
           maximized={editorMaximized}
           setMaximized={setEditorMaximized}
         >
-          <FancyEditor
-            dark
-            value={editorValue}
-            setValue={setEditorValue}
-            readonly={(ownedBySomeoneElse && !isAdminView) || !!historyEntry}
-            ref={editorRef}
-            editorStyle={{
-              width: editorMaximized ? "100%" : "100%",
-              height: editorMaximized ? "100vh" : "100%"
-            }}
-            containerStyle={
-              editorMaximized ? { border: "none", borderRadius: 0 } : undefined
-            }
-            editorOptions={
-              editorMaximized
-                ? {
-                    minimap: {
-                      enabled: true
-                    }
+          <Tabs style={{ height: "100%" }}>
+            {isCSVPipelineDefinition(pipeline) && (
+              <TabList>
+                <Tab>Configuration</Tab>
+                <Tab>Data</Tab>
+              </TabList>
+            )}
+
+            <TabPanels style={{ height: "100%", overflow: "hidden" }}>
+              <TabPanel style={{ height: "100%" }}>
+                <FancyEditor
+                  dark
+                  value={editorValue}
+                  setValue={setEditorValue}
+                  readonly={
+                    (ownedBySomeoneElse && !isAdminView) || !!historyEntry
                   }
-                : undefined
-            }
-            language="json"
-          />
+                  ref={editorRef}
+                  editorStyle={{
+                    width: editorMaximized ? "100%" : "100%",
+                    height: editorMaximized ? "100vh" : "100%"
+                  }}
+                  containerStyle={
+                    editorMaximized
+                      ? { border: "none", borderRadius: 0 }
+                      : undefined
+                  }
+                  editorOptions={
+                    editorMaximized
+                      ? {
+                          minimap: {
+                            enabled: true
+                          }
+                        }
+                      : undefined
+                  }
+                  language="json"
+                />
+              </TabPanel>
+              {isCSVPipelineDefinition(pipeline) && (
+                <TabPanel style={{ height: "100%", overflowY: "scroll" }}>
+                  <CSVPreview
+                    previewType={PreviewType.CSVSheet}
+                    csv={pipeline.options.csv}
+                    onChange={(newCsv: string) => {
+                      try {
+                        const pipelineContent = JSON.parse(editorValue);
+                        if (pipelineContent) {
+                          pipelineContent.options.csv = newCsv;
+                          setEditorValue(
+                            JSON.stringify(pipelineContent, null, 2)
+                          );
+                        }
+                      } catch (e) {
+                        console.log(e);
+                      }
+                    }}
+                  />
+                </TabPanel>
+              )}
+            </TabPanels>
+          </Tabs>
         </Maximizer>
       </div>
 

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/PipelineEditSection.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/PipelineEditSection.tsx
@@ -15,7 +15,7 @@ import { Maximizer } from "../../../components/Maximizer";
 import { useViewingPipelineDefinition } from "../../../helpers/Context";
 import { stringifyAndFormat } from "../../../helpers/util";
 import { PreviewType } from "./CSVPreview";
-import { CSVPreviewWrapper } from "./CSVPreviewWrapper";
+import { CSVPreviewEditWrapper } from "./CSVPreviewEditWrapper";
 import { PipelineActions } from "./PipelineActions";
 import { SinglePipelineTable } from "./SinglePipelineTable";
 
@@ -114,7 +114,7 @@ export function PipelineEditSection({
               </TabPanel>
               {isCSVPipelineDefinition(pipeline) && (
                 <TabPanel style={{ height: "100%", overflowY: "scroll" }}>
-                  <CSVPreviewWrapper
+                  <CSVPreviewEditWrapper
                     previewType={PreviewType.CSVSheet}
                     pipelineDefinitionText={editorValue}
                     onChange={(newCsv: string) => {

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelinePage.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelinePage.tsx
@@ -147,6 +147,7 @@ export const TwoColumns = styled.div`
   }
 
   .editor-col {
+    flex-grow: 1;
     height: 100%;
     max-height: 100%;
     overflow: hidden;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7146,10 +7146,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.7.0.tgz#8de8ba9cafadc38e89003fe303e219c9250089ae"
   integrity sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==
 
-"@typescript-eslint/types@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.13.1.tgz#787db283bd0b58751094c90d5b58bbf5e9fc9bd8"
-  integrity sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==
+"@typescript-eslint/types@7.14.1":
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.14.1.tgz#a43a540dbe5df7f2a11269683d777fc50b4350aa"
+  integrity sha512-mL7zNEOQybo5R3AavY+Am7KLv8BorIv7HCYS5rKoNZKQD9tsfGUpO4KdAn3sSUvTiS4PQkr2+K0KJbxj8H9NDg==
 
 "@typescript-eslint/types@7.4.0":
   version "7.4.0"
@@ -7157,12 +7157,12 @@
   integrity sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==
 
 "@typescript-eslint/typescript-estree@6.7.0", "@typescript-eslint/typescript-estree@7.4.0", "@typescript-eslint/typescript-estree@^7.2.0":
-  version "7.13.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz#3412841b130e070db2f675e3d9b8cb1ae49e1c3f"
-  integrity sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.14.1.tgz#ba7c9bac8744487749d19569e254d057754a1575"
+  integrity sha512-k5d0VuxViE2ulIO6FbxxSZaxqDVUyMbXcidC8rHvii0I56XZPv8cq+EhMns+d/EVIL41sMXqRbK3D10Oza1bbA==
   dependencies:
-    "@typescript-eslint/types" "7.13.1"
-    "@typescript-eslint/visitor-keys" "7.13.1"
+    "@typescript-eslint/types" "7.14.1"
+    "@typescript-eslint/visitor-keys" "7.14.1"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -7191,12 +7191,12 @@
     "@typescript-eslint/types" "6.7.0"
     eslint-visitor-keys "^3.4.1"
 
-"@typescript-eslint/visitor-keys@7.13.1":
-  version "7.13.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz#9c229a795a919db61f2d7f2337ef584ac05fbe96"
-  integrity sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==
+"@typescript-eslint/visitor-keys@7.14.1":
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.14.1.tgz#cc79b5ea154aea734b2a13b983670749f5742274"
+  integrity sha512-Crb+F75U1JAEtBeQGxSKwI60hZmmzaqA3z9sYsVm8X7W5cwLEm5bRe0/uXS6+MR/y8CVpKSR/ontIAIEPFcEkA==
   dependencies:
-    "@typescript-eslint/types" "7.13.1"
+    "@typescript-eslint/types" "7.14.1"
     eslint-visitor-keys "^3.4.3"
 
 "@typescript-eslint/visitor-keys@7.4.0":
@@ -15602,9 +15602,9 @@ minimatch@^9.0.1, minimatch@^9.0.3:
     brace-expansion "^2.0.1"
 
 minimatch@^9.0.4:
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
-  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -19267,16 +19267,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -19409,14 +19400,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21735,7 +21719,7 @@ workspace-tools@^0.36.4:
     js-yaml "^4.1.0"
     micromatch "^4.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21748,15 +21732,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-982/better-ui-for-csv-pipeline

During both creation and editing of a CSV pipeline, it's now possible to view and edit the CSV data using the spreadsheet view.

Editing via the spreadsheet view is equivalent to editing the text in configuration view. It does not automatically save the changes to the back-end, in the same way that editing the configuration view does not auto-save either. The user can switch between the two views, making edits in both, before deciding to save them. If the user edits the configuration so that it is not valid JSON, the CSV spreadsheet view will refuse to load. If the CSV content is edited so that it is no longer a valid CSV (e.g. it has the wrong number of columns) then the CSV parser will also reject it, with an error message.