### PR TITLE
Use Base64 for private keys in example

### DIFF
--- a/examples/pod-gpc-example/src/gpcExample.ts
+++ b/examples/pod-gpc-example/src/gpcExample.ts
@@ -52,8 +52,7 @@ export async function gpcDemo(): Promise<boolean> {
   // explanatory comments.
   //////////////////////////////////////////////////////////////////////////////
 
-  const privateKey =
-    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  const privateKey = "ASNFZ4mrze8BI0VniavN7wEjRWeJq83vASNFZ4mrze8";
   const semaphoreIdentity = new Identity();
   console.log("Semaphore commitment", semaphoreIdentity.commitment);
   const podSword = POD.sign(

--- a/examples/pod-gpc-example/src/podExample.ts
+++ b/examples/pod-gpc-example/src/podExample.ts
@@ -138,9 +138,8 @@ export async function podDemo(): Promise<boolean> {
   console.log("Entry proof", entryProof);
 
   // PODs are signed using EdDSA signatures, which are easy to check in a
-  // ZK circuit.  Our EdDSA private keys can be any 32 bytes encoded as hex.
-  const privateKey =
-    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  // ZK circuit.  Our private keys can be any 32 bytes encoded as Base64 or hex.
+  const privateKey = "ASNFZ4mrze8BI0VniavN7wEjRWeJq83vASNFZ4mrze8";
 
   // Signing a POD is usually performed in a single step like this.  No need
   // to go through the PODContent class.


### PR DESCRIPTION
This gives the GPCPCD display card the same improvements as the PODPCD:
- Scrolling text boxes
- Prettier button for verification
- Verification error display
- Link to docs in description
- General text cleanup

Note that most users won't ever see this display, which only appears if a proof PCD is added to your Zupass.  It may as well be consistent and nice, though, if/when it comes up.  The prove screen is unchanged, and already looks fine.
