### PR TITLE
Ignore .tsbuildinfo files at the package level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,9 +40,6 @@ apps/passport-server/local-db-data
 apps/passport-server/local-db-log
 logfile
 
-# build
-*.tsbuildinfo
-
 # vim
 *.swp
 

--- a/apps/anon-message-client/.gitignore
+++ b/apps/anon-message-client/.gitignore
@@ -39,3 +39,6 @@ jspm_packages
 
 # env
 .env
+
+# build
+*.tsbuildinfo

--- a/apps/consumer-server/.gitignore
+++ b/apps/consumer-server/.gitignore
@@ -1,1 +1,2 @@
 .env
+*.tsbuildinfo

--- a/apps/passport-server/.gitignore
+++ b/apps/passport-server/.gitignore
@@ -5,3 +5,4 @@ envs
 db
 *.ignore
 dev-build
+*.tsbuildinfo

--- a/apps/zupoll-server/.gitignore
+++ b/apps/zupoll-server/.gitignore
@@ -2,3 +2,4 @@
 .prod.env
 .staging.env
 *.env
+*.tsbuildinfo

--- a/examples/pod-gpc-example/.gitignore
+++ b/examples/pod-gpc-example/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/client-shared/.gitignore
+++ b/packages/lib/client-shared/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/emitter/.gitignore
+++ b/packages/lib/emitter/.gitignore
@@ -3,3 +3,4 @@
 *.js
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/gpc/.gitignore
+++ b/packages/lib/gpc/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/gpcircuits/.gitignore
+++ b/packages/lib/gpcircuits/.gitignore
@@ -2,6 +2,7 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo
 ptau
 circuits/test
 artifacts/test

--- a/packages/lib/passport-crypto/.gitignore
+++ b/packages/lib/passport-crypto/.gitignore
@@ -3,3 +3,4 @@
 *.js
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/passport-interface/.gitignore
+++ b/packages/lib/passport-interface/.gitignore
@@ -3,3 +3,4 @@
 *.js
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/passport-ui/.gitignore
+++ b/packages/lib/passport-ui/.gitignore
@@ -3,3 +3,4 @@
 *.js
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/pcd-collection/.gitignore
+++ b/packages/lib/pcd-collection/.gitignore
@@ -3,3 +3,4 @@
 *.js
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/pcd-types/.gitignore
+++ b/packages/lib/pcd-types/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/pod/.gitignore
+++ b/packages/lib/pod/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/podbox-shared/.gitignore
+++ b/packages/lib/podbox-shared/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/server-shared/.gitignore
+++ b/packages/lib/server-shared/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/util/.gitignore
+++ b/packages/lib/util/.gitignore
@@ -1,3 +1,4 @@
 *.js
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/zuauth/.gitignore
+++ b/packages/lib/zuauth/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/lib/zupoll-shared/.gitignore
+++ b/packages/lib/zupoll-shared/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/eddsa-frog-pcd/.gitignore
+++ b/packages/pcd/eddsa-frog-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/eddsa-pcd/.gitignore
+++ b/packages/pcd/eddsa-pcd/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/eddsa-ticket-pcd/.gitignore
+++ b/packages/pcd/eddsa-ticket-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/email-pcd/.gitignore
+++ b/packages/pcd/email-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/ethereum-group-pcd/.gitignore
+++ b/packages/pcd/ethereum-group-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/ethereum-ownership-pcd/.gitignore
+++ b/packages/pcd/ethereum-ownership-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/gpc-pcd/.gitignore
+++ b/packages/pcd/gpc-pcd/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/halo-nonce-pcd/.gitignore
+++ b/packages/pcd/halo-nonce-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/input-test-pcd/.gitignore
+++ b/packages/pcd/input-test-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.js
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/message-pcd/.gitignore
+++ b/packages/pcd/message-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/obj-pcd/.gitignore
+++ b/packages/pcd/obj-pcd/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/pod-pcd/.gitignore
+++ b/packages/pcd/pod-pcd/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/pod-ticket-pcd/.gitignore
+++ b/packages/pcd/pod-ticket-pcd/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/rln-pcd/.gitignore
+++ b/packages/pcd/rln-pcd/.gitignore
@@ -2,3 +2,4 @@
 *.d.ts
 *.ts.map
 dist
+*.tsbuildinfo

--- a/packages/pcd/rsa-image-pcd/.gitignore
+++ b/packages/pcd/rsa-image-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/rsa-pcd/.gitignore
+++ b/packages/pcd/rsa-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/rsa-ticket-pcd/.gitignore
+++ b/packages/pcd/rsa-ticket-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/semaphore-group-pcd/.gitignore
+++ b/packages/pcd/semaphore-group-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/semaphore-identity-pcd/.gitignore
+++ b/packages/pcd/semaphore-identity-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/semaphore-signature-pcd/.gitignore
+++ b/packages/pcd/semaphore-signature-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/pcd/webauthn-pcd/.gitignore
+++ b/packages/pcd/webauthn-pcd/.gitignore
@@ -1,4 +1,5 @@
 *.js
 *.ts.map
 dist
+*.tsbuildinfo
 !.eslintrc.js

--- a/packages/pcd/zk-eddsa-event-ticket-pcd/.gitignore
+++ b/packages/pcd/zk-eddsa-event-ticket-pcd/.gitignore
@@ -1,4 +1,5 @@
 *.js
 *.ts.map
 dist
+*.tsbuildinfo
 !.eslintrc.js

--- a/packages/pcd/zk-eddsa-frog-pcd/.gitignore
+++ b/packages/pcd/zk-eddsa-frog-pcd/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/tools/perftest/.gitignore
+++ b/packages/tools/perftest/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/eddsa-frog-pcd-ui/.gitignore
+++ b/packages/ui/eddsa-frog-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/eddsa-pcd-ui/.gitignore
+++ b/packages/ui/eddsa-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/eddsa-ticket-pcd-ui/.gitignore
+++ b/packages/ui/eddsa-ticket-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/email-pcd-ui/.gitignore
+++ b/packages/ui/email-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/ethereum-group-pcd-ui/.gitignore
+++ b/packages/ui/ethereum-group-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/ethereum-ownership-pcd-ui/.gitignore
+++ b/packages/ui/ethereum-ownership-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/gpc-pcd-ui/.gitignore
+++ b/packages/ui/gpc-pcd-ui/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/halo-nonce-pcd-ui/.gitignore
+++ b/packages/ui/halo-nonce-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/message-pcd-ui/.gitignore
+++ b/packages/ui/message-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/pod-pcd-ui/.gitignore
+++ b/packages/ui/pod-pcd-ui/.gitignore
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/pod-ticket-pcd-ui/.gitignore
+++ b/packages/ui/pod-ticket-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/rsa-image-pcd-ui/.gitignore
+++ b/packages/ui/rsa-image-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/rsa-pcd-ui/.gitignore
+++ b/packages/ui/rsa-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/rsa-ticket-pcd-ui/.gitignore
+++ b/packages/ui/rsa-ticket-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/semaphore-group-pcd-ui/.gitignore
+++ b/packages/ui/semaphore-group-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/semaphore-identity-pcd-ui/.gitignore
+++ b/packages/ui/semaphore-identity-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/semaphore-signature-pcd-ui/.gitignore
+++ b/packages/ui/semaphore-signature-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/webauthn-pcd-ui/.gitignore
+++ b/packages/ui/webauthn-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/zk-eddsa-event-ticket-pcd-ui/.gitignore
+++ b/packages/ui/zk-eddsa-event-ticket-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/packages/ui/zk-eddsa-frog-pcd-ui/.gitignore
+++ b/packages/ui/zk-eddsa-frog-pcd-ui/.gitignore
@@ -3,3 +3,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/templates/package/templates/.gitignore.hbs
+++ b/templates/package/templates/.gitignore.hbs
@@ -2,3 +2,4 @@
 *.ts.map
 !.eslintrc.js
 dist
+*.tsbuildinfo

--- a/test-packaging/vite/.gitignore
+++ b/test-packaging/vite/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
`.tsbuildinfo` files are created by TypeScript during compilation. They are incremental build artifacts which TypeScript uses to speed up compilation - in particular, TypeScript will skip building a package if the `.tsbuildinfo` file is newer than the source files.

Currently we avoid checking these files into the repo by referencing them in the `.gitignore` at the root of the project. But this causes a problem when switching branches, because the build outputs for each package are ignored using the _package-level_ `.gitignore` file.

Let's say I'm on a branch called `new-package`, and I have created a new package and built it. Then I switch to `main`. git will remove the files from my new package which have been checked into the repo (the source files, the package.json, and the .gitignore file, among others). But it will not remove any files that are not checked in. So, my package directly will remain, and it will contain some `.tsbuildinfo` files and a `dist` directory with JavaScript outputs. When I run `git status` I will see that there's an unstaged directory, and I will think "aha, I need to run `git clean -f -d` to get rid of this", which is correct.

`git clean` will remove all _un-ignored_ files in that directory. Since the `dist` directory, containing the build output, is no longer being ignored by the package-level `.gitignore` file, it will be removed. However, the `.tsbuildinfo` files are ignored by the root-level `.gitignore`, so they will remain.

After I return to my `new-package` branch, I will have the `.tsbuildinfo` files but not the build output from `dist`. If I try to run a build, `tsc` will think it can skip building the package, which is incorrect. I will get a build failure, and will have to go to the package directory, remove the `.tsbuildinfo` files, and then build the package again. Now it will work.

This is happening because the `.tsbuildinfo` files are being ignored at the package root rather than in the package-local .`gitignore` file, which means that the `.tsbuildinfo` files don't get deleted along with the `dist` directory when doing a `git clean` after switching branches. This PR fixes that by removing the `*.tsbuildinfo` reference from the root `.gitignore`, and adding it to each of the individual package-level `.gitignore` files.