### PR TITLE
Fix SnarkJS type dependencies

### DIFF
--- a/examples/pod-gpc-example/package.json
+++ b/examples/pod-gpc-example/package.json
@@ -43,6 +43,7 @@
     "@pcd/tsconfig": "0.11.4",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
+    "@types/snarkjs": "^0.7.5",
     "eslint": "^8.57.0",
     "mocha": "^10.2.0",
     "ts-mocha": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@types/circomlibjs": "0.1.6",
     "@types/node": "^20.11.28",
-    "@types/snarkjs": "0.7.5",
     "plop": "^4.0.1",
     "prettier": "^3.0.0",
     "prettier-plugin-organize-imports": "^3.2.2",

--- a/packages/lib/gpc/package.json
+++ b/packages/lib/gpc/package.json
@@ -42,6 +42,7 @@
     "@pcd/tsconfig": "0.11.4",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
+    "@types/snarkjs": "^0.7.5",
     "circomkit": "^0.0.24",
     "eslint": "^8.57.0",
     "fix-esm-import-path": "^1.10.0",

--- a/packages/lib/gpcircuits/package.json
+++ b/packages/lib/gpcircuits/package.json
@@ -47,6 +47,7 @@
     "@semaphore-protocol/identity": "^3.15.2",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
+    "@types/snarkjs": "^0.7.5",
     "@zk-kit/binary-merkle-root.circom": "1.0.0",
     "circomkit": "^0.0.24",
     "circomlib": "^2.0.5",

--- a/packages/pcd/gpc-pcd/package.json
+++ b/packages/pcd/gpc-pcd/package.json
@@ -47,6 +47,7 @@
     "@semaphore-protocol/identity": "^3.15.2",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
+    "@types/snarkjs": "^0.7.5",
     "eslint": "^8.57.0",
     "fix-esm-import-path": "^1.10.0",
     "mocha": "^10.2.0",

--- a/packages/pcd/zk-eddsa-event-ticket-pcd/package.json
+++ b/packages/pcd/zk-eddsa-event-ticket-pcd/package.json
@@ -53,6 +53,7 @@
     "@pcd/tsconfig": "0.11.4",
     "@types/json-bigint": "^1.0.1",
     "@types/mocha": "^10.0.1",
+    "@types/snarkjs": "^0.7.5",
     "@types/uuid": "^9.0.0",
     "chai": "^4.3.7",
     "eslint": "^8.57.0",

--- a/packages/pcd/zk-eddsa-frog-pcd/package.json
+++ b/packages/pcd/zk-eddsa-frog-pcd/package.json
@@ -52,6 +52,7 @@
     "@pcd/tsconfig": "0.11.4",
     "@types/json-bigint": "^1.0.1",
     "@types/mocha": "^10.0.1",
+    "@types/snarkjs": "^0.7.5",
     "@types/uuid": "^9.0.0",
     "chai": "^4.3.7",
     "eslint": "^8.57.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7043,10 +7043,10 @@
   resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.0.2.tgz#93eb2c243c351f3f17d5c580c7467ae5d686b65f"
   integrity sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg==
 
-"@types/snarkjs@0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@types/snarkjs/-/snarkjs-0.7.5.tgz#bf31c8a43246867df2f148fc5716d95a01d91f41"
-  integrity sha512-Dyeid5dOIxboZmG4RTch3XBX7myVVllE8908rPnp0McSYWUatAdn/MKcXxUx3KUdxe7qeLKBVgZvTqXsR5+d5A==
+"@types/snarkjs@^0.7.5":
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/@types/snarkjs/-/snarkjs-0.7.8.tgz#8fd47457247efd4a6dabcdd71ec1986532155480"
+  integrity sha512-x37Jsv1vx6I6RMJdfvYEmDUOLYgzYMecwlk13gniDOcN20xLVe9hy9DlQxWeCPirqpDY/jwugQSqCi2RxehU3g==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"


### PR DESCRIPTION
In several packages we depend on the `snarkjs` library. However, in each of these cases we do not include a devDependency on `@types/snarkjs`. This means that when our packages referencing SnarkJS types are used by third parties, they lack type information.

I noticed this because the `Groth16Proof` type is used in the return value for `gpcProve`, and was being interpreted by TypeScript as `any`.

This did not show up for us inside the monorepo, because the root package.json has a direct dependency on `@types/snarkjs`, and `yarn` does not ensure that each individual package which depends on those types has its own dependency entry. I've fixed this by removing the dependency from the root package, and adding individual dependencies to each package which also depends on `snarkjs`.