### PR TITLE
Fix GPC owner module compilation

### DIFF
--- a/packages/lib/gpc/src/gpcCompile.ts
+++ b/packages/lib/gpc/src/gpcCompile.ts
@@ -751,11 +751,11 @@ function compileProofEntryConstraints(
     entryEqualToOtherEntryByIndex: CircuitSignal[];
   };
   entryConstraintMetadata: {
-    firstOwnerIndex: number;
+    firstOwnerIndex?: number;
   };
 } {
   // Deal with equality comparision and POD ownership, which share circuitry.
-  let firstOwnerIndex = 0;
+  let firstOwnerIndex = undefined;
   const entryEqualToOtherEntryByIndex: bigint[] = [];
   const virtualEntryEqualToOtherEntryByIndex: bigint[] = [];
 
@@ -764,7 +764,7 @@ function compileProofEntryConstraints(
     // only one owner), or to another entry specified by config, or to itself
     // in order to make the constraint a nop.
     if (entryInfo.entryConfig.isOwnerID) {
-      if (firstOwnerIndex === 0) {
+      if (firstOwnerIndex === undefined) {
         firstOwnerIndex = entryInfo.entryIndex;
       } else if (entryInfo.entryConfig.equalsEntry !== undefined) {
         throw new Error(
@@ -814,13 +814,14 @@ function compileProofEntryConstraints(
         virtualEntryEqualToOtherEntryByIndex
       )
     },
-    entryConstraintMetadata: { firstOwnerIndex }
+    entryConstraintMetadata:
+      firstOwnerIndex !== undefined ? { firstOwnerIndex } : {}
   };
 }
 
-function compileProofOwner(
+export function compileProofOwner(
   ownerInput: GPCProofOwnerInputs | undefined,
-  firstOwnerIndex: number
+  firstOwnerIndex: number | undefined
 ): {
   ownerEntryIndex: CircuitSignal;
   ownerSemaphoreV3IdentityNullifier: CircuitSignal;
@@ -831,7 +832,7 @@ function compileProofOwner(
   // Owner module is enabled if any entry config declared it was an owner
   // commitment.  It can't be enabled purely for purpose of nullifier hash,
   // since an unconstrained owner could be set to any random numbers.
-  const hasOwner = firstOwnerIndex !== 0;
+  const hasOwner = firstOwnerIndex !== undefined;
   if (hasOwner && ownerInput?.semaphoreV3 === undefined) {
     throw new Error("Missing owner identity.");
   }
@@ -1116,9 +1117,9 @@ function compileVerifyVirtualEntry(
   };
 }
 
-function compileVerifyOwner(
+export function compileVerifyOwner(
   ownerInput: GPCRevealedOwnerClaims | undefined,
-  firstOwnerIndex: number
+  firstOwnerIndex: number | undefined
 ): {
   circuitOwnerInputs: {
     ownerEntryIndex: CircuitSignal;
@@ -1132,7 +1133,7 @@ function compileVerifyOwner(
   // Owner module is enabled if any entry config declared it was an owner
   // commitment.  It can't be enabled purely for purpose of nullifier hash,
   // since an unconstrained owner could be set to any random numbers.
-  const hasOwner = firstOwnerIndex !== 0;
+  const hasOwner = firstOwnerIndex !== undefined;
 
   return {
     circuitOwnerInputs: {

--- a/packages/lib/gpc/test/gpcCompile.spec.ts
+++ b/packages/lib/gpc/test/gpcCompile.spec.ts
@@ -1,0 +1,108 @@
+import { CircuitSignal } from "@pcd/gpcircuits";
+import { PODValue } from "@pcd/pod";
+import { BABY_JUB_NEGATIVE_ONE } from "@pcd/util";
+import { expect } from "chai";
+import "mocha";
+import { poseidon2 } from "poseidon-lite/poseidon2";
+import { compileProofOwner, compileVerifyOwner } from "../src/gpcCompile";
+import { makeWatermarkSignal } from "../src/gpcUtil";
+import { ownerIdentity } from "./common";
+
+describe("Owner module compilation for proving should work", () => {
+  it("should work as expected for a proof with no owner input", () => {
+    const circuitOwnerInputs = compileProofOwner(undefined, undefined);
+    expect(circuitOwnerInputs).to.deep.eq({
+      ownerEntryIndex: BABY_JUB_NEGATIVE_ONE,
+      ownerSemaphoreV3IdentityNullifier: BABY_JUB_NEGATIVE_ONE,
+      ownerSemaphoreV3IdentityTrapdoor: BABY_JUB_NEGATIVE_ONE,
+      ownerExternalNullifier: BABY_JUB_NEGATIVE_ONE,
+      ownerIsNullfierHashRevealed: 0n
+    });
+  });
+  it("should work as expected for a proof with an owner entry and the necessary input", () => {
+    for (const firstOwnerIndex of [0, 3, 10]) {
+      for (const externalNullifier of [
+        undefined,
+        { type: "string", value: "I am a nullifier." },
+        { type: "int", value: 5n },
+        { type: "cryptographic", value: 127n }
+      ] as (PODValue | undefined)[]) {
+        const circuitOwnerInputs = compileProofOwner(
+          {
+            semaphoreV3: ownerIdentity,
+            ...(externalNullifier ? { externalNullifier } : {})
+          },
+          firstOwnerIndex
+        );
+        expect(circuitOwnerInputs).to.deep.eq({
+          ownerEntryIndex: BigInt(firstOwnerIndex),
+          ownerSemaphoreV3IdentityNullifier: ownerIdentity.nullifier,
+          ownerSemaphoreV3IdentityTrapdoor: ownerIdentity.trapdoor,
+          ownerExternalNullifier: makeWatermarkSignal(externalNullifier),
+          ownerIsNullfierHashRevealed: BigInt(externalNullifier !== undefined)
+        });
+      }
+    }
+  });
+  it("should throw for a proof with an owner entry without the necessary input", () => {
+    const delayedCircuitOwnerInputs = (): {
+      ownerEntryIndex: CircuitSignal;
+      ownerSemaphoreV3IdentityNullifier: CircuitSignal;
+      ownerSemaphoreV3IdentityTrapdoor: CircuitSignal;
+      ownerExternalNullifier: CircuitSignal;
+      ownerIsNullfierHashRevealed: CircuitSignal;
+    } => compileProofOwner(undefined, 3);
+    expect(delayedCircuitOwnerInputs).to.throw;
+  });
+});
+describe("Owner module compilation for verification should work", () => {
+  it("should work as expected for a proof with no owner input", () => {
+    const { circuitOwnerInputs, circuitOwnerOutputs } = compileVerifyOwner(
+      undefined,
+      undefined
+    );
+    expect(circuitOwnerInputs).to.deep.eq({
+      ownerEntryIndex: BABY_JUB_NEGATIVE_ONE,
+      ownerExternalNullifier: BABY_JUB_NEGATIVE_ONE,
+      ownerIsNullfierHashRevealed: 0n
+    });
+    expect(circuitOwnerOutputs).to.deep.eq({
+      ownerRevealedNullifierHash: BABY_JUB_NEGATIVE_ONE
+    });
+  });
+  it("should work as expected for a proof with an owner entry and the necessary input", () => {
+    for (const firstOwnerIndex of [0, 3, 10]) {
+      for (const externalNullifier of [
+        undefined,
+        { type: "string", value: "I am a nullifier." },
+        { type: "int", value: 5n },
+        { type: "cryptographic", value: 127n }
+      ] as (PODValue | undefined)[]) {
+        const nullifierHash = externalNullifier
+          ? poseidon2([
+              makeWatermarkSignal(externalNullifier),
+              ownerIdentity.nullifier
+            ])
+          : BABY_JUB_NEGATIVE_ONE;
+        const { circuitOwnerInputs, circuitOwnerOutputs } = compileVerifyOwner(
+          externalNullifier
+            ? {
+                externalNullifier,
+                nullifierHash
+              }
+            : undefined,
+          firstOwnerIndex
+        );
+        expect(circuitOwnerInputs).to.deep.eq({
+          ownerEntryIndex: BigInt(firstOwnerIndex),
+          ownerExternalNullifier: makeWatermarkSignal(externalNullifier),
+          ownerIsNullfierHashRevealed: BigInt(externalNullifier !== undefined)
+        });
+        expect(circuitOwnerOutputs).to.deep.eq({
+          ownerRevealedNullifierHash: nullifierHash
+        });
+      }
+    }
+  });
+});
+// TODO(POD-P3): More tests


### PR DESCRIPTION
This PR addresses a GPC compiler bug where the owner nullifier hash is not properly revealed when both an owner ID entry and external nullifier are specified in the case where the owner identity commitment entry has index 0. This may be checked by generating a proof for a simple configuration such as
```js
{
    pods: {
        pod0: {
            entries: {
                owner: { isRevealed: false, isOwnerID: true }
            }
        }
    }
}
```
with appropriate proof inputs and inspecting the revealed nullifier hash, e.g. by commenting out the `attack` entry of the `weapon` POD in `simpleProofConfig` in `examples/pod-gpc-example/src/gpcExample.ts` and checking `revealedClaims.nullifierHash`, whose value is then `BABY_JUB_NEGATIVE_ONE`. Appropriate tests have been added to the `gpc` package to check for this.
