### PR TITLE
add screen improvements when not logged in

### DIFF
--- a/apps/passport-client/components/screens/AddScreen/AddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/AddScreen.tsx
@@ -6,9 +6,8 @@ import {
 } from "@pcd/passport-interface";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import { useDispatch, useLoginIfNoSelf, useSelf } from "../../../src/appHooks";
+import { useDispatch } from "../../../src/appHooks";
 import { validateRequest } from "../../../src/passportRequest";
-import { pendingRequestKeys } from "../../../src/sessionStorage";
 import { useSyncE2EEStorage } from "../../../src/useSyncE2EEStorage";
 import { err } from "../../../src/util";
 import { AppContainer } from "../../shared/AppContainer";
@@ -23,23 +22,17 @@ import { ProveAndAddScreen } from "./ProveAndAddScreen";
 export function AddScreen(): JSX.Element | null {
   useSyncE2EEStorage();
   const dispatch = useDispatch();
-  const self = useSelf();
   const location = useLocation();
   const params = new URLSearchParams(location.search);
   const request = validateRequest(params);
-  const screen = getScreen(request);
+  const autoAdd = params.get("autoAdd") === "true";
+  const screen = getScreen(request, autoAdd);
 
   useEffect(() => {
     if (screen === null) {
       err(dispatch, "Unsupported request", `Expected a PCD ADD request`);
     }
   }, [dispatch, screen]);
-
-  useLoginIfNoSelf(pendingRequestKeys.add, request);
-
-  if (!self) {
-    return null;
-  }
 
   if (!screen) {
     // Need AppContainer to display error
@@ -48,12 +41,14 @@ export function AddScreen(): JSX.Element | null {
   return screen;
 }
 
-function getScreen(request: PCDRequest): JSX.Element | null {
+function getScreen(request: PCDRequest, autoAdd: boolean): JSX.Element | null {
   switch (request.type) {
     case PCDRequestType.ProveAndAdd:
       return <ProveAndAddScreen request={request as PCDProveAndAddRequest} />;
     case PCDRequestType.Add:
-      return <JustAddScreen request={request as PCDAddRequest} />;
+      return (
+        <JustAddScreen autoAdd={autoAdd} request={request as PCDAddRequest} />
+      );
     default:
       return null;
   }

--- a/apps/passport-client/components/screens/AddScreen/ProveAndAddScreen.tsx
+++ b/apps/passport-client/components/screens/AddScreen/ProveAndAddScreen.tsx
@@ -2,8 +2,13 @@ import { PCDProveAndAddRequest } from "@pcd/passport-interface";
 import { PCD, SerializedPCD } from "@pcd/pcd-types";
 import { ReactNode, useCallback, useState } from "react";
 import styled from "styled-components";
-import { useDispatch, useIsSyncSettled } from "../../../src/appHooks";
+import {
+  useDispatch,
+  useIsSyncSettled,
+  useLoginIfNoSelf
+} from "../../../src/appHooks";
 import { safeRedirect } from "../../../src/passportRequest";
+import { pendingRequestKeys } from "../../../src/sessionStorage";
 import { H2, Spacer } from "../../core";
 import { MaybeModal } from "../../modals/Modal";
 import { AddedPCD } from "../../shared/AddedPCD";
@@ -26,6 +31,8 @@ export function ProveAndAddScreen({
   const [serializedPCD, setSerializedPCD] = useState<
     SerializedPCD | undefined
   >();
+
+  useLoginIfNoSelf(pendingRequestKeys.add, request);
 
   const onProve = useCallback(
     async (_: PCD | undefined, serializedPCD: SerializedPCD | undefined) => {

--- a/apps/passport-client/components/screens/LoginScreens/LoginInterstitialScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/LoginInterstitialScreen.tsx
@@ -32,7 +32,9 @@ export function LoginInterstitialScreen(): JSX.Element {
             console.log("Redirecting to add screen");
             const encReq = encodeURIComponent(pendingRequest.value);
             clearAllPendingRequests();
-            navigate("/add?request=" + encReq, { replace: true });
+            navigate("/add?request=" + encReq + "&autoAdd=true", {
+              replace: true
+            });
             break;
           }
           case "halo": {

--- a/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
+++ b/apps/passport-client/components/screens/LoginScreens/LoginScreen.tsx
@@ -151,8 +151,8 @@ export function LoginScreen(): JSX.Element {
           <TextCenter>
             <H2>ZUPASS</H2>
             <Spacer h={24} />
-            To complete this request, you need to either log into your existing
-            Zupass account, or create a new one.
+            To complete this request, please login or register with your email
+            below.
           </TextCenter>
         </>
       ) : (

--- a/apps/passport-client/components/shared/AppHeader.tsx
+++ b/apps/passport-client/components/shared/AppHeader.tsx
@@ -3,7 +3,7 @@ import React, { useCallback } from "react";
 import { IoMdSettings } from "react-icons/io";
 import { MdInfo, MdOutlineQrCodeScanner, MdRssFeed } from "react-icons/md";
 import styled from "styled-components";
-import { useDispatch, useSubscriptions } from "../../src/appHooks";
+import { useDispatch, useSelf, useSubscriptions } from "../../src/appHooks";
 import { AppState } from "../../src/state";
 
 export const AppHeader = React.memo(AppHeaderImpl);
@@ -18,6 +18,7 @@ function AppHeaderImpl({
   isProveOrAddScreen?: boolean;
 }): JSX.Element {
   const dispatch = useDispatch();
+  const self = useSelf();
 
   const setModal = useCallback(
     (modal: AppState["modal"]) =>
@@ -43,6 +44,10 @@ function AppHeaderImpl({
     []
   );
   const subscriptions = useSubscriptions();
+
+  if (!self) {
+    return <AppHeaderWrap>{children}</AppHeaderWrap>;
+  }
 
   return (
     <AppHeaderWrap>


### PR DESCRIPTION
When logged out, rather than forcing user to register / log in _before_ seeing any kind of add screen, we do it after they see the initial "add pcd" screen.