### PR TITLE
Add bounds checks to GPC

### DIFF
--- a/apps/consumer-client/src/pages/examples/gpc-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/gpc-proof.tsx
@@ -19,7 +19,7 @@ import {
   checkPODEntriesAgainstPrescribedEntries,
   checkPrescribedEntriesAgainstProofConfig,
   checkPrescribedSignerPublicKeysAgainstProofConfig,
-  podEntryRecordFromSimplifiedJSON
+  fixedPODEntriesFromSimplifiedJSON
 } from "@pcd/gpc-pcd";
 import {
   constructZupassPcdGetRequestUrl,
@@ -436,7 +436,7 @@ async function verifyProof(
   if (prescribedEntries !== undefined) {
     const params = { notFoundMessage: undefined };
     const deserialisedPrescribedEntries =
-      podEntryRecordFromSimplifiedJSON(prescribedEntries);
+      fixedPODEntriesFromSimplifiedJSON(prescribedEntries);
 
     for (const podName of Object.keys(deserialisedPrescribedEntries)) {
       const revealedPODData = pcd.claim.revealed.pods[podName];

--- a/apps/consumer-client/src/podExampleConstants.ts
+++ b/apps/consumer-client/src/podExampleConstants.ts
@@ -49,8 +49,10 @@ export const EXAMPLE_GPC_CONFIG = `{
         },
         "F": {
           "isRevealed": false,
-          "minValue": 38,
-          "maxValue": 5000000000
+          "inRange": {
+            "min": 38,
+            "max": 5000000000
+          }
         },
         "owner": {
           "isRevealed": false,

--- a/apps/consumer-client/src/podExampleConstants.ts
+++ b/apps/consumer-client/src/podExampleConstants.ts
@@ -47,6 +47,11 @@ export const EXAMPLE_GPC_CONFIG = `{
           "isRevealed": false,
           "equalsEntry": "examplePOD.A"
         },
+        "F": {
+          "isRevealed": false,
+          "minValue": 38,
+          "maxValue": 5000000000
+        },
         "owner": {
           "isRevealed": false,
           "isOwnerID": true

--- a/packages/lib/gpc/src/gpcChecks.ts
+++ b/packages/lib/gpc/src/gpcChecks.ts
@@ -34,6 +34,7 @@ import {
   TupleIdentifier
 } from "./gpcTypes";
 import {
+  BoundsConfig,
   GPCProofMembershipListConfig,
   GPCRequirements,
   LIST_MEMBERSHIP,
@@ -211,17 +212,18 @@ export function checkProofEntryConfig(
   const hasBoundsCheck = entryConfig.inRange !== undefined;
 
   if (hasBoundsCheck) {
-    if (entryConfig.inRange.min < POD_INT_MIN) {
+    const inRange = entryConfig.inRange as BoundsConfig;
+    if (inRange.min < POD_INT_MIN) {
       throw new RangeError(
         `Minimum value of entry ${nameForErrorMessages} is less than smallest admissible value ${POD_INT_MIN}.`
       );
     }
-    if (entryConfig.inRange.max > POD_INT_MAX) {
+    if (inRange.max > POD_INT_MAX) {
       throw new RangeError(
         `Maximum value of entry ${nameForErrorMessages} is greater than largest admissible ${POD_INT_MAX}.`
       );
     }
-    if (entryConfig.inRange.max < entryConfig.inRange.min) {
+    if (inRange.max < inRange.min) {
       throw new Error(
         "Minimum value for entry ${nameForErrorMesages} must be less than or equal to its maximum value."
       );

--- a/packages/lib/gpc/src/gpcChecks.ts
+++ b/packages/lib/gpc/src/gpcChecks.ts
@@ -8,6 +8,8 @@ import {
   PODName,
   PODValue,
   PODValueTuple,
+  POD_INT_MAX,
+  POD_INT_MIN,
   applyOrMap,
   calcMinMerkleDepthForEntries,
   checkPODName,
@@ -103,15 +105,17 @@ export function checkProofConfig(proofConfig: GPCProofConfig): GPCRequirements {
   let totalObjects = 0;
   let totalEntries = 0;
   let requiredMerkleDepth = 0;
+  let totalBoundsChecks = 0;
   for (const [objName, objConfig] of Object.entries(proofConfig.pods)) {
     checkPODName(objName);
-    const nEntries = checkProofObjConfig(objName, objConfig);
+    const { nEntries, nBoundsChecks } = checkProofObjConfig(objName, objConfig);
     totalObjects++;
     totalEntries += nEntries;
     requiredMerkleDepth = Math.max(
       requiredMerkleDepth,
       calcMinMerkleDepthForEntries(nEntries)
     );
+    totalBoundsChecks += nBoundsChecks;
   }
 
   if (proofConfig.tuples !== undefined) {
@@ -120,9 +124,6 @@ export function checkProofConfig(proofConfig: GPCProofConfig): GPCRequirements {
 
   const listConfig: GPCProofMembershipListConfig =
     listConfigFromProofConfig(proofConfig);
-
-  // TODO(POD-P2): Replace this with actual value.
-  const nBoundsChecks = 0;
 
   const numLists = Object.keys(listConfig).length;
 
@@ -139,7 +140,7 @@ export function checkProofConfig(proofConfig: GPCProofConfig): GPCRequirements {
     totalObjects,
     totalEntries,
     requiredMerkleDepth,
-    nBoundsChecks,
+    totalBoundsChecks,
     numLists,
     maxListSize,
     tupleArities
@@ -149,7 +150,7 @@ export function checkProofConfig(proofConfig: GPCProofConfig): GPCRequirements {
 function checkProofObjConfig(
   nameForErrorMessages: string,
   objConfig: GPCProofObjectConfig
-): number {
+): { nEntries: number; nBoundsChecks: number } {
   if (Object.keys(objConfig.entries).length === 0) {
     throw new TypeError(
       `Must prove at least one entry in object "${nameForErrorMessages}".`
@@ -157,10 +158,15 @@ function checkProofObjConfig(
   }
 
   let nEntries = 0;
+  let nBoundsChecks = 0;
   for (const [entryName, entryConfig] of Object.entries(objConfig.entries)) {
     checkPODEntryName(entryName, true);
-    checkProofEntryConfig(`${nameForErrorMessages}.${entryName}`, entryConfig);
+    const { hasBoundsCheck } = checkProofEntryConfig(
+      `${nameForErrorMessages}.${entryName}`,
+      entryConfig
+    );
     nEntries++;
+    nBoundsChecks += +hasBoundsCheck;
   }
   if (objConfig.signerPublicKey !== undefined) {
     checkProofEntryConfig(
@@ -168,13 +174,13 @@ function checkProofObjConfig(
       objConfig.signerPublicKey
     );
   }
-  return nEntries;
+  return { nEntries, nBoundsChecks };
 }
 
-function checkProofEntryConfig(
+export function checkProofEntryConfig(
   nameForErrorMessages: string,
   entryConfig: GPCProofEntryConfig
-): void {
+): { hasBoundsCheck: boolean } {
   requireType(
     `${nameForErrorMessages}.isValueRevealed`,
     entryConfig.isRevealed,
@@ -201,6 +207,33 @@ function checkProofEntryConfig(
       entryConfig.equalsEntry
     );
   }
+
+  const hasBoundsCheck = (
+    [
+      ["Minimum value", entryConfig.minValue],
+      ["Maximum value", entryConfig.maxValue]
+    ] as [string, bigint][]
+  ).reduce((hasBoundsCheck, [boundType, bound]) => {
+    const isBoundDefined = bound !== undefined;
+    if (isBoundDefined && (bound < POD_INT_MIN || bound > POD_INT_MAX)) {
+      throw new RangeError(
+        `${boundType} of entry ${nameForErrorMessages} lies outside admissible bounds ([${POD_INT_MIN}, ${POD_INT_MAX}]).`
+      );
+    }
+    return hasBoundsCheck || isBoundDefined;
+  }, false);
+
+  if (
+    entryConfig.minValue !== undefined &&
+    entryConfig.maxValue !== undefined &&
+    entryConfig.maxValue < entryConfig.minValue
+  ) {
+    throw new Error(
+      "Minimum value for entry ${nameForErrorMesages} must be less than or equal to its maximum value."
+    );
+  }
+
+  return { hasBoundsCheck };
 }
 
 export function checkProofTupleConfig(proofConfig: GPCProofConfig): void {
@@ -300,9 +333,6 @@ export function checkProofInputs(proofInputs: GPCProofInputs): GPCRequirements {
     }
   }
 
-  // TODO(POD-P2): Replace this with actual value.
-  const nBoundsChecks = 0;
-
   const numListElements =
     proofInputs.membershipLists === undefined
       ? {}
@@ -318,7 +348,9 @@ export function checkProofInputs(proofInputs: GPCProofInputs): GPCRequirements {
     totalObjects,
     totalObjects,
     requiredMerkleDepth,
-    nBoundsChecks,
+    // The bounds checks are handled solely in the proof config, hence we return
+    // 0 here.
+    0,
     // The number of required lists cannot be properly deduced here, so we
     // return 0.
     0,
@@ -425,6 +457,13 @@ export function checkProofInputsForConfig(
           );
         }
       }
+
+      // Check bounds for entry
+      checkProofBoundsCheckInputsForConfig(
+        `${objName}.${entryName}`,
+        entryConfig,
+        podValue
+      );
     }
   }
   // Check that nullifier isn't requested if it's not linked to anything.
@@ -434,6 +473,39 @@ export function checkProofInputsForConfig(
   }
 
   checkProofListMembershipInputsForConfig(proofConfig, proofInputs);
+}
+
+export function checkProofBoundsCheckInputsForConfig(
+  entryName: PODEntryIdentifier,
+  entryConfig: GPCProofEntryConfig,
+  entryValue: PODValue
+): void {
+  if (
+    entryConfig.minValue !== undefined ||
+    entryConfig.maxValue !== undefined
+  ) {
+    if (entryValue.type !== "int") {
+      throw new TypeError(
+        `Proof configuration for entry ${entryName} has bounds check but entry value is not of type "int".`
+      );
+    }
+    if (
+      entryConfig.minValue !== undefined &&
+      entryValue.value < entryConfig.minValue
+    ) {
+      throw new RangeError(
+        `Entry ${entryName} is less than its prescribed minimum value ${entryConfig.minValue}.`
+      );
+    }
+    if (
+      entryConfig.maxValue !== undefined &&
+      entryValue.value > entryConfig.maxValue
+    ) {
+      throw new RangeError(
+        `Entry ${entryName} is greater than its prescribed maximum value ${entryConfig.maxValue}.`
+      );
+    }
+  }
 }
 
 export function checkProofListMembershipInputsForConfig(
@@ -726,6 +798,14 @@ export function checkVerifyClaimsForConfig(
               ` doesn't exist in claims.`
           );
         }
+
+        // This named entry should satisfy the bounds set out in the proof
+        // configuration (if any).
+        checkProofBoundsCheckInputsForConfig(
+          `${objName}.${entryName}`,
+          entryConfig,
+          revealedValue
+        );
       }
     }
 

--- a/packages/lib/gpc/src/gpcChecks.ts
+++ b/packages/lib/gpc/src/gpcChecks.ts
@@ -210,7 +210,7 @@ export function checkProofEntryConfig(
 
   const hasBoundsCheck = entryConfig.inRange !== undefined;
 
-  if (entryConfig.inRange !== undefined) {
+  if (hasBoundsCheck) {
     if (entryConfig.inRange.min < POD_INT_MIN) {
       throw new RangeError(
         `Minimum value of entry ${nameForErrorMessages} is less than smallest admissible value ${POD_INT_MIN}.`

--- a/packages/lib/gpc/src/gpcTypes.ts
+++ b/packages/lib/gpc/src/gpcTypes.ts
@@ -131,18 +131,12 @@ export type GPCProofEntryConfigCommon = {
  */
 export type GPCProofEntryConfig = GPCProofEntryConfigCommon & {
   /**
-   * Indicates the minimum value this entry can take. This should be an unsigned
-   * 64-bit integer value and will be revealed by virtue of its inclusion in the
-   * proof configuration.
+   * Indicates the range/interval/bounds within which this entry should
+   * lie. Both (inclusive) bounds must be specified, and they should be
+   * unsigned 63-bit integer values. They will always be revealed by virtue of
+   * their inclusion in the proof configuration.
    */
-  minValue?: bigint;
-
-  /**
-   * Indicates the maximum value this entry can take. This should be an unsigned
-   * 64-bit integer value and will be revealed by virtue of its inclusion in the
-   * proof configuration.
-   */
-  maxValue?: bigint;
+  inRange?: { min: bigint; max: bigint };
 
   /**
    * Indicates that this entry must match the public ID of the owner

--- a/packages/lib/gpc/src/gpcTypes.ts
+++ b/packages/lib/gpc/src/gpcTypes.ts
@@ -131,6 +131,20 @@ export type GPCProofEntryConfigCommon = {
  */
 export type GPCProofEntryConfig = GPCProofEntryConfigCommon & {
   /**
+   * Indicates the minimum value this entry can take. This should be an unsigned
+   * 64-bit integer value and will be revealed by virtue of its inclusion in the
+   * proof configuration.
+   */
+  minValue?: bigint;
+
+  /**
+   * Indicates the maximum value this entry can take. This should be an unsigned
+   * 64-bit integer value and will be revealed by virtue of its inclusion in the
+   * proof configuration.
+   */
+  maxValue?: bigint;
+
+  /**
    * Indicates that this entry must match the public ID of the owner
    * identity given in {@link GPCProofInputs}.  For Semaphore V3 this is
    * the owner's Semaphore commitment (a cryptographic value).

--- a/packages/lib/gpc/src/gpcUtil.ts
+++ b/packages/lib/gpc/src/gpcUtil.ts
@@ -742,12 +742,13 @@ function addIdentifierToListConfig(
 /**
  * Compares two POD entry identifiers according to the rule that they should be
  * arranged by POD name first then entry name with the usual rules for
- * string sorting.
+ * lexicographic string sorting.
  *
  * @param id1 POD entry identifier to compare
  * @param id2 POD entry identifier to compare
  * @returns -1, 0 or 1 according to whether `id1` should precede, be considered
  * equal to, or succeed `id2`.
+ * @throws TypeError if an identifier doesn't match the required format
  */
 export function podEntryIdentifierCompare(
   id1: PODEntryIdentifier,

--- a/packages/lib/gpc/src/gpcUtil.ts
+++ b/packages/lib/gpc/src/gpcUtil.ts
@@ -10,8 +10,6 @@ import {
   PODName,
   PODValue,
   PODValueTuple,
-  POD_INT_MAX,
-  POD_INT_MIN,
   POD_NAME_REGEX,
   checkPODName,
   getPODValueForCircuit,
@@ -152,13 +150,13 @@ export function canonicalizeEntryConfig(
     ...(proofEntryConfig.equalsEntry !== undefined
       ? { equalsEntry: proofEntryConfig.equalsEntry }
       : {}),
-    ...(proofEntryConfig.minValue !== undefined &&
-    proofEntryConfig.minValue !== POD_INT_MIN
-      ? { minValue: proofEntryConfig.minValue }
-      : {}),
-    ...(proofEntryConfig.maxValue !== undefined &&
-    proofEntryConfig.maxValue !== POD_INT_MAX
-      ? { maxValue: proofEntryConfig.maxValue }
+    ...(proofEntryConfig.inRange !== undefined
+      ? {
+          inRange: {
+            min: proofEntryConfig.inRange.min,
+            max: proofEntryConfig.inRange.max
+          }
+        }
       : {}),
     ...(proofEntryConfig.isMemberOf !== undefined
       ? {
@@ -603,7 +601,7 @@ export type GPCProofMembershipListConfig = Record<
  * Bounds check configuration for an individual entry. This specifies the bounds
  * check required for relevant entries at the circuit level.
  */
-export type BoundsConfig = { minValue?: bigint; maxValue?: bigint };
+export type BoundsConfig = { minValue: bigint; maxValue: bigint };
 
 /**
  * List configuration for an individual entry or tuple. This specifies the type
@@ -633,18 +631,14 @@ export function boundsCheckConfigFromProofConfig(
   return Object.fromEntries(
     Object.entries(proofConfig.pods).flatMap(([podName, podConfig]) =>
       Object.entries(podConfig.entries).flatMap(([entryName, entryConfig]) =>
-        entryConfig.minValue === undefined && entryConfig.maxValue === undefined
+        entryConfig.inRange === undefined
           ? []
           : [
               [
                 `${podName}.${entryName}`,
                 {
-                  ...(entryConfig.minValue !== undefined
-                    ? { minValue: entryConfig.minValue }
-                    : {}),
-                  ...(entryConfig.maxValue !== undefined
-                    ? { maxValue: entryConfig.maxValue }
-                    : {})
+                  minValue: entryConfig.inRange.min,
+                  maxValue: entryConfig.inRange.max
                 }
               ]
             ]

--- a/packages/lib/gpc/src/gpcUtil.ts
+++ b/packages/lib/gpc/src/gpcUtil.ts
@@ -746,7 +746,8 @@ function addIdentifierToListConfig(
  *
  * @param id1 POD entry identifier to compare
  * @param id2 POD entry identifier to compare
- * @returns -1, 0 or 1 according to whether `id1` should precede or succeed `id2`.
+ * @returns -1, 0 or 1 according to whether `id1` should precede, be considered
+ * equal to, or succeed `id2`.
  */
 export function podEntryIdentifierCompare(
   id1: PODEntryIdentifier,

--- a/packages/lib/gpc/test/gpc.spec.ts
+++ b/packages/lib/gpc/test/gpc.spec.ts
@@ -4,7 +4,8 @@ import {
   PODCryptographicValue,
   PODEdDSAPublicKeyValue,
   PODValue,
-  PODValueTuple
+  PODValueTuple,
+  POD_INT_MIN
 } from "@pcd/pod";
 import { expect } from "chai";
 import "mocha";
@@ -316,7 +317,7 @@ describe("gpc library (Compiled test artifacts) should work", async function () 
     expect(isVerified).to.be.true;
   });
 
-  it("should prove and verify lower bound check", async function () {
+  it("should prove and verify bounds checks", async function () {
     const { isVerified } = await gpcProofTest(
       {
         pods: {
@@ -326,52 +327,10 @@ describe("gpc library (Compiled test artifacts) should work", async function () 
               ...typicalProofConfig.pods.pod1.entries,
               G: {
                 isRevealed: false,
-                minValue: 3n
-              }
-            }
-          }
-        }
-      },
-      typicalProofInputs,
-      expectedRevealedClaimsForTypicalCase
-    );
-    expect(isVerified).to.be.true;
-  });
-
-  it("should prove and verify upper bound check", async function () {
-    const { isVerified } = await gpcProofTest(
-      {
-        pods: {
-          pod1: {
-            ...typicalProofConfig.pods.pod1,
-            entries: {
-              ...typicalProofConfig.pods.pod1.entries,
-              G: {
-                isRevealed: false,
-                maxValue: 256n
-              }
-            }
-          }
-        }
-      },
-      typicalProofInputs,
-      expectedRevealedClaimsForTypicalCase
-    );
-    expect(isVerified).to.be.true;
-  });
-
-  it("should prove and verify both upper and lower bounds checks", async function () {
-    const { isVerified } = await gpcProofTest(
-      {
-        pods: {
-          pod1: {
-            ...typicalProofConfig.pods.pod1,
-            entries: {
-              ...typicalProofConfig.pods.pod1.entries,
-              G: {
-                isRevealed: false,
-                minValue: 3n,
-                maxValue: 256n
+                inRange: {
+                  min: 3n,
+                  max: 256n
+                }
               }
             }
           }
@@ -411,8 +370,8 @@ describe("gpc library (Compiled test artifacts) should work", async function () 
         },
         pod1: {
           entries: {
-            A: { isRevealed: false, minValue: 100n, maxValue: 132n },
-            G: { isRevealed: true, maxValue: 30n },
+            A: { isRevealed: false, inRange: { min: 100n, max: 132n } },
+            G: { isRevealed: true, inRange: { min: POD_INT_MIN, max: 30n } },
             otherTicketID: { isRevealed: false },
             owner: { isRevealed: false, isOwnerID: true }
           },

--- a/packages/lib/gpc/test/gpc.spec.ts
+++ b/packages/lib/gpc/test/gpc.spec.ts
@@ -141,7 +141,6 @@ describe("gpc library (Compiled test artifacts) should work", async function () 
     expect(boundConfig).to.deep.eq(manuallyBoundConfig);
 
     expect(revealedClaims).to.deep.eq(expectedRevealedClaims);
-
     const isVerified = await gpcVerify(
       proof,
       boundConfig,
@@ -317,6 +316,73 @@ describe("gpc library (Compiled test artifacts) should work", async function () 
     expect(isVerified).to.be.true;
   });
 
+  it("should prove and verify lower bound check", async function () {
+    const { isVerified } = await gpcProofTest(
+      {
+        pods: {
+          pod1: {
+            ...typicalProofConfig.pods.pod1,
+            entries: {
+              ...typicalProofConfig.pods.pod1.entries,
+              G: {
+                isRevealed: false,
+                minValue: 3n
+              }
+            }
+          }
+        }
+      },
+      typicalProofInputs,
+      expectedRevealedClaimsForTypicalCase
+    );
+    expect(isVerified).to.be.true;
+  });
+
+  it("should prove and verify upper bound check", async function () {
+    const { isVerified } = await gpcProofTest(
+      {
+        pods: {
+          pod1: {
+            ...typicalProofConfig.pods.pod1,
+            entries: {
+              ...typicalProofConfig.pods.pod1.entries,
+              G: {
+                isRevealed: false,
+                maxValue: 256n
+              }
+            }
+          }
+        }
+      },
+      typicalProofInputs,
+      expectedRevealedClaimsForTypicalCase
+    );
+    expect(isVerified).to.be.true;
+  });
+
+  it("should prove and verify both upper and lower bounds checks", async function () {
+    const { isVerified } = await gpcProofTest(
+      {
+        pods: {
+          pod1: {
+            ...typicalProofConfig.pods.pod1,
+            entries: {
+              ...typicalProofConfig.pods.pod1.entries,
+              G: {
+                isRevealed: false,
+                minValue: 3n,
+                maxValue: 256n
+              }
+            }
+          }
+        }
+      },
+      typicalProofInputs,
+      expectedRevealedClaimsForTypicalCase
+    );
+    expect(isVerified).to.be.true;
+  });
+
   it("should prove and verify a complex case", async function () {
     const pod1 = POD.sign(sampleEntries, privateKey);
     const pod2 = POD.sign(sampleEntries2, privateKey2);
@@ -345,7 +411,8 @@ describe("gpc library (Compiled test artifacts) should work", async function () 
         },
         pod1: {
           entries: {
-            G: { isRevealed: true },
+            A: { isRevealed: false, minValue: 100n, maxValue: 132n },
+            G: { isRevealed: true, maxValue: 30n },
             otherTicketID: { isRevealed: false },
             owner: { isRevealed: false, isOwnerID: true }
           },

--- a/packages/lib/gpc/test/gpcChecks.spec.ts
+++ b/packages/lib/gpc/test/gpcChecks.spec.ts
@@ -26,8 +26,7 @@ describe("Proof entry config check should work", () => {
     const entryConfig: GPCProofEntryConfig = {
       isRevealed: false,
       isMemberOf: "someList",
-      minValue: 0n,
-      maxValue: 10n,
+      inRange: { min: 0n, max: 10n },
       equalsEntry: "someOtherPOD.someOtherEntry"
     };
     expect(checkProofEntryConfig(entryName, entryConfig)).to.deep.equal({
@@ -39,9 +38,9 @@ describe("Proof entry config check should work", () => {
 
   it("should pass for an entry configuration with bounds checks within the appropriate range", () => {
     for (const boundsCheckConfig of [
-      { minValue: 3n },
-      { maxValue: 100n },
-      { minValue: 3n, maxValue: 100n }
+      { inRange: { min: 3n, max: POD_INT_MAX } },
+      { inRange: { min: POD_INT_MIN, max: 100n } },
+      { inRange: { min: 3n, max: 100n } }
     ]) {
       const entryName = "somePOD.someEntry";
       const entryConfig = { isRevealed: false };
@@ -56,11 +55,11 @@ describe("Proof entry config check should work", () => {
 
   it("should fail for an entry configuration with bounds checks outside of the appropriate range", () => {
     for (const boundsCheckConfig of [
-      { minValue: POD_INT_MIN - 1n },
-      { maxValue: POD_INT_MAX + 1n },
-      { minValue: POD_INT_MIN - 1n, maxValue: 100n },
-      { minValue: 3n, maxValue: POD_INT_MAX + 1n },
-      { minValue: POD_INT_MIN, maxValue: POD_INT_MAX + 1n }
+      { inRange: { min: POD_INT_MIN - 1n, max: POD_INT_MAX } },
+      { inRange: { min: POD_INT_MIN, max: POD_INT_MAX + 1n } },
+      { inRange: { min: POD_INT_MIN - 1n, max: 100n } },
+      { inRange: { min: 3n, max: POD_INT_MAX + 1n } },
+      { inRange: { min: POD_INT_MIN, max: POD_INT_MAX + 1n } }
     ]) {
       const entryName = "somePOD.someEntry";
       const entryConfig = { isRevealed: false };
@@ -85,12 +84,12 @@ describe("Proof config check against input for bounds checks should work", () =>
   });
   it("should pass for an entry configuration containing bounds checks", () => {
     for (const boundsCheckConfig of [
-      { minValue: 3n },
-      { minValue: 25n },
-      { maxValue: 25n },
-      { maxValue: 100n },
-      { minValue: 25n, maxValue: 25n },
-      { minValue: 3n, maxValue: 100n }
+      { inRange: { min: 3n, max: POD_INT_MAX } },
+      { inRange: { min: 25n, max: POD_INT_MAX } },
+      { inRange: { min: POD_INT_MIN, max: 25n } },
+      { inRange: { min: POD_INT_MIN, max: 100n } },
+      { inRange: { min: 25n, max: 25n } },
+      { inRange: { min: 3n, max: 100n } }
     ]) {
       const entryName = "somePOD.someEntry";
       const entryConfig = { isRevealed: false };
@@ -106,10 +105,10 @@ describe("Proof config check against input for bounds checks should work", () =>
   });
   it("should fail for an entry not satisfying bounds", () => {
     for (const boundsCheckConfig of [
-      { minValue: 38n },
-      { maxValue: 20n },
-      { minValue: 3n, maxValue: 24n },
-      { minValue: 26n, maxValue: 100n }
+      { inRange: { min: 38n, max: POD_INT_MAX } },
+      { inRange: { min: POD_INT_MIN, max: 20n } },
+      { inRange: { min: 3n, max: 24n } },
+      { inRange: { min: 26n, max: 100n } }
     ]) {
       const entryName = "somePOD.someEntry";
       const entryConfig = { isRevealed: false };
@@ -130,9 +129,9 @@ describe("Proof config check against input for bounds checks should work", () =>
       { type: "string", value: "hello" } satisfies PODValue
     ]) {
       for (const boundsCheckConfig of [
-        { minValue: 3n },
-        { maxValue: 100n },
-        { minValue: 3n, maxValue: 100n }
+        { inRange: { min: 3n, max: POD_INT_MAX } },
+        { inRange: { min: POD_INT_MIN, max: 100n } },
+        { inRange: { min: 3n, max: 100n } }
       ]) {
         const entryName = "somePOD.someEntry";
         const entryConfig = { isRevealed: false };

--- a/packages/lib/gpc/test/gpcChecks.spec.ts
+++ b/packages/lib/gpc/test/gpcChecks.spec.ts
@@ -1,0 +1,150 @@
+import {
+  PODEdDSAPublicKeyValue,
+  PODValue,
+  POD_INT_MAX,
+  POD_INT_MIN
+} from "@pcd/pod";
+import { expect } from "chai";
+import "mocha";
+import { GPCProofEntryConfig } from "../src";
+import {
+  checkProofBoundsCheckInputsForConfig,
+  checkProofEntryConfig
+} from "../src/gpcChecks";
+
+describe("Proof entry config check should work", () => {
+  it("should pass for a minimal entry configuration", () => {
+    const entryName = "somePOD.someEntry";
+    const entryConfig = { isRevealed: false };
+    expect(checkProofEntryConfig(entryName, entryConfig)).to.deep.equal({
+      hasBoundsCheck: false
+    });
+  });
+
+  it("should pass for a typical entry configuration", () => {
+    const entryName = "somePOD.someEntry";
+    const entryConfig: GPCProofEntryConfig = {
+      isRevealed: false,
+      isMemberOf: "someList",
+      minValue: 0n,
+      maxValue: 10n,
+      equalsEntry: "someOtherPOD.someOtherEntry"
+    };
+    expect(checkProofEntryConfig(entryName, entryConfig)).to.deep.equal({
+      hasBoundsCheck: true
+    });
+  });
+
+  // TODO(POD-P3): Test other aspects of this check
+
+  it("should pass for an entry configuration with bounds checks within the appropriate range", () => {
+    for (const boundsCheckConfig of [
+      { minValue: 3n },
+      { maxValue: 100n },
+      { minValue: 3n, maxValue: 100n }
+    ]) {
+      const entryName = "somePOD.someEntry";
+      const entryConfig = { isRevealed: false };
+      expect(
+        checkProofEntryConfig(entryName, {
+          ...entryConfig,
+          ...boundsCheckConfig
+        })
+      ).to.deep.equal({ hasBoundsCheck: true });
+    }
+  });
+
+  it("should fail for an entry configuration with bounds checks outside of the appropriate range", () => {
+    for (const boundsCheckConfig of [
+      { minValue: POD_INT_MIN - 1n },
+      { maxValue: POD_INT_MAX + 1n },
+      { minValue: POD_INT_MIN - 1n, maxValue: 100n },
+      { minValue: 3n, maxValue: POD_INT_MAX + 1n },
+      { minValue: POD_INT_MIN, maxValue: POD_INT_MAX + 1n }
+    ]) {
+      const entryName = "somePOD.someEntry";
+      const entryConfig = { isRevealed: false };
+      expect(() =>
+        checkProofEntryConfig(entryName, {
+          ...entryConfig,
+          ...boundsCheckConfig
+        })
+      ).to.throw(RangeError);
+    }
+  });
+});
+
+describe("Proof config check against input for bounds checks should work", () => {
+  it("should pass for an entry configuration without bounds checks", () => {
+    const entryName = "somePOD.someEntry";
+    const entryConfig = { isRevealed: true };
+    const entryValue: PODValue = { type: "string", value: "hello" };
+    expect(
+      checkProofBoundsCheckInputsForConfig(entryName, entryConfig, entryValue)
+    ).to.not.throw;
+  });
+  it("should pass for an entry configuration containing bounds checks", () => {
+    for (const boundsCheckConfig of [
+      { minValue: 3n },
+      { minValue: 25n },
+      { maxValue: 25n },
+      { maxValue: 100n },
+      { minValue: 25n, maxValue: 25n },
+      { minValue: 3n, maxValue: 100n }
+    ]) {
+      const entryName = "somePOD.someEntry";
+      const entryConfig = { isRevealed: false };
+      const entryValue: PODValue = { type: "int", value: 25n };
+      expect(
+        checkProofBoundsCheckInputsForConfig(
+          entryName,
+          { ...entryConfig, ...boundsCheckConfig },
+          entryValue
+        )
+      ).to.not.throw;
+    }
+  });
+  it("should fail for an entry not satisfying bounds", () => {
+    for (const boundsCheckConfig of [
+      { minValue: 38n },
+      { maxValue: 20n },
+      { minValue: 3n, maxValue: 24n },
+      { minValue: 26n, maxValue: 100n }
+    ]) {
+      const entryName = "somePOD.someEntry";
+      const entryConfig = { isRevealed: false };
+      const entryValue: PODValue = { type: "int", value: 25n };
+      expect(() =>
+        checkProofBoundsCheckInputsForConfig(
+          entryName,
+          { ...entryConfig, ...boundsCheckConfig },
+          entryValue
+        )
+      ).to.throw(RangeError);
+    }
+  });
+  it("should fail for a non-int entry configuration containing bounds checks", () => {
+    for (const entryValue of [
+      PODEdDSAPublicKeyValue("xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4"),
+      { type: "cryptographic", value: 25n } satisfies PODValue,
+      { type: "string", value: "hello" } satisfies PODValue
+    ]) {
+      for (const boundsCheckConfig of [
+        { minValue: 3n },
+        { maxValue: 100n },
+        { minValue: 3n, maxValue: 100n }
+      ]) {
+        const entryName = "somePOD.someEntry";
+        const entryConfig = { isRevealed: false };
+        expect(() =>
+          checkProofBoundsCheckInputsForConfig(
+            entryName,
+            { ...entryConfig, ...boundsCheckConfig },
+            entryValue
+          )
+        ).to.throw(TypeError);
+      }
+    }
+  });
+});
+// TODO(POD-P3): More tests

--- a/packages/lib/gpc/test/gpcUtil.spec.ts
+++ b/packages/lib/gpc/test/gpcUtil.spec.ts
@@ -135,16 +135,16 @@ describe("Bounds check configuration derivation works as expected", () => {
     const boundsCheckConfig = boundsCheckConfigFromProofConfig(proofConfig);
     expect(boundsCheckConfig).to.deep.eq({
       "somePod.A": {
-        minValue: 0n,
-        maxValue: POD_INT_MAX
+        min: 0n,
+        max: POD_INT_MAX
       },
       "somePod.B": {
-        minValue: POD_INT_MIN,
-        maxValue: 87n
+        min: POD_INT_MIN,
+        max: 87n
       },
       "someOtherPod.D": {
-        minValue: 5n,
-        maxValue: 25n
+        min: 5n,
+        max: 25n
       }
     });
   });

--- a/packages/lib/gpc/test/gpcUtil.spec.ts
+++ b/packages/lib/gpc/test/gpcUtil.spec.ts
@@ -1,3 +1,4 @@
+import { POD_INT_MAX, POD_INT_MIN } from "@pcd/pod";
 import { expect } from "chai";
 import "mocha";
 import {
@@ -110,11 +111,11 @@ describe("Bounds check configuration derivation works as expected", () => {
             A: {
               isRevealed: false, // Not relevant, but bounds checks make the
               // most sense when the entry is *not* revealed!
-              minValue: 0n
+              inRange: { min: 0n, max: POD_INT_MAX }
             },
             B: {
               isRevealed: false,
-              maxValue: 87n
+              inRange: { min: POD_INT_MIN, max: 87n }
             },
             C: {
               isRevealed: true
@@ -125,8 +126,7 @@ describe("Bounds check configuration derivation works as expected", () => {
           entries: {
             D: {
               isRevealed: false,
-              minValue: 5n,
-              maxValue: 25n
+              inRange: { min: 5n, max: 25n }
             }
           }
         }
@@ -135,9 +135,11 @@ describe("Bounds check configuration derivation works as expected", () => {
     const boundsCheckConfig = boundsCheckConfigFromProofConfig(proofConfig);
     expect(boundsCheckConfig).to.deep.eq({
       "somePod.A": {
-        minValue: 0n
+        minValue: 0n,
+        maxValue: POD_INT_MAX
       },
       "somePod.B": {
+        minValue: POD_INT_MIN,
         maxValue: 87n
       },
       "someOtherPod.D": {

--- a/packages/pcd/gpc-pcd/src/GPCPCDPackage.ts
+++ b/packages/pcd/gpc-pcd/src/GPCPCDPackage.ts
@@ -34,7 +34,7 @@ import {
   GPCPCDTypeName,
   PODPCDArgValidatorParams
 } from "./GPCPCD";
-import { podEntryRecordFromSimplifiedJSON } from "./util";
+import { fixedPODEntriesFromSimplifiedJSON } from "./util";
 import {
   checkPCDType,
   checkPODAgainstPrescribedSignerPublicKeys,
@@ -304,7 +304,7 @@ function validateInputPOD(
 
     prescribedEntries =
       params.prescribedEntries !== undefined
-        ? podEntryRecordFromSimplifiedJSON(params.prescribedEntries)
+        ? fixedPODEntriesFromSimplifiedJSON(params.prescribedEntries)
         : undefined;
   } catch (e) {
     if (e instanceof TypeError || e instanceof Error) {

--- a/packages/pcd/gpc-pcd/src/util.ts
+++ b/packages/pcd/gpc-pcd/src/util.ts
@@ -14,18 +14,17 @@ const jsonBigSerializer = JSONBig({
 });
 
 /**
- * Deserializes `PODEntryRecord` from the simplified format produced by
- * {@link podEntryRecordToSimplifiedJSON}.  Type information is inferred from
- * the values in a way which should preserve hashing and circuit behavior, but
- * isn't guaranteed to be identical to the types before serialization.  For
- * instance, small numbers are always annotated as `int`, rather than
- * `cryptographic`.
+ * Deserializes `FixedPODEntries` from the simplified format produced by {@link
+ * podEntryRecordToSimplifiedJSON}.  Type information is inferred from the
+ * values in a way which should preserve hashing and circuit behavior, but isn't
+ * guaranteed to be identical to the types before serialization.  For instance,
+ * small numbers are always annotated as `int`, rather than `cryptographic`.
  *
- * @param simplifiedJSON a string representation of `PODEntryRecord`
- * @returns `PODEntryRecord` deserialized from the string
+ * @param simplifiedJSON a string representation of `FixedPODEntries`
+ * @returns `FixedPODEntries` deserialized from the string
  * @throws if the serialized form is invalid
  */
-export function podEntryRecordFromSimplifiedJSON(
+export function fixedPODEntriesFromSimplifiedJSON(
   simplifiedJSON: string
 ): FixedPODEntries {
   const simplifiedValues = jsonBigSerializer.parse(simplifiedJSON) as Record<
@@ -60,7 +59,9 @@ export function podEntryRecordFromSimplifiedJSON(
       )
     )
   ) {
-    throw new TypeError(`Invalid serialised PODEntryRecord: ${simplifiedJSON}`);
+    throw new TypeError(
+      `Invalid serialised FixedPODEntries: ${simplifiedJSON}`
+    );
   }
 
   const entryRecord: FixedPODEntries = Object.fromEntries(
@@ -79,9 +80,9 @@ export function podEntryRecordFromSimplifiedJSON(
 }
 
 /**
- * Serializes `PODEntryRecord` to a string in a simplified format optimized for
+ * Serializes `FixedPODEntries` to a string in a simplified format optimized for
  * compactness and human readability.  Calling {@link
- * podEntryRecordFromSimplifiedJSON} will reconstruct `PODEntryRecord` whose POD
+ * podEntryRecordFromSimplifiedJSON} will reconstruct `FixedPODEntries` whose POD
  * values will contain the same values and behave the same in hashing and
  * circuits, but the type information may not be identical.
  *
@@ -90,7 +91,7 @@ export function podEntryRecordFromSimplifiedJSON(
  *   argument to JSON.stringify.
  * @returns a string representation
  */
-export function podEntryRecordToSimplifiedJSON(
+export function fixedPODEntriesToSimplifiedJSON(
   toSerialize: FixedPODEntries,
   space?: number
 ): string {

--- a/packages/pcd/gpc-pcd/src/validatorChecks.ts
+++ b/packages/pcd/gpc-pcd/src/validatorChecks.ts
@@ -46,12 +46,10 @@ export function checkPODEntriesAgainstProofConfig(
   if (
     Object.entries(podConfig.entries).some(
       ([entryName, entryConfig]) =>
-        (entryConfig.minValue !== undefined &&
-          (podEntries[entryName].type !== "int" ||
-            (podEntries[entryName].value as bigint) < entryConfig.minValue)) ||
-        (entryConfig.maxValue !== undefined &&
-          (podEntries[entryName].type !== "int" ||
-            (podEntries[entryName].value as bigint) > entryConfig.maxValue))
+        entryConfig.inRange !== undefined &&
+        (podEntries[entryName].type !== "int" ||
+          (podEntries[entryName].value as bigint) < entryConfig.inRange.min ||
+          (podEntries[entryName].value as bigint) > entryConfig.inRange.max)
     )
   ) {
     return false;

--- a/packages/pcd/gpc-pcd/src/validatorChecks.ts
+++ b/packages/pcd/gpc-pcd/src/validatorChecks.ts
@@ -40,9 +40,24 @@ export function checkPODEntriesAgainstProofConfig(
   // Return false if some entry in the config is not in the POD
   if (configEntries.some((entryName) => podEntries[entryName] === undefined)) {
     return false;
-  } else {
-    return true;
   }
+
+  // Return false if bounds checks specified in the config are not satisfied.
+  if (
+    Object.entries(podConfig.entries).some(
+      ([entryName, entryConfig]) =>
+        (entryConfig.minValue !== undefined &&
+          (podEntries[entryName].type !== "int" ||
+            (podEntries[entryName].value as bigint) < entryConfig.minValue)) ||
+        (entryConfig.maxValue !== undefined &&
+          (podEntries[entryName].type !== "int" ||
+            (podEntries[entryName].value as bigint) > entryConfig.maxValue))
+    )
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 export function checkPODEntriesAgainstMembershipLists(

--- a/packages/pcd/gpc-pcd/test/gpc-pcd.spec.ts
+++ b/packages/pcd/gpc-pcd/test/gpc-pcd.spec.ts
@@ -5,7 +5,7 @@ import {
   serializeGPCProofConfig
 } from "@pcd/gpc";
 import { ArgumentTypeName } from "@pcd/pcd-types";
-import { POD, PODEdDSAPublicKeyValue } from "@pcd/pod";
+import { POD, PODEdDSAPublicKeyValue, POD_INT_MAX } from "@pcd/pod";
 import { PODPCD, PODPCDPackage } from "@pcd/pod-pcd";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import { expect } from "chai";
@@ -44,7 +44,7 @@ describe("GPCPCD should work", async function () {
       pods: {
         pod0: {
           entries: {
-            A: { isRevealed: true, minValue: 100n, maxValue: 256n },
+            A: { isRevealed: true, inRange: { min: 100n, max: 256n } },
             E: { isRevealed: false, equalsEntry: "pod0.A" },
             owner: {
               isRevealed: false,
@@ -189,7 +189,7 @@ describe("GPCPCD input POD validator should work", () => {
     pods: {
       pod0: {
         entries: {
-          A: { isRevealed: true, minValue: 100n },
+          A: { isRevealed: true, inRange: { min: 100n, max: POD_INT_MAX } },
           H: { isRevealed: true },
           E: { isRevealed: false, equalsEntry: "pod0.A" },
           owner: {
@@ -286,8 +286,8 @@ describe("GPCPCD input POD validator should work", () => {
         pods: {
           pod0: {
             entries: {
-              A: { isRevealed: false, minValue: 100n, maxValue: 256n },
-              H: { isRevealed: false, minValue: 3n }
+              A: { isRevealed: false, inRange: { min: 100n, max: 256n } },
+              H: { isRevealed: false, inRange: { min: 3n, max: POD_INT_MAX } }
             }
           },
           ticketPOD: {
@@ -413,15 +413,15 @@ describe("GPCPCD input POD validator should work", () => {
         pods: {
           pod0: {
             entries: {
-              A: { isRevealed: false, minValue: 200n, maxValue: 256n },
-              H: { isRevealed: false, minValue: 3n }
+              A: { isRevealed: false, inRange: { min: 200n, max: 256n } },
+              H: { isRevealed: false, inRange: { min: 3n, max: POD_INT_MAX } }
             }
           },
           ticketPOD: {
             entries: {
               eventID: {
                 isRevealed: true,
-                minValue: 8n
+                inRange: { min: 8n, max: POD_INT_MAX }
               },
               ticketID: {
                 isRevealed: false,

--- a/packages/pcd/gpc-pcd/test/util.spec.ts
+++ b/packages/pcd/gpc-pcd/test/util.spec.ts
@@ -2,8 +2,8 @@ import { expect } from "chai";
 import JSONBig from "json-bigint";
 import {
   FixedPODEntries,
-  podEntryRecordFromSimplifiedJSON,
-  podEntryRecordToSimplifiedJSON
+  fixedPODEntriesFromSimplifiedJSON,
+  fixedPODEntriesToSimplifiedJSON
 } from "../src";
 
 const jsonBigSerializer = JSONBig({
@@ -13,9 +13,9 @@ const jsonBigSerializer = JSONBig({
 
 describe("PODEntryRecord serialisation should work", () => {
   it("Should serialise and deserialise empty object", async function () {
-    const serialised = podEntryRecordToSimplifiedJSON({});
+    const serialised = fixedPODEntriesToSimplifiedJSON({});
     const expectedSerialised = "{}";
-    const deserialised = podEntryRecordFromSimplifiedJSON(serialised);
+    const deserialised = fixedPODEntriesFromSimplifiedJSON(serialised);
     expect(serialised).to.eq(expectedSerialised);
     expect(deserialised).to.deep.eq({});
   });
@@ -31,7 +31,9 @@ describe("PODEntryRecord serialisation should work", () => {
       }
     };
 
-    const serialised = podEntryRecordToSimplifiedJSON(typicalPrescribedEntries);
+    const serialised = fixedPODEntriesToSimplifiedJSON(
+      typicalPrescribedEntries
+    );
 
     const expectedSerialised = jsonBigSerializer.stringify({
       pod1: {
@@ -43,21 +45,21 @@ describe("PODEntryRecord serialisation should work", () => {
       }
     });
 
-    const deserialised = podEntryRecordFromSimplifiedJSON(serialised);
+    const deserialised = fixedPODEntriesFromSimplifiedJSON(serialised);
 
     expect(serialised).to.eq(expectedSerialised);
     expect(deserialised).to.deep.eq(typicalPrescribedEntries);
   });
 
   it("Should fail to deserialise a string not representing an object", () => {
-    expect(() => podEntryRecordFromSimplifiedJSON(`"hello"`)).to.throw(
+    expect(() => fixedPODEntriesFromSimplifiedJSON(`"hello"`)).to.throw(
       TypeError
     );
   });
 
   it("Should fail to deserialise a record with an invalid POD name", () => {
     expect(() =>
-      podEntryRecordFromSimplifiedJSON(`{
+      fixedPODEntriesFromSimplifiedJSON(`{
         "$notPOD": { "entry": 5 }
       }`)
     ).to.throw(TypeError);
@@ -65,13 +67,13 @@ describe("PODEntryRecord serialisation should work", () => {
 
   it("Should fail to deserialise a record with a POD with no data", () => {
     expect(() =>
-      podEntryRecordFromSimplifiedJSON(`{ "somePOD": {} }`)
+      fixedPODEntriesFromSimplifiedJSON(`{ "somePOD": {} }`)
     ).to.throw(TypeError);
   });
 
   it("Should fail to deserialise a record with a POD with an invalid raw entry value", () => {
     expect(() =>
-      podEntryRecordFromSimplifiedJSON(`{
+      fixedPODEntriesFromSimplifiedJSON(`{
         "somePOD": { "entry": {} }
       }`)
     ).to.throw(TypeError);

--- a/packages/pcd/gpc-pcd/test/validatorChecks.spec.ts
+++ b/packages/pcd/gpc-pcd/test/validatorChecks.spec.ts
@@ -108,6 +108,95 @@ describe("POD entry check against proof configuration should work", () => {
     expect(params.notFoundMessage).to.be.undefined;
   });
 
+  it("should pass for a named POD containing a named entry satisfying prescribed bounds", () => {
+    for (const boundsCheckConfig of [
+      { minValue: 0n },
+      { maxValue: 124n },
+      { minValue: 0n, maxValue: 124n }
+    ]) {
+      const proofConfig: GPCProofConfig = {
+        pods: {
+          pod0: {
+            entries: {
+              A: { isRevealed: true, ...boundsCheckConfig },
+              E: {
+                isRevealed: false,
+                equalsEntry: "pod0.A"
+              }
+            }
+          }
+        }
+      };
+      const params = {
+        proofConfig: serializeGPCProofConfig(proofConfig),
+        notFoundMessage: undefined
+      };
+      expect(
+        checkPODEntriesAgainstProofConfig("pod0", podPCD0, proofConfig, params)
+      ).to.be.true;
+      expect(params.notFoundMessage).to.be.undefined;
+    }
+  });
+
+  it("should fail for a named POD containing a named entry not satisfying prescribed bounds", () => {
+    for (const boundsCheckConfig of [
+      { minValue: 124n },
+      { maxValue: 122n },
+      { minValue: 0n, maxValue: 122n },
+      { minValue: 124n, maxValue: 256n }
+    ]) {
+      const proofConfig: GPCProofConfig = {
+        pods: {
+          pod0: {
+            entries: {
+              A: { isRevealed: true, ...boundsCheckConfig },
+              E: { isRevealed: false, equalsEntry: "pod0.A" }
+            }
+          }
+        }
+      };
+      const params = {
+        proofConfig: serializeGPCProofConfig(proofConfig),
+        notFoundMessage: undefined
+      };
+      expect(
+        checkPODEntriesAgainstProofConfig("pod0", podPCD0, proofConfig, params)
+      ).to.be.false;
+      expect(params.notFoundMessage).to.be.undefined;
+    }
+  });
+
+  it("should fail for a named POD containing a named non-int entry that should satisfy given bounds", () => {
+    for (const boundsCheckConfig of [
+      { minValue: 0n },
+      { maxValue: 124n },
+      { minValue: 0n, maxValue: 124n }
+    ]) {
+      const proofConfig: GPCProofConfig = {
+        pods: {
+          pod0: {
+            entries: {
+              A: { isRevealed: true },
+              E: {
+                isRevealed: false,
+                equalsEntry: "pod0.A",
+                ...boundsCheckConfig
+              }
+            }
+          }
+        }
+      };
+      const params = {
+        proofConfig: serializeGPCProofConfig(proofConfig),
+        notFoundMessage: undefined
+      };
+      expect(
+        checkPODEntriesAgainstProofConfig("pod0", podPCD0, proofConfig, params)
+      ).to.be.false;
+      expect(params.notFoundMessage).to.be.undefined;
+    }
+  });
+
   it("should pass for a named POD containing all entries in the proof configuration", () => {
     const proofConfig: GPCProofConfig = {
       pods: {

--- a/packages/pcd/gpc-pcd/test/validatorChecks.spec.ts
+++ b/packages/pcd/gpc-pcd/test/validatorChecks.spec.ts
@@ -1,5 +1,5 @@
 import { GPCProofConfig, serializeGPCProofConfig } from "@pcd/gpc";
-import { POD } from "@pcd/pod";
+import { POD, POD_INT_MAX, POD_INT_MIN } from "@pcd/pod";
 import { PODPCD } from "@pcd/pod-pcd";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import { expect } from "chai";
@@ -110,9 +110,9 @@ describe("POD entry check against proof configuration should work", () => {
 
   it("should pass for a named POD containing a named entry satisfying prescribed bounds", () => {
     for (const boundsCheckConfig of [
-      { minValue: 0n },
-      { maxValue: 124n },
-      { minValue: 0n, maxValue: 124n }
+      { inRange: { min: 0n, max: POD_INT_MAX } },
+      { inRange: { min: POD_INT_MIN, max: 124n } },
+      { inRange: { min: 0n, max: 124n } }
     ]) {
       const proofConfig: GPCProofConfig = {
         pods: {
@@ -140,10 +140,10 @@ describe("POD entry check against proof configuration should work", () => {
 
   it("should fail for a named POD containing a named entry not satisfying prescribed bounds", () => {
     for (const boundsCheckConfig of [
-      { minValue: 124n },
-      { maxValue: 122n },
-      { minValue: 0n, maxValue: 122n },
-      { minValue: 124n, maxValue: 256n }
+      { inRange: { min: 124n, max: POD_INT_MAX } },
+      { inRange: { min: POD_INT_MIN, max: 122n } },
+      { inRange: { min: 0n, max: 122n } },
+      { inRange: { min: 124n, max: 256n } }
     ]) {
       const proofConfig: GPCProofConfig = {
         pods: {
@@ -168,9 +168,9 @@ describe("POD entry check against proof configuration should work", () => {
 
   it("should fail for a named POD containing a named non-int entry that should satisfy given bounds", () => {
     for (const boundsCheckConfig of [
-      { minValue: 0n },
-      { maxValue: 124n },
-      { minValue: 0n, maxValue: 124n }
+      { inRange: { min: 0n, max: POD_INT_MAX } },
+      { inRange: { min: POD_INT_MIN, max: 124n } },
+      { inRange: { min: 0n, max: 124n } }
     ]) {
       const proofConfig: GPCProofConfig = {
         pods: {


### PR DESCRIPTION
Resolves https://linear.app/0xparc-pcd/issue/0XP-951/gpc-lowerboundupperbound-proofs

This PR adds bounds checks to the GPC config. Summary of changes:
- Addition of `minValue` and `maxValue` fields to the proof entry config
- Additional checks and compilation steps in GPC package
- Unit tests
- POD PCD filtering for prescribed bounds in GPC PCD package