### PR TITLE
Insert and delete PODs, with insertion demo in test-client

### DIFF
--- a/apps/passport-client/src/zapp/ZappServer.ts
+++ b/apps/passport-client/src/zapp/ZappServer.ts
@@ -3,7 +3,7 @@ import { GPCPCDArgs, GPCPCDPackage, GPCPCDTypeName } from "@pcd/gpc-pcd";
 import { PCDGetRequest, PCDRequestType } from "@pcd/passport-interface";
 import { SerializedPCD } from "@pcd/pcd-types";
 import { POD } from "@pcd/pod";
-import { PODPCD, PODPCDPackage, PODPCDTypeName } from "@pcd/pod-pcd";
+import { isPODPCD, PODPCD, PODPCDPackage, PODPCDTypeName } from "@pcd/pod-pcd";
 import { p } from "@pcd/podspec";
 import {
   ZupassAPI,
@@ -241,9 +241,7 @@ class PODServer extends BaseZappServer implements ZupassPOD {
     const allPCDs = this.getContext()
       .getState()
       .pcds.getAllPCDsInFolder(ZAPP_POD_SPECIAL_FOLDER_NAME);
-    const pods = allPCDs
-      .filter((pcd) => pcd.type === PODPCDTypeName)
-      .map((pcd) => (pcd as PODPCD).pod);
+    const pods = allPCDs.filter(isPODPCD).map((pcd) => pcd.pod);
 
     const result = q.query(pods);
 

--- a/apps/passport-client/src/zapp/ZappServer.ts
+++ b/apps/passport-client/src/zapp/ZappServer.ts
@@ -281,6 +281,9 @@ class PODServer extends BaseZappServer implements ZupassPOD {
       .getState()
       // Deletion is restricted to Zapp-created PODs
       .pcds.getAllPCDsInFolder(ZAPP_POD_SPECIAL_FOLDER_NAME);
+    // This will delete *all* PODs in the folder which have a matching
+    // signature. Since signatures are unique, this seems reasonable. There is
+    // probably no good reason to have multiple PODs with the same signature.
     const pcdIds = allPCDs
       .filter(
         (pcd) =>

--- a/apps/passport-client/src/zapp/ZappServer.ts
+++ b/apps/passport-client/src/zapp/ZappServer.ts
@@ -238,7 +238,9 @@ class PODServer extends BaseZappServer implements ZupassPOD {
       console.log(e);
       throw e;
     }
-    const allPCDs = this.getContext().getState().pcds.getAll();
+    const allPCDs = this.getContext()
+      .getState()
+      .pcds.getAllPCDsInFolder(ZAPP_POD_SPECIAL_FOLDER_NAME);
     const pods = allPCDs
       .filter((pcd) => pcd.type === PODPCDTypeName)
       .map((pcd) => (pcd as PODPCD).pod);

--- a/examples/test-client/src/apis/PODSection.tsx
+++ b/examples/test-client/src/apis/PODSection.tsx
@@ -1,9 +1,14 @@
-import { POD, POD_INT_MAX } from "@pcd/pod";
+import { POD, POD_INT_MAX, POD_INT_MIN, PODEntries, PODValue } from "@pcd/pod";
 import { p } from "@pcd/podspec";
+import { ZupassAPIWrapper } from "@pcd/zupass-client";
 import JSONBig from "json-bigint";
-import { ReactNode, useState } from "react";
+import { ReactNode, useReducer, useState } from "react";
+import { Button } from "../components/Button";
 import { TryIt } from "../components/TryIt";
 import { useEmbeddedZupass } from "../hooks/useEmbeddedZupass";
+
+const MAGIC_PRIVATE_KEY =
+  "00112233445566778899AABBCCDDEEFF00112233445566778899aabbccddeeff";
 
 export function PODSection(): ReactNode {
   const { z, connected } = useEmbeddedZupass();
@@ -55,7 +60,235 @@ const pods = await z.pod.query(q);
             </pre>
           )}
         </div>
+        <InsertPOD z={z} />
       </div>
+    </div>
+  );
+}
+
+type Action =
+  | {
+      type: "SET_KEY";
+      key: string;
+      newKey: string;
+    }
+  | {
+      type: "SET_VALUE";
+      key: string;
+      value: PODValue["value"];
+    }
+  | {
+      type: "SET_TYPE";
+      key: string;
+      podValueType: PODValue["type"];
+    }
+  | {
+      type: "ADD_ENTRY";
+      value: PODValue;
+    };
+
+const stringish = ["string", "eddsa_pubkey"];
+const bigintish = ["int", "cryptographic"];
+
+const insertPODReducer = function (
+  state: PODEntries,
+  action: Action
+): PODEntries {
+  switch (action.type) {
+    case "ADD_ENTRY":
+      let key = "entry";
+      let n = 1;
+      while (key in state) {
+        key = `entry${n}`;
+        n++;
+      }
+      state[key] = action.value;
+      break;
+    case "SET_KEY":
+      state[action.newKey] = state[action.key];
+      delete state[action.key];
+      break;
+    case "SET_TYPE":
+      const existingType = state[action.key].type;
+
+      if (
+        stringish.includes(existingType) &&
+        bigintish.includes(action.podValueType)
+      ) {
+        state[action.key] = {
+          type: action.podValueType as "int" | "cryptographic",
+          value: BigInt(0)
+        };
+      } else if (
+        bigintish.includes(existingType) &&
+        stringish.includes(action.podValueType)
+      ) {
+        state[action.key] = {
+          type: action.podValueType as "string" | "eddsa_pubkey",
+          value: state[action.key].value.toString()
+        };
+      } else {
+        state[action.key].type = action.podValueType;
+      }
+      break;
+    case "SET_VALUE":
+      if (bigintish.includes(state[action.key].type)) {
+        const value = BigInt(action.value);
+        if (value >= POD_INT_MIN && value <= POD_INT_MAX) {
+          state[action.key].value = value;
+        }
+      } else {
+        state[action.key].value = action.value;
+      }
+      break;
+  }
+  return { ...state };
+};
+
+enum PODCreationState {
+  None,
+  Success,
+  Failure
+}
+
+function InsertPOD({ z }: { z: ZupassAPIWrapper }): ReactNode {
+  const [creationState, setCreationState] = useState<PODCreationState>(
+    PODCreationState.None
+  );
+  const [entries, dispatch] = useReducer(insertPODReducer, {
+    test: { type: "string", value: "Testing" }
+  } satisfies PODEntries);
+  return (
+    <div>
+      <p>
+        To insert a POD, first we have to create one. Select the entries for the
+        POD below:
+      </p>
+      <div className="flex flex-col gap-2 mb-4">
+        {Object.entries(entries).map(([name, value], index) => (
+          <InsertPODEntry
+            key={name}
+            showLabels={index === 0}
+            name={name}
+            value={value.value}
+            type={value.type}
+            dispatch={dispatch}
+          />
+        ))}
+        <Button
+          onClick={() =>
+            dispatch({
+              type: "ADD_ENTRY",
+              value: { type: "string", value: "" }
+            })
+          }
+        >
+          Add Another Entry
+        </Button>
+      </div>
+      <p>
+        Then we can insert the POD:
+        <code className="block text-xs font-base rounded-md p-2 whitespace-pre">
+          {`const pod = POD.sign({
+${Object.entries(entries)
+  .map(([key, value]) => {
+    return `  ${key}: { type: "${value.type}", value: ${
+      bigintish.includes(value.type)
+        ? `${value.value.toString()}n`
+        : `"${value.value.toString()}"`
+    } }`;
+  })
+  .join(",\n")}
+}, privateKey);
+
+await z.pod.insert(pod);`}
+        </code>
+      </p>
+      <TryIt
+        onClick={async () => {
+          try {
+            const pod = POD.sign(entries, MAGIC_PRIVATE_KEY);
+            await z.pod.insert(pod);
+            setCreationState(PODCreationState.Success);
+          } catch (e) {
+            setCreationState(PODCreationState.Failure);
+          }
+        }}
+        label="Insert POD"
+      />
+      {creationState !== PODCreationState.None && (
+        <div className="my-2">
+          {creationState === PODCreationState.Success && (
+            <div>POD inserted successfully!</div>
+          )}
+          {creationState === PODCreationState.Failure && (
+            <div>An error occurred while inserting your POD.</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InsertPODEntry({
+  name,
+  value,
+  type,
+  dispatch,
+  showLabels
+}: {
+  name: string;
+  value: PODValue["value"];
+  type: PODValue["type"];
+  showLabels: boolean;
+  dispatch: (action: Action) => void;
+}): ReactNode {
+  return (
+    <div className="flex flex-row gap-2">
+      <label className="block">
+        {showLabels && <span className="text-gray-700">Name</span>}
+        <input
+          type="text"
+          value={name}
+          className="mt-1 block w-full rounded-md bg-gray-100 border-transparent focus:border-gray-500 focus:bg-white focus:ring-0"
+          placeholder=""
+          onChange={(ev) =>
+            dispatch({ type: "SET_KEY", key: name, newKey: ev.target.value })
+          }
+        />
+      </label>
+      <label className="block">
+        {showLabels && <span className="text-gray-700">Type</span>}
+        <select
+          value={type}
+          className="block w-full mt-1 rounded-md bg-gray-100 border-transparent focus:border-gray-500 focus:bg-white focus:ring-0"
+          onChange={(ev) =>
+            dispatch({
+              type: "SET_TYPE",
+              key: name,
+              podValueType: ev.target.value as PODValue["type"]
+            })
+          }
+        >
+          <option value="string">String</option>
+          <option value="int">Int</option>
+          <option value="cryptographic">Cryptographic</option>
+        </select>
+      </label>
+      <label className="block">
+        {showLabels && <span className="text-gray-700">Value</span>}
+        <input
+          value={value.toString()}
+          type={typeof value === "string" ? "text" : "number"}
+          className="mt-1 block w-full rounded-md bg-gray-100 border-transparent focus:border-gray-500 focus:bg-white focus:ring-0"
+          placeholder=""
+          onChange={(ev) =>
+            dispatch({ type: "SET_VALUE", key: name, value: ev.target.value })
+          }
+          max={POD_INT_MAX.toString()}
+          min={POD_INT_MIN.toString()}
+        />
+      </label>
     </div>
   );
 }

--- a/examples/test-client/src/apis/PODSection.tsx
+++ b/examples/test-client/src/apis/PODSection.tsx
@@ -340,8 +340,9 @@ function DeletePOD({ z }: { z: ZupassAPIWrapper }): ReactNode {
         onClick={async () => {
           try {
             await z.pod.delete(signature);
+            setDeletionState(PODDeletionState.Success);
           } catch (e) {
-            console.log(e);
+            setDeletionState(PODDeletionState.Failure);
           }
         }}
         label="Delete POD"

--- a/examples/test-client/src/components/Navbar.tsx
+++ b/examples/test-client/src/components/Navbar.tsx
@@ -20,7 +20,7 @@ export function Navbar({ connecting }: { connecting: boolean }): ReactNode {
   return (
     <div className="navbar bg-base-100 w-full">
       <div className="flex-none">
-        <a className="btn btn-ghost text-lg md:text-xl">Parcnet API Client</a>
+        <a className="btn btn-ghost text-lg md:text-xl">PARCNET API Client</a>
       </div>
       <div className="flex-1"></div>
       <div className="flex-none flex items-center">

--- a/examples/test-client/src/components/Navbar.tsx
+++ b/examples/test-client/src/components/Navbar.tsx
@@ -20,7 +20,7 @@ export function Navbar({ connecting }: { connecting: boolean }): ReactNode {
   return (
     <div className="navbar bg-base-100 w-full">
       <div className="flex-none">
-        <a className="btn btn-ghost text-lg md:text-xl">Zupass API Client</a>
+        <a className="btn btn-ghost text-lg md:text-xl">Parcnet API Client</a>
       </div>
       <div className="flex-1"></div>
       <div className="flex-none flex items-center">
@@ -43,7 +43,7 @@ export function Navbar({ connecting }: { connecting: boolean }): ReactNode {
             {" "}
             <HiLightningBolt
               title={
-                connecting ? "Connecting to Zupass..." : "Connected to Zupass"
+                connecting ? "Connecting to Parcnet..." : "Connected to Parcnet"
               }
               className={cn(
                 connecting ? "animate-pulse text-base-500" : "text-green-500"

--- a/examples/test-client/src/main.tsx
+++ b/examples/test-client/src/main.tsx
@@ -26,7 +26,8 @@ export default function Main(): ReactNode {
     <>
       <Navbar connecting={!connected} />
       <div className="container mx-auto my-4 p-4">
-        <p>You can use this page to test the embedded Zupass API.</p>
+        <p>Welcome to Parcnet!</p>
+        <p>You can use this page to test the Parcnet API.</p>
         <div className="flex flex-col gap-4 my-4">
           <FileSystem />
           <PODSection />

--- a/examples/test-client/src/main.tsx
+++ b/examples/test-client/src/main.tsx
@@ -26,8 +26,8 @@ export default function Main(): ReactNode {
     <>
       <Navbar connecting={!connected} />
       <div className="container mx-auto my-4 p-4">
-        <p>Welcome to Parcnet!</p>
-        <p>You can use this page to test the Parcnet API.</p>
+        <p>Welcome to PARCNET!</p>
+        <p>You can use this page to test the PARCNET API.</p>
         <div className="flex flex-col gap-4 my-4">
           <FileSystem />
           <PODSection />

--- a/packages/lib/zupass-client/src/api_internal.ts
+++ b/packages/lib/zupass-client/src/api_internal.ts
@@ -40,6 +40,8 @@ export interface ZupassIdentity {
 export interface ZupassPOD {
   // Returns array of serialized PODs
   query: (query: PODQuery) => Promise<string[]>;
+  insert: (serializedPod: string) => Promise<void>;
+  delete: (signature: string) => Promise<void>;
 }
 
 export interface ZupassAPI {

--- a/packages/lib/zupass-client/src/api_wrapper.ts
+++ b/packages/lib/zupass-client/src/api_wrapper.ts
@@ -18,6 +18,15 @@ class ZupassAPIPODWrapper {
     const pods = await this.#api.pod.query(serialized);
     return pods.map((pod) => POD.deserialize(pod));
   }
+
+  async insert(pod: POD): Promise<void> {
+    const serialized = pod.serialize();
+    return this.#api.pod.insert(serialized);
+  }
+
+  async delete(signature: string): Promise<void> {
+    return this.#api.pod.delete(signature);
+  }
 }
 
 /**

--- a/packages/lib/zupass-client/src/schema.ts
+++ b/packages/lib/zupass-client/src/schema.ts
@@ -156,6 +156,8 @@ export const ZupassAPISchema = z.object({
     query: z
       .function()
       .args(PODQuerySchema)
-      .returns(z.promise(z.array(z.string())))
+      .returns(z.promise(z.array(z.string()))),
+    insert: z.function().args(z.string()).returns(z.promise(z.void())),
+    delete: z.function().args(z.string()).returns(z.promise(z.void()))
   })
 }) satisfies z.ZodSchema<ZupassAPI>;


### PR DESCRIPTION
Stacks on top of #1861, which should probably be reviewed first.

This demonstrates adding and deleting PODs. Since PODs are immutable, there isn't really an "update" operation. To replace a POD with a new version, simply delete the old one and insert a new one.

Most of the code here is the `test-client` UI, which allows you to create a brand-new POD interactively. The actual API implementation is very simple.