### PR TITLE
Basic Semaphore groups for CSV pipelines

### DIFF
--- a/apps/passport-server/src/services/generic-issuance/SemaphoreGroupProvider.ts
+++ b/apps/passport-server/src/services/generic-issuance/SemaphoreGroupProvider.ts
@@ -289,6 +289,10 @@ export class SemaphoreGroupProvider {
     for (const groupConfig of this.groupConfigs) {
       const matchingEmails = ticketDataList
         .filter((ticketData) => {
+          // If no criteria are specified, match all tickets
+          if (groupConfig.memberCriteria.length === 0) {
+            return true;
+          }
           // See if the ticket matches any of the criteria for group membership
           for (const ticketSpec of groupConfig.memberCriteria) {
             if (

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
@@ -5,6 +5,7 @@ import {
   PipelineEdDSATicketZuAuthConfig,
   PipelineLoadSummary,
   PipelineLog,
+  PipelineSemaphoreGroupInfo,
   PipelineType,
   PipelineZuAuthConfig,
   PollFeedRequest,
@@ -12,18 +13,27 @@ import {
 } from "@pcd/passport-interface";
 import { PCDActionType } from "@pcd/pcd-collection";
 import { SerializedPCD } from "@pcd/pcd-types";
+import { SerializedSemaphoreGroup } from "@pcd/semaphore-group-pcd";
 import { parse } from "csv-parse";
-import { v4 as uuid } from "uuid";
+import PQueue from "p-queue";
+import { v4 as uuid, v5 as uuidv5 } from "uuid";
 import {
   IPipelineAtomDB,
   PipelineAtom
 } from "../../../../database/queries/pipelineAtomDB";
+import { IPipelineConsumerDB } from "../../../../database/queries/pipelineConsumerDB";
+import { IPipelineSemaphoreHistoryDB } from "../../../../database/queries/pipelineSemaphoreHistoryDB";
 import { logger } from "../../../../util/logger";
 import { setError, traced } from "../../../telemetryService";
+import {
+  SemaphoreGroupProvider,
+  SemaphoreGroupTicketInfo
+} from "../../SemaphoreGroupProvider";
 import {
   FeedIssuanceCapability,
   makeGenericIssuanceFeedUrl
 } from "../../capabilities/FeedIssuanceCapability";
+import { SemaphoreGroupCapability } from "../../capabilities/SemaphoreGroupCapability";
 import { PipelineCapability } from "../../capabilities/types";
 import { tracePipeline } from "../../honeycombQueries";
 import { CredentialSubservice } from "../../subservices/CredentialSubservice";
@@ -53,6 +63,9 @@ export class CSVPipeline implements BasePipeline {
   private db: IPipelineAtomDB<CSVAtom>;
   private definition: CSVPipelineDefinition;
   private credentialSubservice: CredentialSubservice;
+  private semaphoreGroupProvider?: SemaphoreGroupProvider;
+  private consumerDB: IPipelineConsumerDB;
+  private semaphoreUpdateQueue: PQueue;
 
   public get id(): string {
     return this.definition.id;
@@ -66,7 +79,9 @@ export class CSVPipeline implements BasePipeline {
     eddsaPrivateKey: string,
     definition: CSVPipelineDefinition,
     db: IPipelineAtomDB,
-    credentialSubservice: CredentialSubservice
+    credentialSubservice: CredentialSubservice,
+    consumerDB: IPipelineConsumerDB,
+    semaphoreHistoryDB: IPipelineSemaphoreHistoryDB
   ) {
     this.eddsaPrivateKey = eddsaPrivateKey;
     this.definition = definition;
@@ -81,9 +96,50 @@ export class CSVPipeline implements BasePipeline {
         ),
         options: this.definition.options.feedOptions,
         getZuAuthConfig: this.getZuAuthConfig.bind(this)
-      } satisfies FeedIssuanceCapability
+      } satisfies FeedIssuanceCapability,
+      {
+        type: PipelineCapability.SemaphoreGroup,
+        getSerializedLatestGroup: async (
+          groupId: string
+        ): Promise<SerializedSemaphoreGroup | undefined> => {
+          return this.semaphoreGroupProvider?.getSerializedLatestGroup(groupId);
+        },
+        getLatestGroupRoot: async (
+          groupId: string
+        ): Promise<string | undefined> => {
+          return this.semaphoreGroupProvider?.getLatestGroupRoot(groupId);
+        },
+        getSerializedHistoricalGroup: async (
+          groupId: string,
+          rootHash: string
+        ): Promise<SerializedSemaphoreGroup | undefined> => {
+          return this.semaphoreGroupProvider?.getSerializedHistoricalGroup(
+            groupId,
+            rootHash
+          );
+        },
+        getSupportedGroups: (): PipelineSemaphoreGroupInfo[] => {
+          return this.semaphoreGroupProvider?.getSupportedGroups() ?? [];
+        }
+      } satisfies SemaphoreGroupCapability
     ] as unknown as BasePipelineCapability[];
     this.credentialSubservice = credentialSubservice;
+    this.consumerDB = consumerDB;
+    if (definition.options.semaphoreGroupName) {
+      this.semaphoreGroupProvider = new SemaphoreGroupProvider(
+        this.id,
+        [
+          {
+            name: definition.options.semaphoreGroupName,
+            groupId: uuidv5(this.id, this.id),
+            memberCriteria: []
+          }
+        ],
+        consumerDB,
+        semaphoreHistoryDB
+      );
+    }
+    this.semaphoreUpdateQueue = new PQueue({ concurrency: 1 });
   }
 
   private async issue(req: PollFeedRequest): Promise<PollFeedResponseValue> {
@@ -106,6 +162,22 @@ export class CSVPipeline implements BasePipeline {
             await this.credentialSubservice.verifyAndExpectZupassEmail(req.pcd);
           requesterEmail = email;
           requesterSemaphoreId = semaphoreId;
+          // Consumer is validated, so save them in the consumer list
+          const didUpdate = await this.consumerDB.save(
+            this.id,
+            email,
+            semaphoreId,
+            new Date()
+          );
+
+          if (this.definition.options.semaphoreGroupName) {
+            // If the user's Semaphore commitment has changed, `didUpdate` will be
+            // true, and we need to update the Semaphore groups
+            if (didUpdate) {
+              span?.setAttribute("semaphore_groups_updated", true);
+              await this.triggerSemaphoreGroupUpdate();
+            }
+          }
         } catch (e) {
           logger(LOG_TAG, "credential PCD not verified for req", req);
         }
@@ -205,7 +277,8 @@ export class CSVPipeline implements BasePipeline {
           lastRunEndTimestamp: end.toISOString(),
           lastRunStartTimestamp: start.toISOString(),
           latestLogs: logs,
-          success: true
+          success: true,
+          semaphoreGroups: this.semaphoreGroupProvider?.getSupportedGroups()
         } satisfies PipelineLoadSummary;
       } catch (e) {
         setError(e, span);
@@ -231,6 +304,9 @@ export class CSVPipeline implements BasePipeline {
 
   public async start(): Promise<void> {
     logger(LOG_TAG, `starting csv pipeline`);
+    // Initialize the Semaphore Group provider by loading groups from the DB,
+    // if one exists.
+    await this.semaphoreGroupProvider?.start();
   }
 
   public async stop(): Promise<void> {
@@ -270,6 +346,66 @@ export class CSVPipeline implements BasePipeline {
       }
     }
     return Object.values(uniqueProductMetadata);
+  }
+
+  /**
+   * Collects data that is require for Semaphore groups to update.
+   * Returns an array of { eventId, productId, email } objects, which the
+   * SemaphoreGroupProvider will use to look up Semaphore IDs and match them
+   * to configured Semaphore groups.
+   * In practice, CSV pipelines do not currently support Semaphore groups that
+   * are filtered by event ID or product ID, but this data is required by the
+   * SemaphoreGroupProvider class.
+   */
+  private async semaphoreGroupData(): Promise<SemaphoreGroupTicketInfo[]> {
+    return traced(LOG_NAME, "semaphoreGroupData", async (span) => {
+      const data = [];
+      if (
+        this.definition.options.outputType === CSVPipelineOutputType.Ticket ||
+        this.definition.options.outputType === CSVPipelineOutputType.PODTicket
+      ) {
+        for (const atom of await this.db.load(this.id)) {
+          // We can use a dummy Semaphore ID here because we only care about
+          // the event ID and product ID for the ticket.
+          const ticket = rowToTicket(atom.row, "0", this.id);
+          if (ticket) {
+            data.push({
+              email: ticket.attendeeEmail,
+              eventId: ticket.eventId,
+              productId: ticket.productId
+            });
+          }
+        }
+      }
+
+      span?.setAttribute("ticket_data_length", data.length);
+      return data;
+    });
+  }
+
+  /**
+   * Tell the Semaphore group provider to update memberships.
+   * Marked as public so that it can be called from tests, but otherwise should
+   * not be called from outside the class.
+   */
+  public async triggerSemaphoreGroupUpdate(): Promise<void> {
+    return traced(LOG_NAME, "triggerSemaphoreGroupUpdate", async (_span) => {
+      tracePipeline(this.definition);
+      // Whenever an update is triggered, we want to make sure that the
+      // fetching of data and the actual update are atomic.
+      // If there were two concurrenct updates, it might be possible for them
+      // to use slightly different data sets, but send them to the `update`
+      // method in the wrong order, producing unexpected outcomes. Although the
+      // group diffing mechanism would eventually cause the group to converge
+      // on the correct membership, we can avoid any temporary inconsistency by
+      // queuing update requests.
+      // By returning this promise, we allow the caller to await on the update
+      // having been processed.
+      return this.semaphoreUpdateQueue.add(async () => {
+        const data = await this.semaphoreGroupData();
+        await this.semaphoreGroupProvider?.update(data);
+      });
+    });
   }
 
   /**

--- a/apps/passport-server/src/services/generic-issuance/subservices/utils/instantiatePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/subservices/utils/instantiatePipeline.ts
@@ -105,7 +105,9 @@ export function instantiatePipeline(
         args.eddsaPrivateKey,
         definition,
         args.pipelineAtomDB,
-        args.credentialSubservice
+        args.credentialSubservice,
+        args.consumerDB,
+        args.semaphoreHistoryDB
       );
     }
 

--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -506,7 +506,8 @@ const CSVPipelineOptionsSchema = BasePipelineOptionsSchema.extend({
   csv: z.string(),
   outputType: z.nativeEnum(CSVPipelineOutputType).optional(),
   feedOptions: FeedIssuanceOptionsSchema,
-  issueToUnmatchedEmail: z.boolean().optional()
+  issueToUnmatchedEmail: z.boolean().optional(),
+  semaphoreGroupName: z.string().optional()
 });
 
 export type CSVPipelineOptions = z.infer<typeof CSVPipelineOptionsSchema>;

--- a/packages/lib/zupoll-shared/src/configs/2024_zuvillage_georgia.ts
+++ b/packages/lib/zupoll-shared/src/configs/2024_zuvillage_georgia.ts
@@ -1,4 +1,4 @@
-import { makePodboxLoginConfigs } from "../makePodboxLoginConfigs";
+import { makePodboxLoginConfigSingleGroup } from "../makePodboxLoginConfigs";
 import { LoginConfig } from "../types";
 
 export function makeZuvillageGeorgia(
@@ -10,22 +10,17 @@ export function makeZuvillageGeorgia(
   const ZUVILLAGE_GEORGIA_RESIDENTS_NAME = "Polls";
   const ZUVILLAGE_GEORGIA_RESIDENTS_DESCRIPTION =
     "Polls created by ZuVillage Georgia pass holders";
-  const ZUVILLAGE_GEORGIA_ORGANIZER_NAME = "Staff Polls";
-  const ZUVILLAGE_GEORGIA_ORGANIZER_DESCRIPTION =
-    "Polls created by ZuVillage Georgia Staff";
   const ZUVILLAGE_GEORGIA_DESCRIPTION =
     "Polls created by ZuVillagers. Add to the discussion by creating a new Ballot!";
   const ZUVILLAGE_GEORGIA_CONFIG_PIPELINE_ID =
     "fca0ba48-125b-43a4-90ef-04f9fdede43d";
   const ZUVILLAGE_GEORGIA_CONFIG_SEMA_GROUP_ID =
     "7ce6f74a-1383-57be-a77a-d4fc04e02f45";
-  const ZUVILLAGE_GEORGIA_CONFIG_ORGANIZER_SEMA_GROUP_ID =
-    "7ce6f74a-1383-57be-a77a-d4fc04e02f45";
   const ZUVILLAGE_GEORGIA_YEAR = 2024;
   const ZUVILLAGE_GEORGIA_MONTH = 7;
   const ZUVILLAGE_GEORGIA_DAY = 20;
   // Only one config
-  const [, ZUVILLAGE_GEORGIA_CONFIG] = makePodboxLoginConfigs(
+  const ZUVILLAGE_GEORGIA_CONFIG = makePodboxLoginConfigSingleGroup(
     ZUPASS_CLIENT_URL,
     ZUPASS_SERVER_URL,
     ZUVILLAGE_GEORGIA_CONFIG_ID,
@@ -33,15 +28,12 @@ export function makeZuvillageGeorgia(
     ZUVILLAGE_GEORGIA_CONFIG_NAME,
     ZUVILLAGE_GEORGIA_RESIDENTS_NAME,
     ZUVILLAGE_GEORGIA_RESIDENTS_DESCRIPTION,
-    ZUVILLAGE_GEORGIA_ORGANIZER_NAME,
-    ZUVILLAGE_GEORGIA_ORGANIZER_DESCRIPTION,
     ZUVILLAGE_GEORGIA_CONFIG_PIPELINE_ID,
     ZUVILLAGE_GEORGIA_CONFIG_SEMA_GROUP_ID,
-    ZUVILLAGE_GEORGIA_CONFIG_ORGANIZER_SEMA_GROUP_ID,
     ZUVILLAGE_GEORGIA_YEAR,
     ZUVILLAGE_GEORGIA_MONTH,
     ZUVILLAGE_GEORGIA_DAY
   );
 
-  return [ZUVILLAGE_GEORGIA_CONFIG];
+  return ZUVILLAGE_GEORGIA_CONFIG;
 }

--- a/packages/lib/zupoll-shared/src/configs/2024_zuvillage_georgia.ts
+++ b/packages/lib/zupoll-shared/src/configs/2024_zuvillage_georgia.ts
@@ -18,9 +18,9 @@ export function makeZuvillageGeorgia(
   const ZUVILLAGE_GEORGIA_CONFIG_PIPELINE_ID =
     "fca0ba48-125b-43a4-90ef-04f9fdede43d";
   const ZUVILLAGE_GEORGIA_CONFIG_SEMA_GROUP_ID =
-    "fca0ba48-125b-43a4-90ef-04f9fdede43d";
+    "7ce6f74a-1383-57be-a77a-d4fc04e02f45";
   const ZUVILLAGE_GEORGIA_CONFIG_ORGANIZER_SEMA_GROUP_ID =
-    "fca0ba48-125b-43a4-90ef-04f9fdede43d";
+    "7ce6f74a-1383-57be-a77a-d4fc04e02f45";
   const ZUVILLAGE_GEORGIA_YEAR = 2024;
   const ZUVILLAGE_GEORGIA_MONTH = 7;
   const ZUVILLAGE_GEORGIA_DAY = 20;

--- a/packages/lib/zupoll-shared/src/configs/2024_zuvillage_georgia.ts
+++ b/packages/lib/zupoll-shared/src/configs/2024_zuvillage_georgia.ts
@@ -1,0 +1,47 @@
+import { makePodboxLoginConfigs } from "../makePodboxLoginConfigs";
+import { LoginConfig } from "../types";
+
+export function makeZuvillageGeorgia(
+  ZUPASS_CLIENT_URL: string,
+  ZUPASS_SERVER_URL: string
+): LoginConfig[] {
+  const ZUVILLAGE_GEORGIA_CONFIG_ID = "ZuVillage Georgia";
+  const ZUVILLAGE_GEORGIA_CONFIG_NAME = "ZuVillage Georgia";
+  const ZUVILLAGE_GEORGIA_RESIDENTS_NAME = "Polls";
+  const ZUVILLAGE_GEORGIA_RESIDENTS_DESCRIPTION =
+    "Polls created by ZuVillage Georgia pass holders";
+  const ZUVILLAGE_GEORGIA_ORGANIZER_NAME = "Staff Polls";
+  const ZUVILLAGE_GEORGIA_ORGANIZER_DESCRIPTION =
+    "Polls created by ZuVillage Georgia Staff";
+  const ZUVILLAGE_GEORGIA_DESCRIPTION =
+    "Polls created by ZuVillagers. Add to the discussion by creating a new Ballot!";
+  const ZUVILLAGE_GEORGIA_CONFIG_PIPELINE_ID =
+    "fca0ba48-125b-43a4-90ef-04f9fdede43d";
+  const ZUVILLAGE_GEORGIA_CONFIG_SEMA_GROUP_ID =
+    "fca0ba48-125b-43a4-90ef-04f9fdede43d";
+  const ZUVILLAGE_GEORGIA_CONFIG_ORGANIZER_SEMA_GROUP_ID =
+    "fca0ba48-125b-43a4-90ef-04f9fdede43d";
+  const ZUVILLAGE_GEORGIA_YEAR = 2024;
+  const ZUVILLAGE_GEORGIA_MONTH = 7;
+  const ZUVILLAGE_GEORGIA_DAY = 20;
+  // Only one config
+  const [, ZUVILLAGE_GEORGIA_CONFIG] = makePodboxLoginConfigs(
+    ZUPASS_CLIENT_URL,
+    ZUPASS_SERVER_URL,
+    ZUVILLAGE_GEORGIA_CONFIG_ID,
+    ZUVILLAGE_GEORGIA_DESCRIPTION,
+    ZUVILLAGE_GEORGIA_CONFIG_NAME,
+    ZUVILLAGE_GEORGIA_RESIDENTS_NAME,
+    ZUVILLAGE_GEORGIA_RESIDENTS_DESCRIPTION,
+    ZUVILLAGE_GEORGIA_ORGANIZER_NAME,
+    ZUVILLAGE_GEORGIA_ORGANIZER_DESCRIPTION,
+    ZUVILLAGE_GEORGIA_CONFIG_PIPELINE_ID,
+    ZUVILLAGE_GEORGIA_CONFIG_SEMA_GROUP_ID,
+    ZUVILLAGE_GEORGIA_CONFIG_ORGANIZER_SEMA_GROUP_ID,
+    ZUVILLAGE_GEORGIA_YEAR,
+    ZUVILLAGE_GEORGIA_MONTH,
+    ZUVILLAGE_GEORGIA_DAY
+  );
+
+  return [ZUVILLAGE_GEORGIA_CONFIG];
+}

--- a/packages/lib/zupoll-shared/src/configs/2024_zuvillage_georgia.ts
+++ b/packages/lib/zupoll-shared/src/configs/2024_zuvillage_georgia.ts
@@ -17,8 +17,8 @@ export function makeZuvillageGeorgia(
   const ZUVILLAGE_GEORGIA_CONFIG_SEMA_GROUP_ID =
     "7ce6f74a-1383-57be-a77a-d4fc04e02f45";
   const ZUVILLAGE_GEORGIA_YEAR = 2024;
-  const ZUVILLAGE_GEORGIA_MONTH = 7;
-  const ZUVILLAGE_GEORGIA_DAY = 20;
+  const ZUVILLAGE_GEORGIA_MONTH = 5;
+  const ZUVILLAGE_GEORGIA_DAY = 1;
   // Only one config
   const ZUVILLAGE_GEORGIA_CONFIG = makePodboxLoginConfigSingleGroup(
     ZUPASS_CLIENT_URL,

--- a/packages/lib/zupoll-shared/src/makePodboxLoginConfigs.ts
+++ b/packages/lib/zupoll-shared/src/makePodboxLoginConfigs.ts
@@ -2,6 +2,60 @@ import urljoin from "url-join";
 import { makePodboxGroupUrl } from "./makePodboxGroupUrl";
 import { BallotType, LoginConfig } from "./types";
 
+export function makePodboxLoginConfigSingleGroup(
+  ZUPASS_CLIENT_URL: string,
+  ZUPASS_SERVER_URL: string,
+  id: string,
+  description: string,
+  name: string,
+  residentName: string,
+  residentDescription: string,
+  pipelineId: string,
+  residentSemaphoreGroupId: string,
+  year: number,
+  month: number,
+  day: number
+): LoginConfig[] {
+  const RESIDENT_GROUP_URL = makePodboxGroupUrl(
+    ZUPASS_SERVER_URL,
+    pipelineId,
+    residentSemaphoreGroupId
+  );
+
+  const RESIDENT_CONFIG: LoginConfig = {
+    pipelineId,
+    year,
+    month,
+    day,
+    configCategoryId: id,
+    groupId: residentSemaphoreGroupId,
+    groupUrl: RESIDENT_GROUP_URL,
+    passportServerUrl: ZUPASS_SERVER_URL,
+    passportAppUrl: ZUPASS_CLIENT_URL,
+    name: name + " Resident",
+    description: description,
+    buttonName: "Sign in as Attendee",
+    canCreateBallotTypes: [BallotType.PODBOX],
+    ballotConfigs: [
+      {
+        name: residentName,
+        description: residentDescription,
+        voterGroupId: residentSemaphoreGroupId,
+        voterGroupUrl: RESIDENT_GROUP_URL,
+        creatorGroupId: residentSemaphoreGroupId,
+        creatorGroupUrl: RESIDENT_GROUP_URL,
+        passportServerUrl: ZUPASS_SERVER_URL,
+        passportAppUrl: ZUPASS_CLIENT_URL,
+        ballotType: BallotType.PODBOX,
+        latestVoterGroupHashUrl: urljoin(RESIDENT_GROUP_URL, "latest-root"),
+        makeHistoricVoterGroupUrl: (hash) => urljoin(RESIDENT_GROUP_URL, hash),
+        isDefault: true
+      }
+    ]
+  };
+  return [RESIDENT_CONFIG];
+}
+
 export function makePodboxLoginConfigs(
   ZUPASS_CLIENT_URL: string,
   ZUPASS_SERVER_URL: string,

--- a/packages/lib/zupoll-shared/src/podboxLoginConfigs.ts
+++ b/packages/lib/zupoll-shared/src/podboxLoginConfigs.ts
@@ -2,6 +2,7 @@ import { make0xpSummer } from "./configs/2024_0xparc_summer";
 import { makeEsmeralda } from "./configs/2024_edge_esmeralda";
 import { makeEthBerlin } from "./configs/2024_eth_berlin";
 import { makeEthPrague } from "./configs/2024_eth_prague";
+import { makeZuvillageGeorgia } from "./configs/2024_zuvillage_georgia";
 import { LoginConfig } from "./types";
 
 export function getPodboxConfigs(
@@ -16,13 +17,18 @@ export function getPodboxConfigs(
   const ESMERALDA_CONFIG = makeEsmeralda(ZUPASS_CLIENT_URL, ZUPASS_SERVER_URL);
   const ETH_PRAGUE_CONFIG = makeEthPrague(ZUPASS_CLIENT_URL, ZUPASS_SERVER_URL);
   const ETH_BERLIN_CONFIG = makeEthBerlin(ZUPASS_CLIENT_URL, ZUPASS_SERVER_URL);
+  const ZUVILLAGE_GEORGIA_CONFIG = makeZuvillageGeorgia(
+    ZUPASS_CLIENT_URL,
+    ZUPASS_SERVER_URL
+  );
 
   return [
     // ...PARC_HQ_CONFIG,
     ...PARC_SUMMER_CONFIG,
     ...ESMERALDA_CONFIG,
     ...ETH_PRAGUE_CONFIG,
-    ...ETH_BERLIN_CONFIG
+    ...ETH_BERLIN_CONFIG,
+    ...ZUVILLAGE_GEORGIA_CONFIG
   ];
 }
 


### PR DESCRIPTION
Adds basic Semaphore group support to CSV pipelines.

It is not possible to configure multiple groups. Instead, a single setting called `semaphoreGroupName` is provided. If unset, there are no Semaphore groups. If set, a single group will be created which includes all of the consumers of the pipeline. Consumers will only be members of the group after they have fetched their tickets at least once.