### PR TITLE
fix `DeleteFolder` action being sporadically issued by Podbox

### DIFF
--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -834,7 +834,9 @@ export class LemonadePipeline implements BasePipeline {
 
       const ticketActions: PCDAction[] = [];
 
-      if (this.loaded) {
+      // If the Atom DB is not empty, i.e. if we have loaded atoms for this pipeline
+      // at least once since the server started, delete the folder.
+      if ((await this.db.load(this.id)).length > 0) {
         ticketActions.push({
           type: PCDActionType.DeleteFolder,
           folder: this.definition.options.feedOptions.feedFolder,

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -991,7 +991,9 @@ export class PretixPipeline implements BasePipeline {
 
       const actions: PCDAction[] = [];
 
-      if (this.loaded) {
+      // If the Atom DB is not empty, i.e. if we have loaded atoms for this pipeline
+      // at least once since the server started, delete the folder.
+      if ((await this.db.load(this.id)).length > 0) {
         actions.push({
           type: PCDActionType.DeleteFolder,
           folder: this.definition.options.feedOptions.feedFolder,


### PR DESCRIPTION
fixes https://linear.app/0xparc-pcd/issue/0XP-1061/pretixpipelines-deletefolder-action-is-sporadic

determine whether to delete a pipeline's folder based on whether or not it has loaded at least once since server start, rather than based on whether the current instance of the class corresponding to the pipeline has loaded