### PR TITLE
Replace call to "assert.equal" with manual check and exception

### DIFF
--- a/packages/lib/pod/src/podContent.ts
+++ b/packages/lib/pod/src/podContent.ts
@@ -91,13 +91,15 @@ export class PODContent {
       }
       if (!Object.is(hashes.length, this._map.size * 2)) {
         throw new Error(
-          `Assertion failed: ${hashes.length} == ${this._map.size * 2}`
+          `[ERR_ASSERTION] Expected inputs to be strictly equal:\n\n${
+            hashes.length
+          } !== ${this._map.size * 2}`
         );
       }
       merkleTree.insertMany(hashes);
       if (!Object.is(merkleTree.size, hashes.length)) {
         throw new Error(
-          `Assertion failed: ${merkleTree.size} == ${hashes.length}`
+          `[ERR_ASSERTION] Expected inputs to be strictly equal:\n\n${merkleTree.size} !== ${hashes.length}`
         );
       }
       this._merkleTree = merkleTree;

--- a/packages/lib/pod/src/podContent.ts
+++ b/packages/lib/pod/src/podContent.ts
@@ -1,5 +1,4 @@
 import { LeanIMT, LeanIMTMerkleProof } from "@zk-kit/lean-imt";
-import assert from "assert";
 import { podMerkleTreeHash, podNameHash, podValueHash } from "./podCrypto";
 import { PODEntries, PODName, PODValue } from "./podTypes";
 import {
@@ -90,9 +89,17 @@ export class PODContent {
         hashes.push(podNameHash(podName));
         hashes.push(podValueHash(podInfo.value));
       }
-      assert.equal(hashes.length, this._map.size * 2);
+      if (!Object.is(hashes.length, this._map.size * 2)) {
+        throw new Error(
+          `Assertion failed: ${hashes.length} == ${this._map.size * 2}`
+        );
+      }
       merkleTree.insertMany(hashes);
-      assert.equal(merkleTree.size, hashes.length);
+      if (!Object.is(merkleTree.size, hashes.length)) {
+        throw new Error(
+          `Assertion failed: ${merkleTree.size} == ${hashes.length}`
+        );
+      }
       this._merkleTree = merkleTree;
     }
     return this._merkleTree;


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-1142/remove-assert-dependency

The `assert` module is built in to NodeJS, but not in browser contexts. It can be polyfilled, but the polyfill is ~80KB and can't be reduced by tree-shaking. It also requires consumers to figure out why `assert` isn't working and how to install the relevant polyfill, which is annoying for them.

We're only using it for `assert.equal`, and only in one place (in non-test code). 

According to the docs, `assert.equal` is an alias for `[assert.strictEqual](https://nodejs.org/api/assert.html#assertstrictequalactual-expected-message)`, which tests equality according to the criteria used by `Object.is`. We can replace our `assert.equal` call with a check using `Object.is`, throwing our own exception if the check fails, and avoid the need for the polyfill. I've approximately replicated the error message that `assert.strictEqual` would show.

Janabel ran into this issue recently, and I just encountered it myself, so I presume that this is reasonably common.