### PR TITLE
Ignore generated files in circuits/main

### DIFF
--- a/packages/lib/gpcircuits/.gitignore
+++ b/packages/lib/gpcircuits/.gitignore
@@ -4,5 +4,6 @@
 dist
 *.tsbuildinfo
 ptau
+circuits/main
 circuits/test
 artifacts/test


### PR DESCRIPTION
I keep seeing stray files in gpcircuits/circuits/main in my git status.  Those used to be checked in, but that seems to have been changed at some point.  I recall discussing with Rob the idea of deleting and gitignoring them instead, but it seems the current state of the repo is only half of that change.  This PR gitignores the whole directory since it's always generated by our circuit-gen scripts anyway.

@ax0 @robknight do you have an opinion on this?  Am I misinterpreting something?
