### PR TITLE
Add missing dependency to gpc-pcd

### DIFF
--- a/packages/pcd/gpc-pcd/package.json
+++ b/packages/pcd/gpc-pcd/package.json
@@ -35,6 +35,7 @@
     "@pcd/util": "0.5.3",
     "@types/lodash": "^4.17.5",
     "json-bigint": "^1.0.0",
+    "lodash": "^4.17.21",
     "snarkjs": "^0.7.4",
     "uuid": "^9.0.0"
   },


### PR DESCRIPTION
`gpc-pcd` relies on `lodash` but does not include it in the package dependencies. This escapes notice because `@types/lodash` is included.