### PR TITLE
Expose more exports on passport-interface

### DIFF
--- a/apps/consumer-client/CHANGELOG.md
+++ b/apps/consumer-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # consumer-client
 
+## 0.0.45
+
+### Patch Changes
+
+- Updated dependencies
+  - @pcd/passport-interface@0.11.7
+
 ## 0.0.44
 
 ### Patch Changes

--- a/apps/consumer-client/package.json
+++ b/apps/consumer-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consumer-client",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "license": "GPL-3.0-or-later",
   "private": true,
   "scripts": {
@@ -21,7 +21,7 @@
     "@pcd/ethereum-ownership-pcd": "0.11.4",
     "@pcd/gpc": "0.0.6",
     "@pcd/gpc-pcd": "0.0.6",
-    "@pcd/passport-interface": "0.11.6",
+    "@pcd/passport-interface": "0.11.7",
     "@pcd/pcd-types": "0.11.4",
     "@pcd/pod": "0.1.5",
     "@pcd/pod-pcd": "0.1.5",

--- a/apps/generic-issuance-client/CHANGELOG.md
+++ b/apps/generic-issuance-client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # generic-issuance-client
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @pcd/passport-interface@0.11.7
+  - @pcd/podbox-shared@0.0.4
+
 ## 0.0.8
 
 ### Patch Changes

--- a/apps/generic-issuance-client/package.json
+++ b/apps/generic-issuance-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generic-issuance-client",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "GPL-3.0-or-later",
   "private": true,
   "scripts": {
@@ -19,9 +19,9 @@
     "@emotion/styled": "^11.11.0",
     "@monaco-editor/react": "^4.6.0",
     "@pcd/pod": "0.1.5",
-    "@pcd/podbox-shared": "0.0.3",
+    "@pcd/podbox-shared": "0.0.4",
     "@pcd/client-shared": "0.0.5",
-    "@pcd/passport-interface": "0.11.6",
+    "@pcd/passport-interface": "0.11.7",
     "@pcd/util": "0.5.3",
     "@rollbar/react": "^0.11.2",
     "@stytch/react": "^15.0.0",

--- a/apps/passport-client/CHANGELOG.md
+++ b/apps/passport-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # passport-client
 
+## 0.0.35
+
+### Patch Changes
+
+- Updated dependencies
+  - @pcd/passport-interface@0.11.7
+
 ## 0.0.34
 
 ### Patch Changes

--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-client",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "license": "GPL-3.0-or-later",
   "private": true,
   "scripts": {
@@ -37,7 +37,7 @@
     "@pcd/message-pcd-ui": "0.1.4",
     "@pcd/obj-pcd": "0.0.5",
     "@pcd/passport-crypto": "0.11.4",
-    "@pcd/passport-interface": "0.11.6",
+    "@pcd/passport-interface": "0.11.7",
     "@pcd/passport-ui": "0.11.4",
     "@pcd/pcd-collection": "0.11.4",
     "@pcd/pcd-types": "0.11.4",

--- a/apps/passport-server/CHANGELOG.md
+++ b/apps/passport-server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # passport-server
 
+## 0.0.35
+
+### Patch Changes
+
+- Updated dependencies
+  - @pcd/passport-interface@0.11.7
+  - @pcd/podbox-shared@0.0.4
+
 ## 0.0.34
 
 ### Patch Changes

--- a/apps/passport-server/package.json
+++ b/apps/passport-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-server",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "license": "GPL-3.0-or-later",
   "private": true,
   "scripts": {
@@ -31,13 +31,13 @@
     "@pcd/message-pcd": "0.1.4",
     "@pcd/obj-pcd": "0.0.5",
     "@pcd/passport-crypto": "0.11.4",
-    "@pcd/passport-interface": "0.11.6",
+    "@pcd/passport-interface": "0.11.7",
     "@pcd/pcd-collection": "0.11.4",
     "@pcd/pcd-types": "0.11.4",
     "@pcd/pod": "0.1.5",
     "@pcd/pod-pcd": "0.1.5",
     "@pcd/pod-ticket-pcd": "0.1.5",
-    "@pcd/podbox-shared": "0.0.3",
+    "@pcd/podbox-shared": "0.0.4",
     "@pcd/rln-pcd": "0.10.4",
     "@pcd/rsa-image-pcd": "0.5.4",
     "@pcd/rsa-pcd": "0.6.4",

--- a/apps/zupoll-client/CHANGELOG.md
+++ b/apps/zupoll-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # zupoll-client
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @pcd/passport-interface@0.11.7
+
 ## 0.0.8
 
 ### Patch Changes

--- a/apps/zupoll-client/package.json
+++ b/apps/zupoll-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zupoll-client",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "GPL-3.0-or-later",
   "private": true,
   "scripts": {
@@ -18,7 +18,7 @@
     "@heroicons/react": "^2.1.3",
     "@hookform/resolvers": "^3.3.4",
     "@pcd/client-shared": "0.0.5",
-    "@pcd/passport-interface": "0.11.6",
+    "@pcd/passport-interface": "0.11.7",
     "@pcd/pcd-types": "0.11.4",
     "@pcd/semaphore-group-pcd": "0.11.4",
     "@pcd/semaphore-identity-pcd": "0.11.4",

--- a/packages/lib/passport-interface/CHANGELOG.md
+++ b/packages/lib/passport-interface/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pcd/passport-interface
 
+## 0.11.7
+
+### Patch Changes
+
+- Expose more exports from passport-interface
+
 ## 0.11.6
 
 ### Patch Changes

--- a/packages/lib/passport-interface/package.json
+++ b/packages/lib/passport-interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcd/passport-interface",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "license": "GPL-3.0-or-later",
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
@@ -10,6 +10,16 @@
       "types": "./dist/types/src/index.d.ts",
       "import": "./dist/esm/src/index.js",
       "require": "./dist/cjs/src/index.js"
+    },
+    "./Credential": {
+      "types": "./dist/types/src/Credential.d.ts",
+      "import": "./dist/esm/src/Credential.js",
+      "require": "./dist/cjs/src/Credential.js"
+    },
+    "./FeedHost": {
+      "types": "./dist/types/src/FeedHost.d.ts",
+      "import": "./dist/esm/src/FeedHost.js",
+      "require": "./dist/cjs/src/FeedHost.js"
     },
     "./PassportPopup/core": {
       "types": "./dist/types/src/PassportPopup/core.d.ts",
@@ -25,6 +35,11 @@
       "types": "./dist/types/src/PassportInterface.d.ts",
       "import": "./dist/esm/src/PassportInterface.js",
       "require": "./dist/cjs/src/PassportInterface.js"
+    },
+    "./RequestTypes": {
+      "types": "./dist/types/src/RequestTypes.d.ts",
+      "import": "./dist/esm/src/RequestTypes.js",
+      "require": "./dist/cjs/src/RequestTypes.js"
     }
   },
   "files": [

--- a/packages/lib/podbox-shared/CHANGELOG.md
+++ b/packages/lib/podbox-shared/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pcd/podbox-shared
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @pcd/passport-interface@0.11.7
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/lib/podbox-shared/package.json
+++ b/packages/lib/podbox-shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pcd/podbox-shared",
   "private": false,
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "GPL-3.0-or-later",
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
@@ -28,7 +28,7 @@
     "clean": "rm -rf dist node_modules *.tsbuildinfo"
   },
   "dependencies": {
-    "@pcd/passport-interface": "0.11.6",
+    "@pcd/passport-interface": "0.11.7",
     "@pcd/pod": "0.1.5",
     "@pcd/util": "0.5.3",
     "csv-parse": "^5.5.3",


### PR DESCRIPTION
When importing from `passport-interface` in a NextJS project, NextJS complains if React code is being imported in a server-side component. But, `passport-interface` also exports things which are useful in a server context. This adds some extra exports which are useful to server-side apps, and avoids accidentally importing React code.