### PR TITLE
Remove all uses of top-level lodash import

### DIFF
--- a/apps/consumer-client/src/pages/examples/gpc-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/gpc-proof.tsx
@@ -32,7 +32,7 @@ import { PODPCDPackage } from "@pcd/pod-pcd";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import { emptyStrToUndefined } from "@pcd/util";
 import JSONBig from "json-bigint";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import { useEffect, useState } from "react";
 import { CodeLink, CollapsableCode, HomeLink } from "../../components/Core";
 import { ExampleContainer } from "../../components/ExamplePage";
@@ -413,14 +413,14 @@ async function verifyProof(
   } catch (configError) {
     return { valid: false, err: "Invalid proof config." };
   }
-  const sameConfig = _.isEqual(localBoundConfig, pcd.claim.config);
+  const sameConfig = isEqual(localBoundConfig, pcd.claim.config);
   if (!sameConfig) {
     return { valid: false, err: "Config does not match." };
   }
 
   // Check for equality of membership lists as sets, since the elements are
   // sorted by hash before being fed into circuits.
-  const sameMembershipLists = _.isEqual(
+  const sameMembershipLists = isEqual(
     membershipListsToSets(pcd.claim.revealed.membershipLists ?? {}),
     membershipLists === undefined
       ? {}

--- a/apps/generic-issuance-client/src/components/FancyEditor.tsx
+++ b/apps/generic-issuance-client/src/components/FancyEditor.tsx
@@ -1,6 +1,6 @@
 import { Box, Spinner } from "@chakra-ui/react";
 import { Editor, Monaco } from "@monaco-editor/react";
-import _ from "lodash";
+import merge from "lodash/merge";
 import { editor } from "monaco-editor";
 import React, {
   useCallback,
@@ -56,7 +56,7 @@ export const FancyEditor = React.forwardRef(
 
     const mergedEditorOptions =
       useMemo<editor.IStandaloneEditorConstructionOptions>(() => {
-        return _.merge(
+        return merge(
           {
             readOnly: readonly,
             minimap: {

--- a/apps/generic-issuance-client/src/pages/pipeline/DetailsSections/PipelineZuAuthConfig.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/DetailsSections/PipelineZuAuthConfig.tsx
@@ -1,7 +1,8 @@
 import { CheckIcon, CopyIcon } from "@chakra-ui/icons";
 import { Button, Spacer, useToast } from "@chakra-ui/react";
 import { PipelineZuAuthConfig } from "@pcd/passport-interface";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
+import uniqWith from "lodash/uniqWith";
 import { ReactNode, useCallback, useState } from "react";
 
 /**
@@ -58,7 +59,7 @@ export function PipelineZuAuthConfigSection({
    */
   if (!includeProductOptions) {
     json = JSON.stringify(
-      _.uniqWith(
+      uniqWith(
         pipelineZuAuthConfig.map(
           ({ eventId, eventName, publicKey, pcdType }) =>
             ({
@@ -68,7 +69,7 @@ export function PipelineZuAuthConfigSection({
               eventName
             }) satisfies PipelineZuAuthConfig
         ),
-        _.isEqual
+        isEqual
       ),
       null,
       2

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelineDetailSection.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelineDetailSection.tsx
@@ -16,7 +16,7 @@ import {
   PipelineDefinition,
   PipelineInfoResponseValue
 } from "@pcd/passport-interface";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import { ReactNode } from "react";
 import { PodLink } from "../../components/Core";
 import { pipelineDisplayNameStr } from "../../components/PipelineDisplayUtils";
@@ -270,7 +270,7 @@ function ExpandAllButton(): ReactNode {
   const ctx = useGIContext();
   const disabled =
     !ctx.pipelineDetailsAccordionState ||
-    _.isEqual(ctx.pipelineDetailsAccordionState, EXPANDED);
+    isEqual(ctx.pipelineDetailsAccordionState, EXPANDED);
 
   return (
     <Button

--- a/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/PipelineActions.tsx
+++ b/apps/generic-issuance-client/src/pages/pipeline/PipelineEditSection/PipelineActions.tsx
@@ -7,7 +7,7 @@ import {
   PipelineInfoResponseValue,
   isCSVPipelineDefinition
 } from "@pcd/passport-interface";
-import _ from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 import React, { ReactNode, useCallback, useState } from "react";
 import styled from "styled-components";
 import { AddDataModal } from "../../../components/AddDataModal";
@@ -81,7 +81,7 @@ export function PipelineActions({
     }
 
     setActionInProgress(`Reverting pipeline '${pipeline.id}'...`);
-    const historicVersion: Partial<PipelineDefinition> = _.cloneDeep(
+    const historicVersion: Partial<PipelineDefinition> = cloneDeep(
       maybeHistoricPipeline
     );
     historicVersion.timeUpdated = pipeline.timeUpdated;
@@ -114,7 +114,7 @@ export function PipelineActions({
     }
 
     setActionInProgress(`Duplicating pipeline '${pipeline.id}'...`);
-    const copyDefinition: Partial<PipelineDefinition> = _.cloneDeep(pipeline);
+    const copyDefinition: Partial<PipelineDefinition> = cloneDeep(pipeline);
     delete copyDefinition.id;
     delete copyDefinition.ownerUserId;
     copyDefinition.options = {
@@ -179,7 +179,7 @@ export function PipelineActions({
       setActionInProgress(
         `Changing protection status of pipeline '${pipeline.id}'...`
       );
-      const copyDefinition: Partial<PipelineDefinition> = _.cloneDeep(pipeline);
+      const copyDefinition: Partial<PipelineDefinition> = cloneDeep(pipeline);
       copyDefinition.options = {
         ...copyDefinition.options,
         protected: !pipelineProtected
@@ -210,7 +210,7 @@ export function PipelineActions({
       setActionInProgress(
         `Changing pause state of pipeline '${pipeline.id}'...`
       );
-      const copyDefinition: Partial<PipelineDefinition> = _.cloneDeep(pipeline);
+      const copyDefinition: Partial<PipelineDefinition> = cloneDeep(pipeline);
       copyDefinition.options = {
         ...copyDefinition.options,
         paused: !pipelinePaused
@@ -241,7 +241,7 @@ export function PipelineActions({
       setActionInProgress(
         `Changing importance of pipeline '${pipeline.id}'...`
       );
-      const copyDefinition: Partial<PipelineDefinition> = _.cloneDeep(pipeline);
+      const copyDefinition: Partial<PipelineDefinition> = cloneDeep(pipeline);
       copyDefinition.options = {
         ...copyDefinition.options,
         important: !pipelineImportant

--- a/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
+++ b/apps/passport-client/components/screens/AddSubscriptionScreen.tsx
@@ -13,7 +13,7 @@ import {
   isReplaceInFolderPermission
 } from "@pcd/pcd-collection";
 import { sleep } from "@pcd/util";
-import _ from "lodash";
+import uniq from "lodash/uniq";
 import React, {
   MouseEvent,
   useCallback,
@@ -545,7 +545,7 @@ function AlreadySubscribed({
   };
 
   const navigate = useNavigate();
-  const folders = _.uniq(
+  const folders = uniq(
     existingSubscription.feed.permissions.map((p) => p.folder)
   ).sort((a, b) => a.localeCompare(b));
   const goToFolder = useCallback(

--- a/apps/passport-client/components/screens/EdgeCityScreens/ExperienceModal.tsx
+++ b/apps/passport-client/components/screens/EdgeCityScreens/ExperienceModal.tsx
@@ -1,5 +1,5 @@
 import { EdDSATicketPCD } from "@pcd/eddsa-ticket-pcd";
-import _ from "lodash";
+import range from "lodash/range";
 import styled from "styled-components";
 import { Button } from "../../core";
 import { AdhocModal } from "../../modals/AdhocModal";
@@ -78,7 +78,7 @@ const Container = styled.div<{ index: number; count: number; color: string }>`
     padding: 0;
     border: 1px solid ${({ color }): string => color};
     box-shadow: ${({ index, count, color }): string => {
-      return [..._.range(-1, -index - 1, -1), ..._.range(1, count - index)]
+      return [...range(-1, -index - 1, -1), ...range(1, count - index)]
         .map((i) => {
           const offset = i * 2;
 

--- a/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogFolder.tsx
@@ -1,5 +1,5 @@
 import { FrogCryptoFolderName } from "@pcd/passport-interface";
-import _ from "lodash";
+import min from "lodash/min";
 import prettyMilliseconds from "pretty-ms";
 import { PropsWithChildren, useEffect, useMemo, useState } from "react";
 import styled, {
@@ -108,7 +108,7 @@ function useFetchTimestamp(): number | null {
         return null;
       }
 
-      return _.min(activeFeeds.map((feed) => feed.nextFetchAt)) ?? null;
+      return min(activeFeeds.map((feed) => feed.nextFetchAt)) ?? null;
     } catch (e) {
       console.error(e);
       return null;
@@ -131,7 +131,7 @@ function CountDown({
   }, [timestamp]);
   const [diffText, setDiffText] = useState(
     timestamp < Date.now() && !frogcryptoGrayscale
-      ? _.upperCase("Available Now")
+      ? "Available Now".toLocaleUpperCase()
       : ""
   );
 
@@ -142,7 +142,7 @@ function CountDown({
       if (frogcryptoGrayscale) {
         setDiffText("");
       } else if (diffMs < 0) {
-        setDiffText(_.upperCase("Available Now"));
+        setDiffText("Available Now".toLocaleUpperCase());
       } else {
         const diffString = prettyMilliseconds(diffMs, {
           millisecondsDecimalDigits: 0,

--- a/apps/passport-client/components/screens/FrogScreens/FrogsModal.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/FrogsModal.tsx
@@ -1,5 +1,5 @@
 import { EdDSAFrogPCD } from "@pcd/eddsa-frog-pcd";
-import _ from "lodash";
+import range from "lodash/range";
 import { useCallback, useState } from "react";
 import { useSwipeable } from "react-swipeable";
 import styled from "styled-components";
@@ -78,7 +78,7 @@ const Container = styled.div<{ index: number; count: number; color: string }>`
     padding: 0;
     border: 1px solid ${({ color }): string => color};
     box-shadow: ${({ index, count, color }): string => {
-      return [..._.range(-1, -index - 1, -1), ..._.range(1, count - index)]
+      return [...range(-1, -index - 1, -1), ...range(1, count - index)]
         .map((i) => {
           const offset = i * 2;
 

--- a/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/GetFrogTab.tsx
@@ -8,7 +8,8 @@ import {
   SubscriptionErrorType
 } from "@pcd/passport-interface";
 import { Separator } from "@pcd/passport-ui";
-import _ from "lodash";
+import keyBy from "lodash/keyBy";
+import maxBy from "lodash/maxBy";
 import prettyMilliseconds from "pretty-ms";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "react-hot-toast";
@@ -47,7 +48,7 @@ export function GetFrogTab({
 }): JSX.Element {
   const { value: subManager } = useSubscriptions();
   const userStateByFeedId = useMemo(
-    () => _.keyBy(userState.feeds, (feed) => feed.feedId),
+    () => keyBy(userState.feeds, (feed) => feed.feedId),
     [userState]
   );
 
@@ -194,7 +195,10 @@ const SearchButton = ({
     refreshUserState,
     subManager
   ]);
-  const name = useMemo(() => `search ${_.upperCase(feed.name)}`, [feed.name]);
+  const name = useMemo(
+    () => `search ${feed.name.toLocaleUpperCase()}`,
+    [feed.name]
+  );
   const freerolls = FROG_FREEROLLS + 1 - (score ?? 0);
   const ButtonComponent = useMemo(() => {
     switch (feed.name) {
@@ -241,7 +245,7 @@ const useGetLastFrog = (): (() => EdDSAFrogPCD | undefined) => {
   const pcdCollection = usePCDCollection();
   const getLastFrog = useCallback(
     () =>
-      _.maxBy(
+      maxBy(
         pcdCollection
           .getAllPCDsInFolder(FrogCryptoFolderName)
           .filter(isEdDSAFrogPCD),

--- a/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
@@ -8,7 +8,6 @@ import {
 import { ErrorMessage, Separator } from "@pcd/passport-ui";
 import { SerializedPCD } from "@pcd/pcd-types";
 import { getErrorMessage } from "@pcd/util";
-import chain from "lodash/chain";
 import upperFirst from "lodash/upperFirst";
 import prettyMilliseconds from "pretty-ms";
 import { useEffect, useMemo, useState } from "react";
@@ -293,7 +292,10 @@ export function DataTable({
   }));
   const keys =
     data.length > 0
-      ? chain(data).map(Object.keys).flatten().uniq().value()
+      ? data
+          .map(Object.keys)
+          .flat()
+          .filter((key, index, self) => self.indexOf(key) === index)
       : [];
 
   return (

--- a/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ManageFeedsSection.tsx
@@ -8,7 +8,8 @@ import {
 import { ErrorMessage, Separator } from "@pcd/passport-ui";
 import { SerializedPCD } from "@pcd/pcd-types";
 import { getErrorMessage } from "@pcd/util";
-import _ from "lodash";
+import chain from "lodash/chain";
+import upperFirst from "lodash/upperFirst";
 import prettyMilliseconds from "pretty-ms";
 import { useEffect, useMemo, useState } from "react";
 // react-table-lite does not have types
@@ -206,7 +207,7 @@ function feedParser(data: string): FrogCryptoDbFeedData[] {
       Object.keys(Biome).reduce((acc, biome) => {
         const dropWeightScaler =
           rawFeed[
-            `biomes${_.upperFirst(
+            `biomes${upperFirst(
               biome.replace(/\s/, "").toLowerCase()
             )}Dropweightscaler`
           ];
@@ -265,7 +266,7 @@ function feedUnparser(feeds: FrogCryptoDbFeedData[]): string {
         const biomeConfig = feed.feed.biomes[biome];
         if (biomeConfig) {
           acc[
-            `biomes${_.upperFirst(
+            `biomes${upperFirst(
               biome.replace(/\s/, "").toLowerCase()
             )}Dropweightscaler`
           ] = biomeConfig.dropWeightScaler;
@@ -292,7 +293,7 @@ export function DataTable({
   }));
   const keys =
     data.length > 0
-      ? _.chain(data).map(Object.keys).flatten().uniq().value()
+      ? chain(data).map(Object.keys).flatten().uniq().value()
       : [];
 
   return (

--- a/apps/passport-client/components/screens/FrogScreens/ManageFrogsSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ManageFrogsSection.tsx
@@ -7,7 +7,6 @@ import {
 import { ErrorMessage, Separator } from "@pcd/passport-ui";
 import { SerializedPCD } from "@pcd/pcd-types";
 import { getErrorMessage } from "@pcd/util";
-import chain from "lodash/chain";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 // react-table-lite does not have types
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -277,7 +276,10 @@ export function DataTable({
 }): JSX.Element {
   const keys =
     data.length > 0
-      ? chain(data).map(Object.keys).flatten().uniq().value()
+      ? data
+          .map(Object.keys)
+          .flat()
+          .filter((key, index, self) => self.indexOf(key) === index)
       : [];
 
   const dataWithChecked = data.map((row) => ({

--- a/apps/passport-client/components/screens/FrogScreens/ManageFrogsSection.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ManageFrogsSection.tsx
@@ -7,7 +7,7 @@ import {
 import { ErrorMessage, Separator } from "@pcd/passport-ui";
 import { SerializedPCD } from "@pcd/pcd-types";
 import { getErrorMessage } from "@pcd/util";
-import _ from "lodash";
+import chain from "lodash/chain";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 // react-table-lite does not have types
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -277,7 +277,7 @@ export function DataTable({
 }): JSX.Element {
   const keys =
     data.length > 0
-      ? _.chain(data).map(Object.keys).flatten().uniq().value()
+      ? chain(data).map(Object.keys).flatten().uniq().value()
       : [];
 
   const dataWithChecked = data.map((row) => ({

--- a/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
+++ b/apps/passport-client/components/screens/FrogScreens/ScoreTab.tsx
@@ -2,7 +2,7 @@ import {
   FrogCryptoScore,
   requestFrogCryptoGetScoreboard
 } from "@pcd/passport-interface";
-import _ from "lodash";
+import orderBy from "lodash/orderBy";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";
@@ -225,7 +225,7 @@ export function groupScores(scores: FrogCryptoScore[]): {
     scores: [] as FrogCryptoScore[]
   })).reverse();
 
-  _.orderBy(scores, ["score"], ["desc"]).forEach((score) => {
+  orderBy(scores, ["score"], ["desc"]).forEach((score) => {
     const index = SCORES.findIndex((item) => item.score > score.score);
     const curr = SCORES[index === -1 ? SCORES.length - 1 : index - 1];
 

--- a/apps/passport-client/components/screens/FrogScreens/useUsername.ts
+++ b/apps/passport-client/components/screens/FrogScreens/useUsername.ts
@@ -1,5 +1,5 @@
 import { PCDCrypto } from "@pcd/passport-crypto";
-import _ from "lodash";
+import startCase from "lodash/startCase";
 import { useCallback, useEffect, useState } from "react";
 import { bigintToUint8Array, uint8arrayToBigint } from "../../../src/util";
 
@@ -39,7 +39,7 @@ export function useUsernameGenerator():
 
         return lowercase
           ? randomAdjective + "_" + randomAnimal
-          : _.startCase(`${randomAdjective} ${randomAnimal}`);
+          : startCase(`${randomAdjective} ${randomAnimal}`);
       } catch (e) {
         console.debug("Error in useUsernameGenerator", e);
         return "An Unknown Toad";

--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -27,7 +27,6 @@ import {
   ZKEdDSAEventTicketPCDPackage,
   isZKEdDSAEventTicketPCDPackage
 } from "@pcd/zk-eddsa-event-ticket-pcd";
-import _ from "lodash";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";
@@ -163,7 +162,7 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
         const result: SerializedPCD<ZKEdDSAEventTicketPCD>[] = [];
 
         for (const t of relevantPCDs) {
-          const argsClone = _.clone(args) as ArgsOf<
+          const argsClone = structuredClone(args) as ArgsOf<
             typeof ZKEdDSAEventTicketPCDPackage
           >;
           argsClone.ticket.value = await EdDSATicketPCDPackage.serialize(

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
@@ -16,7 +16,7 @@ import {
   SemaphoreSignaturePCDArgs,
   SemaphoreSignaturePCDPackage
 } from "@pcd/semaphore-signature-pcd";
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 import { ReactNode, useCallback, useState } from "react";
 import styled from "styled-components";
 import { appConfig } from "../../../src/appConfig";

--- a/apps/passport-client/components/shared/PCDArgs.tsx
+++ b/apps/passport-client/components/shared/PCDArgs.tsx
@@ -28,7 +28,9 @@ import {
   isStringArrayArgument,
   isToggleListArgument
 } from "@pcd/pcd-types";
-import _ from "lodash";
+import kebabCase from "lodash/kebabCase";
+import partition from "lodash/partition";
+import startCase from "lodash/startCase";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { FaCheck, FaHashtag, FaQuestion } from "react-icons/fa";
 import { FaInfo, FaList, FaRegEye, FaRegEyeSlash } from "react-icons/fa6";
@@ -108,7 +110,7 @@ export function PCDArgs<T extends PCDPackage>({
     }
   );
 
-  const [visible, hidden] = _.partition(
+  const [visible, hidden] = partition(
     flattenedArgs,
     ([parentArgName, argName, arg]) =>
       arg.defaultVisible ??
@@ -229,7 +231,7 @@ export function ArgInput<T extends PCDPackage, ArgName extends string>({
     return {
       // merge arg with default value
       arg: {
-        displayName: _.startCase(qualifiedArgName),
+        displayName: startCase(qualifiedArgName),
         ...(defaultArg || {}),
         ...arg
       },
@@ -723,7 +725,7 @@ function ArgContainer({
               <Caption>{displayName}</Caption>
               {description && (
                 <a
-                  data-tooltip-id={`arg-input-tooltip-${_.kebabCase(
+                  data-tooltip-id={`arg-input-tooltip-${kebabCase(
                     displayName
                   )}`}
                   data-tooltip-content={description}
@@ -734,7 +736,7 @@ function ArgContainer({
                 </a>
               )}
               <TooltipContainer
-                id={`arg-input-tooltip-${_.kebabCase(displayName)}`}
+                id={`arg-input-tooltip-${kebabCase(displayName)}`}
               />
             </>
           ) : (

--- a/apps/passport-client/components/shared/PCDCardList.tsx
+++ b/apps/passport-client/components/shared/PCDCardList.tsx
@@ -1,6 +1,6 @@
 import { PCD } from "@pcd/pcd-types";
 import { sleep } from "@pcd/util";
-import _ from "lodash";
+import orderBy from "lodash/orderBy";
 import { useCallback, useMemo, useState } from "react";
 import styled from "styled-components";
 import { usePCDCollection, useUserIdentityPCD } from "../../src/appHooks";
@@ -88,7 +88,7 @@ export function PCDCardList({
   const sortedPCDs = useMemo(
     () =>
       (sortState.sortBy && sortState.sortOrder
-        ? _.orderBy(sortablePCDs, [sortState.sortBy], [sortState.sortOrder])
+        ? orderBy(sortablePCDs, [sortState.sortBy], [sortState.sortOrder])
         : sortablePCDs
       ).map((o) => o.value),
     [sortState, sortablePCDs]

--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -39,7 +39,7 @@ import {
 import { assertUnreachable, sleep } from "@pcd/util";
 import { StrichSDK } from "@pixelverse/strichjs-sdk";
 import { Identity } from "@semaphore-protocol/identity";
-import _ from "lodash";
+import uniq from "lodash/uniq";
 import { createContext } from "react";
 import { appConfig } from "./appConfig";
 import {
@@ -1281,7 +1281,7 @@ async function removeSubscription(
 
   if (deleteContents) {
     const subscriptionFolders = existingSubscription
-      ? _.uniq(existingSubscription.feed.permissions.map((p) => p.folder)).sort(
+      ? uniq(existingSubscription.feed.permissions.map((p) => p.folder)).sort(
           (a, b) => a.localeCompare(b)
         )
       : [];

--- a/apps/passport-client/src/util.ts
+++ b/apps/passport-client/src/util.ts
@@ -5,7 +5,7 @@ import {
 } from "@pcd/passport-interface";
 import { splitPath } from "@pcd/pcd-collection";
 import { sleep } from "@pcd/util";
-import _ from "lodash";
+import chain from "lodash/chain";
 import { v4 as uuid } from "uuid";
 import { Dispatcher } from "./dispatch";
 
@@ -78,7 +78,7 @@ function getVerifyUrlPrefixes(): string[] {
 // Given an input string, check if there exists a ticket verify URL within it.
 // If so, return the last occurance of a verify URL. If not, return null.
 export function getLastValidVerifyUrl(inputString: string): string | null {
-  const lastValidUrlStartIdx = _.chain(getVerifyUrlPrefixes())
+  const lastValidUrlStartIdx = chain(getVerifyUrlPrefixes())
     .map((verifyUrlPrefix) => inputString.lastIndexOf(verifyUrlPrefix))
     .max()
     .value();

--- a/apps/passport-client/src/util.ts
+++ b/apps/passport-client/src/util.ts
@@ -5,7 +5,6 @@ import {
 } from "@pcd/passport-interface";
 import { splitPath } from "@pcd/pcd-collection";
 import { sleep } from "@pcd/util";
-import chain from "lodash/chain";
 import { v4 as uuid } from "uuid";
 import { Dispatcher } from "./dispatch";
 
@@ -78,10 +77,11 @@ function getVerifyUrlPrefixes(): string[] {
 // Given an input string, check if there exists a ticket verify URL within it.
 // If so, return the last occurance of a verify URL. If not, return null.
 export function getLastValidVerifyUrl(inputString: string): string | null {
-  const lastValidUrlStartIdx = chain(getVerifyUrlPrefixes())
-    .map((verifyUrlPrefix) => inputString.lastIndexOf(verifyUrlPrefix))
-    .max()
-    .value();
+  const lastValidUrlStartIdx = Math.max(
+    ...getVerifyUrlPrefixes().map((verifyUrlPrefix) =>
+      inputString.lastIndexOf(verifyUrlPrefix)
+    )
+  );
   if (lastValidUrlStartIdx !== -1) {
     return inputString.slice(lastValidUrlStartIdx);
   }

--- a/apps/passport-server/src/database/queries/frogcrypto.ts
+++ b/apps/passport-server/src/database/queries/frogcrypto.ts
@@ -10,7 +10,8 @@ import {
   FrogCryptoScore
 } from "@pcd/passport-interface";
 import { PCDPermissionType } from "@pcd/pcd-collection";
-import _ from "lodash";
+import chain from "lodash/chain";
+import omit from "lodash/omit";
 import { Client } from "pg";
 import { Pool } from "postgres-pool";
 import { parseFrogEnum } from "../../util/frogcrypto";
@@ -130,7 +131,7 @@ export async function upsertFrogData(
     on conflict (id) do update
     set uuid = $2, frog = $3
     `,
-      [frogData.id, frogData.uuid, _.omit(frogData, ["id", "uuid"])]
+      [frogData.id, frogData.uuid, omit(frogData, ["id", "uuid"])]
     );
   }
 }
@@ -190,7 +191,7 @@ export async function sampleFrogData(
   pool: Pool,
   biomes: FrogCryptoFeedBiomeConfigs
 ): Promise<FrogCryptoFrogData | undefined> {
-  const [biomeKeys, scalingFactors] = _.chain(biomes)
+  const [biomeKeys, scalingFactors] = chain(biomes)
     .toPairs()
     .map(([biome, config]) => [biome, config?.dropWeightScaler])
     .filter(([, scalingFactor]) => !!scalingFactor)
@@ -308,7 +309,7 @@ export async function getScoreboard(
   );
 
   return result.rows.map(
-    (row) => _.omit(row, ["semaphore_id"]) as FrogCryptoScore
+    (row) => omit(row, ["semaphore_id"]) as FrogCryptoScore
   );
 }
 
@@ -326,7 +327,7 @@ export async function getUserScore(
   );
 
   return result.rows.map(
-    (row) => _.omit(row, ["semaphore_id"]) as FrogCryptoScore
+    (row) => omit(row, ["semaphore_id"]) as FrogCryptoScore
   )[0];
 }
 

--- a/apps/passport-server/src/database/queries/frogcrypto.ts
+++ b/apps/passport-server/src/database/queries/frogcrypto.ts
@@ -10,8 +10,8 @@ import {
   FrogCryptoScore
 } from "@pcd/passport-interface";
 import { PCDPermissionType } from "@pcd/pcd-collection";
-import chain from "lodash/chain";
 import omit from "lodash/omit";
+import unzip from "lodash/unzip";
 import { Client } from "pg";
 import { Pool } from "postgres-pool";
 import { parseFrogEnum } from "../../util/frogcrypto";
@@ -191,12 +191,11 @@ export async function sampleFrogData(
   pool: Pool,
   biomes: FrogCryptoFeedBiomeConfigs
 ): Promise<FrogCryptoFrogData | undefined> {
-  const [biomeKeys, scalingFactors] = chain(biomes)
-    .toPairs()
+  const biomePairs = Object.entries(biomes);
+  const filteredPairs = biomePairs
     .map(([biome, config]) => [biome, config?.dropWeightScaler])
-    .filter(([, scalingFactor]) => !!scalingFactor)
-    .unzip()
-    .value();
+    .filter(([, scalingFactor]) => !!scalingFactor);
+  const [biomeKeys, scalingFactors] = unzip(filteredPairs);
 
   const result = await sqlQuery(
     pool,

--- a/apps/passport-server/src/database/queries/pipelineDefinitionDB.ts
+++ b/apps/passport-server/src/database/queries/pipelineDefinitionDB.ts
@@ -4,7 +4,8 @@ import {
   PipelineLoadSummary,
   PipelineType
 } from "@pcd/passport-interface";
-import _ from "lodash";
+import difference from "lodash/difference";
+import isEqual from "lodash/isEqual";
 import { Pool, PoolClient } from "postgres-pool";
 import { GenericIssuancePipelineRow } from "../models";
 import { sqlQuery, sqlTransaction } from "../sqlQuery";
@@ -214,12 +215,12 @@ export class PipelineDefinitionDB implements IPipelineDefinitionDB {
           )
         ).rows.map((row) => row.editor_id);
 
-        if (!_.isEqual(pipeline.editor_user_ids, definition.editorUserIds)) {
-          const editorsToRemove = _.difference(
+        if (!isEqual(pipeline.editor_user_ids, definition.editorUserIds)) {
+          const editorsToRemove = difference(
             pipeline.editor_user_ids,
             definition.editorUserIds
           );
-          const editorsToAdd = _.difference(
+          const editorsToAdd = difference(
             definition.editorUserIds,
             pipeline.editor_user_ids
           );

--- a/apps/passport-server/src/services/frogcryptoService.ts
+++ b/apps/passport-server/src/services/frogcryptoService.ts
@@ -26,7 +26,9 @@ import {
 } from "@pcd/passport-interface";
 import { PCDActionType } from "@pcd/pcd-collection";
 import { RollbarService } from "@pcd/server-shared";
-import _ from "lodash";
+import intersection from "lodash/intersection";
+import keyBy from "lodash/keyBy";
+import pick from "lodash/pick";
 import { FrogCryptoUserFeedState } from "../database/models";
 import {
   deleteFrogData,
@@ -144,7 +146,7 @@ export class FrogcryptoService {
 
     const semaphoreId = await this.verifyCredentialAndGetSemaphoreId(req.pcd);
 
-    const userFeeds = _.keyBy(
+    const userFeeds = keyBy(
       await fetchUserFeedsState(this.context.dbPool, semaphoreId),
       "feed_id"
     );
@@ -359,7 +361,7 @@ export class FrogcryptoService {
     const rarity = parseFrogEnum(Rarity, frogData.rarity);
 
     return {
-      ..._.pick(frogData, "name", "description"),
+      ...pick(frogData, "name", "description"),
       imageUrl: `${process.env.PASSPORT_SERVER_URL}/frogcrypto/images/${frogData.uuid}`,
       frogId: frogData.id,
       biome: parseFrogEnum(Biome, frogData.biome),
@@ -409,7 +411,7 @@ export class FrogcryptoService {
     if (!user) {
       throw new PCDHTTPError(400, "invalid PCD");
     }
-    if (!_.intersection(this.adminUsers, user.emails)) {
+    if (!intersection(this.adminUsers, user.emails)) {
       throw new PCDHTTPError(403, "not authorized");
     }
   }

--- a/apps/passport-server/src/services/generic-issuance/SemaphoreGroupProvider.ts
+++ b/apps/passport-server/src/services/generic-issuance/SemaphoreGroupProvider.ts
@@ -9,7 +9,7 @@ import {
 } from "@pcd/semaphore-group-pcd";
 import { uuidToBigInt } from "@pcd/util";
 import { Group } from "@semaphore-protocol/group";
-import _ from "lodash";
+import uniq from "lodash/uniq";
 import { IPipelineConsumerDB } from "../../database/queries/pipelineConsumerDB";
 import { IPipelineSemaphoreHistoryDB } from "../../database/queries/pipelineSemaphoreHistoryDB";
 import { traced } from "../telemetryService";
@@ -212,7 +212,7 @@ export class SemaphoreGroupProvider {
           ? await this.consumerDB.loadByEmails(this.pipelineId, emails)
           : [];
 
-      const semaphoreIds = _.uniq(
+      const semaphoreIds = uniq(
         consumers.map((consumer) => consumer.commitment)
       );
       const group = this.groups.get(groupConfig.groupId);

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -40,7 +40,7 @@ import { SerializedSemaphoreGroup } from "@pcd/semaphore-group-pcd";
 import { str } from "@pcd/util";
 import { randomUUID } from "crypto";
 import stable_stringify from "fast-json-stable-stringify";
-import _ from "lodash";
+import keyBy from "lodash/keyBy";
 import PQueue from "p-queue";
 import { DatabaseError } from "pg";
 import urljoin from "url-join";
@@ -754,7 +754,7 @@ export class LemonadePipeline implements BasePipeline {
       this.id,
       relevantTickets.map((ticket) => ticket.id)
     );
-    const checkInsById = _.keyBy(checkIns, (checkIn) => checkIn.ticketId);
+    const checkInsById = keyBy(checkIns, (checkIn) => checkIn.ticketId);
 
     // Convert atoms to ticket data
     const ticketDatas = relevantTickets.map((t) => {
@@ -1918,7 +1918,7 @@ export class LemonadePipeline implements BasePipeline {
     return traced(LOG_NAME, "getManualCheckinSummary", async (span) => {
       const results: PipelineCheckinSummary[] = [];
       const checkIns = await this.checkinDB.getByPipelineId(this.id);
-      const checkInsById = _.keyBy(checkIns, (checkIn) => checkIn.ticketId);
+      const checkInsById = keyBy(checkIns, (checkIn) => checkIn.ticketId);
 
       for (const ticketAtom of await this.db.load(this.id)) {
         const checkIn = checkInsById[ticketAtom.id];

--- a/apps/passport-server/src/services/generic-issuance/subservices/utils/upsertPipelineDefinition.ts
+++ b/apps/passport-server/src/services/generic-issuance/subservices/utils/upsertPipelineDefinition.ts
@@ -5,7 +5,7 @@ import {
   isCSVPipelineDefinition
 } from "@pcd/passport-interface";
 import { onlyDefined, str } from "@pcd/util";
-import _ from "lodash";
+import isEqual from "lodash";
 import { v4 as uuidv4 } from "uuid";
 import { PCDHTTPError } from "../../../../routing/pcdHttpError";
 import { logger } from "../../../../util/logger";
@@ -116,7 +116,7 @@ export async function upsertPipelineDefinition(
 
     if (
       !editor.isAdmin &&
-      !_.isEqual(
+      !isEqual(
         existingPipelineDefinition.options.alerts,
         newDefinition.options.alerts
       )

--- a/apps/passport-server/src/services/generic-issuance/subservices/utils/upsertPipelineDefinition.ts
+++ b/apps/passport-server/src/services/generic-issuance/subservices/utils/upsertPipelineDefinition.ts
@@ -5,7 +5,7 @@ import {
   isCSVPipelineDefinition
 } from "@pcd/passport-interface";
 import { onlyDefined, str } from "@pcd/util";
-import isEqual from "lodash";
+import isEqual from "lodash/isEqual";
 import { v4 as uuidv4 } from "uuid";
 import { PCDHTTPError } from "../../../../routing/pcdHttpError";
 import { logger } from "../../../../util/logger";

--- a/apps/passport-server/src/services/issuanceService.ts
+++ b/apps/passport-server/src/services/issuanceService.ts
@@ -48,7 +48,7 @@ import { RSAImagePCDPackage } from "@pcd/rsa-image-pcd";
 import { RollbarService } from "@pcd/server-shared";
 import { ONE_HOUR_MS } from "@pcd/util";
 import { ZKEdDSAEventTicketPCDPackage } from "@pcd/zk-eddsa-event-ticket-pcd";
-import _ from "lodash";
+import sample from "lodash/sample";
 import { LRUCache } from "lru-cache";
 import NodeRSA from "node-rsa";
 import { Pool } from "postgres-pool";
@@ -502,7 +502,7 @@ export class IssuanceService {
       "images/frogs/frog4.jpeg"
     ];
 
-    const randomFrogPath = _.sample(frogPaths);
+    const randomFrogPath = sample(frogPaths);
 
     const id = timeBasedId(FROG_INTERVAL_MS) + "";
 

--- a/apps/passport-server/src/services/poapService.ts
+++ b/apps/passport-server/src/services/poapService.ts
@@ -24,7 +24,7 @@ import {
   ZKEdDSAEventTicketPCDPackage
 } from "@pcd/zk-eddsa-event-ticket-pcd";
 import AsyncLock from "async-lock";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { PoapEvent } from "../database/models";
 import { fetchDevconnectPretixTicketByTicketId } from "../database/queries/devconnect_pretix_tickets/fetchDevconnectPretixTicket";
 import {

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -38,7 +38,7 @@ import {
   Message,
   UserFromGetMe
 } from "grammy/types";
-import _ from "lodash";
+import uniq from "lodash/uniq";
 import { v1 as uuidV1 } from "uuid";
 import { AnonMessageWithDetails } from "../database/models";
 import {
@@ -1352,7 +1352,7 @@ export class TelegramService {
         anonMessageId
       );
 
-      const allEmojis = _.uniq([
+      const allEmojis = uniq([
         ...getDisplayEmojis(new Date(anonMessage.message_timestamp)),
         ...reactionsForMessage.map((rc) => rc.reaction)
       ]);

--- a/apps/passport-server/src/util/frogcrypto.ts
+++ b/apps/passport-server/src/util/frogcrypto.ts
@@ -14,7 +14,9 @@ import {
   PollFeedResponseValue
 } from "@pcd/passport-interface";
 import { PCDPackage } from "@pcd/pcd-types";
-import _ from "lodash";
+import findKey from "lodash/findKey";
+import random from "lodash/random";
+import sample from "lodash/sample";
 import { Pool } from "postgres-pool";
 import { getFeedData } from "../database/queries/frogcrypto";
 import { PCDHTTPError } from "../routing/pcdHttpError";
@@ -138,7 +140,7 @@ export function sampleFrogAttribute(
   max?: number,
   rarity?: Rarity
 ): number {
-  return _.random(
+  return random(
     Math.round(min ?? 0),
     Math.round(max ?? (rarity === Rarity.Common ? 7 : 15))
   );
@@ -148,7 +150,7 @@ export function parseFrogEnum(
   e: Record<number, string>,
   value: string
 ): number {
-  const key = _.findKey(
+  const key = findKey(
     e,
     (v) =>
       typeof v === "string" &&
@@ -162,7 +164,7 @@ export function parseFrogEnum(
 
 export function parseFrogTemperament(value?: string): Temperament {
   if (!value) {
-    return _.sample(COMMON_TEMPERAMENT_SET) ?? Temperament.N_A; // fallback makes TS happy
+    return sample(COMMON_TEMPERAMENT_SET) ?? Temperament.N_A; // fallback makes TS happy
   }
   if (value === "N/A") {
     return Temperament.N_A;

--- a/apps/passport-server/src/util/zuzaluUser.ts
+++ b/apps/passport-server/src/util/zuzaluUser.ts
@@ -5,7 +5,7 @@ import {
   ZupassUserJson,
   ZuzaluUserRole
 } from "@pcd/passport-interface";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import { UserRow, ZuzaluPretixTicket } from "../database/models";
 
 /**
@@ -20,9 +20,7 @@ export function pretixTicketsDifferent(
     return true;
   }
 
-  if (
-    !_.isEqual(oldTicket.visitor_date_ranges, newTicket.visitor_date_ranges)
-  ) {
+  if (!isEqual(oldTicket.visitor_date_ranges, newTicket.visitor_date_ranges)) {
     return true;
   }
 

--- a/apps/passport-server/test/frogcryptodb.spec.ts
+++ b/apps/passport-server/test/frogcryptodb.spec.ts
@@ -1,6 +1,6 @@
 import { FrogCryptoDbFeedData } from "@pcd/passport-interface";
 import { expect } from "chai";
-import _ from "lodash";
+import range from "lodash/range";
 import "mocha";
 import { step } from "mocha-steps";
 import { Client } from "pg";
@@ -94,7 +94,7 @@ describe("database reads and writes for frogcrypto features", function () {
 
   step("sample a frog from weighted biomes", async function () {
     const frogs = await Promise.all(
-      _.range(0, 1000).map(() =>
+      range(0, 1000).map(() =>
         sampleFrogData(db, {
           TheCapital: { dropWeightScaler: 100 },
           Desert: { dropWeightScaler: 0.01 },

--- a/apps/passport-server/test/pretix/devconnectPretixDataMocker.ts
+++ b/apps/passport-server/test/pretix/devconnectPretixDataMocker.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import sample from "lodash/sample";
 import { v4 as uuid } from "uuid";
 import {
   DevconnectPretixCategory,
@@ -388,6 +388,6 @@ export class DevconnectPretixDataMocker {
       "Slimbo",
       "Froggy"
     ];
-    return _.sample(firstNames) + " " + _.sample(lastNames);
+    return sample(firstNames) + " " + sample(lastNames);
   }
 }

--- a/apps/passport-server/test/pretix/zuzaluPretixDataMocker.ts
+++ b/apps/passport-server/test/pretix/zuzaluPretixDataMocker.ts
@@ -1,5 +1,5 @@
 import { ONE_HOUR_MS } from "@pcd/util";
-import _ from "lodash";
+import sample from "lodash/sample";
 import { v4 as uuid } from "uuid";
 import {
   ZuzaluPretixConfig,
@@ -236,6 +236,6 @@ export class ZuzaluPretixDataMocker {
       "Slimbo",
       "Froggy"
     ];
-    return _.sample(firstNames) + " " + _.sample(lastNames);
+    return sample(firstNames) + " " + sample(lastNames);
   }
 }

--- a/apps/passport-server/test/util/newDatabase.ts
+++ b/apps/passport-server/test/util/newDatabase.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import sample from "lodash/sample";
 import pgtools from "pgtools";
 import { getDatabaseConfiguration } from "../../src/database/postgresConfiguration";
 
@@ -6,7 +6,7 @@ export async function newDatabase(): Promise<void> {
   const letters = "abcdefghijklmnopqrstuvwxyz";
   let name = "";
   for (let i = 0; i < 16; i++) {
-    name += _.sample(letters);
+    name += sample(letters);
   }
 
   const dbconfig = getDatabaseConfiguration();

--- a/apps/passport-server/test/util/util.ts
+++ b/apps/passport-server/test/util/util.ts
@@ -1,8 +1,7 @@
 import { expect } from "chai";
 import JSONBig from "json-bigint";
-import _ from "lodash";
+import sample from "lodash/sample";
 import { v4 as uuid } from "uuid";
-
 export function randomEmail(): string {
   return uuid() + "@test.com";
 }
@@ -129,5 +128,5 @@ export function safeTrue(): boolean {
 export function randomName(): string {
   const firstNames = ["Bob", "Steve", "Gub", "Mob", "Flub", "Jib", "Grub"];
   const lastNames = ["Froby", "Shmoby", "Glowby", "Brimby", "Slimbo", "Froggy"];
-  return _.sample(firstNames) + " " + _.sample(lastNames);
+  return sample(firstNames) + " " + sample(lastNames);
 }

--- a/apps/zupoll-client/src/api/loginGroups.ts
+++ b/apps/zupoll-client/src/api/loginGroups.ts
@@ -3,7 +3,7 @@ import {
   LoginConfig,
   getPodboxConfigs
 } from "@pcd/zupoll-shared";
-import _ from "lodash";
+import groupBy from "lodash/groupBy";
 import { ZUPASS_CLIENT_URL, ZUPASS_SERVER_URL } from "../env";
 import {
   DEVCONNECT_ORGANIZER_CONFIG,
@@ -39,7 +39,7 @@ export const LOGIN_GROUPS: LoginGroup[] = groupLoginConfigs([
 
 function groupLoginConfigs(configs: LoginConfig[]): LoginGroup[] {
   const rawGroups = Object.entries(
-    _.groupBy(configs, (r) => r.configCategoryId)
+    groupBy(configs, (r) => r.configCategoryId)
   ) as [LoginCategory, LoginConfig[]][];
 
   return rawGroups.map(

--- a/apps/zupoll-client/src/app/login/LoginWidget.tsx
+++ b/apps/zupoll-client/src/app/login/LoginWidget.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@/components/ui/spinner";
 import { LoginCategory } from "@pcd/zupoll-shared";
-import _ from "lodash";
+import sample from "lodash/sample";
 import { useMemo, useState } from "react";
 import styled from "styled-components";
 import { LOGIN_GROUPS } from "../../api/loginGroups";
@@ -52,7 +52,7 @@ const tips = [
 
 export function LoggingIn() {
   const randomTip = useMemo(() => {
-    return _.sample(tips);
+    return sample(tips);
   }, []);
 
   return (

--- a/apps/zupoll-client/src/app/login/SelectLoginGroup.tsx
+++ b/apps/zupoll-client/src/app/login/SelectLoginGroup.tsx
@@ -7,7 +7,7 @@ import {
   SelectValue
 } from "@/components/ui/select";
 import { LoginCategory } from "@pcd/zupoll-shared";
-import _ from "lodash";
+import groupBy from "lodash/groupBy";
 import { Dispatch, SetStateAction } from "react";
 import { LoginGroup } from "../../api/loginGroups";
 
@@ -38,7 +38,7 @@ export function SelectLoginGroup({
         <SelectValue placeholder="Select a Group to Log In" />
       </SelectTrigger>
       <SelectContent>
-        {Object.entries(_.groupBy(groups, (g: LoginGroup) => g.configs[0].year))
+        {Object.entries(groupBy(groups, (g: LoginGroup) => g.configs[0].year))
           .sort((lhs, rhs) => {
             return (
               new Date(

--- a/examples/pod-gpc-example/src/gpcExample.ts
+++ b/examples/pod-gpc-example/src/gpcExample.ts
@@ -36,7 +36,7 @@ import { POD, PODEntries, podEntriesToSimplifiedJSON } from "@pcd/pod";
 import { PODPCD, PODPCDPackage } from "@pcd/pod-pcd";
 import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
 import { Identity } from "@semaphore-protocol/identity";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import * as path from "path";
 import { v4 as uuid } from "uuid";
 
@@ -244,7 +244,7 @@ export async function gpcDemo(): Promise<boolean> {
   // If the config isn't hard-coded in the verifier, you need to ensure it's
   // suitable.  The canonicalization which happens in binding means you can
   // compare bound configs using a simple deep equals.
-  if (!_.isEqual(boundConfig, manualBoundConfig)) {
+  if (!isEqual(boundConfig, manualBoundConfig)) {
     throw new Error("Unexpected configuration.");
   }
 
@@ -286,9 +286,9 @@ export async function gpcDemo(): Promise<boolean> {
   const vConfig = deserializeGPCBoundConfig(serializedConfig);
   const vClaims = deserializeGPCRevealedClaims(serializedClaims);
   if (
-    !_.isEqual(vProof, proof) ||
-    !_.isEqual(vConfig, boundConfig) ||
-    !_.isEqual(vClaims, revealedClaims)
+    !isEqual(vProof, proof) ||
+    !isEqual(vConfig, boundConfig) ||
+    !isEqual(vClaims, revealedClaims)
   ) {
     throw new Error("Serialization should maintain contents.");
   }

--- a/packages/lib/gpc/package.json
+++ b/packages/lib/gpc/package.json
@@ -35,6 +35,7 @@
     "@semaphore-protocol/core": "^4.0.3",
     "@types/lodash": "^4.17.1",
     "json-bigint": "^1.0.0",
+    "lodash": "^4.17.21",
     "snarkjs": "^0.7.4",
     "url-join": "^4.0.1"
   },

--- a/packages/lib/gpc/src/gpcChecks.ts
+++ b/packages/lib/gpc/src/gpcChecks.ts
@@ -23,7 +23,7 @@ import {
 import { Identity as IdentityV4 } from "@semaphore-protocol/core";
 import { Identity } from "@semaphore-protocol/identity";
 import JSONBig from "json-bigint";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import {
   GPCBoundConfig,
   GPCIdentifier,
@@ -702,7 +702,7 @@ export function checkProofListMembershipInputsForConfig(
       for (const element of inputList) {
         const elementWidth = widthOfEntryOrTuple(element);
 
-        if (!_.isEqual(elementWidth, comparisonWidth)) {
+        if (!isEqual(elementWidth, comparisonWidth)) {
           throw new TypeError(
             `Membership list ${listIdentifier} in input contains element of width ${elementWidth} while comparison value with identifier ${JSON.stringify(
               comparisonId
@@ -715,7 +715,7 @@ export function checkProofListMembershipInputsForConfig(
       // hashes as this reflects how the values will be treated in the
       // circuit.
       const isComparisonValueInList = inputList.find((element) =>
-        _.isEqual(
+        isEqual(
           applyOrMap(podValueHash, element),
           applyOrMap(podValueHash, comparisonValue)
         )
@@ -760,7 +760,7 @@ export function checkInputListNamesForConfig(
   );
   const inputListNames = new Set(listNames);
 
-  if (!_.isEqual(configListNames, inputListNames)) {
+  if (!isEqual(configListNames, inputListNames)) {
     throw new Error(
       `Config and input list mismatch.` +
         `  Configuration expects lists ${JSON.stringify(

--- a/packages/lib/gpc/src/gpcCompile.ts
+++ b/packages/lib/gpc/src/gpcCompile.ts
@@ -29,7 +29,6 @@ import {
   BABY_JUB_NEGATIVE_ONE,
   BABY_JUB_SUBGROUP_ORDER_MINUS_ONE
 } from "@pcd/util";
-import _ from "lodash";
 import {
   GPCBoundConfig,
   GPCProofEntryConfig,

--- a/packages/lib/gpc/src/gpcUtil.ts
+++ b/packages/lib/gpc/src/gpcUtil.ts
@@ -12,7 +12,8 @@ import {
   requireType
 } from "@pcd/pod";
 import { BABY_JUB_NEGATIVE_ONE } from "@pcd/util";
-import _ from "lodash";
+import max from "lodash/max";
+import min from "lodash/min";
 import {
   GPCBoundConfig,
   GPCIdentifier,
@@ -224,7 +225,7 @@ export function canonicalizeBoundsCheckConfig(
       ? {
           inRange: {
             min: inRange.min,
-            max: _.min([notInRange.min - 1n, inRange.max]) as bigint
+            max: min([notInRange.min - 1n, inRange.max]) as bigint
           }
         }
       : // inRange\notInRange = [⍺, inRange.max] for some ⍺, i.e. `notInRange.max`
@@ -234,7 +235,7 @@ export function canonicalizeBoundsCheckConfig(
       notInRange.min <= inRange.min && notInRange.max < inRange.max
       ? {
           inRange: {
-            min: _.max([notInRange.max + 1n, inRange.min]) as bigint,
+            min: max([notInRange.max + 1n, inRange.min]) as bigint,
             max: inRange.max
           }
         }

--- a/packages/lib/gpcircuits/test/proto-pod-gpc.spec.ts
+++ b/packages/lib/gpcircuits/test/proto-pod-gpc.spec.ts
@@ -12,7 +12,6 @@ import {
 } from "@pcd/util";
 import { expect } from "chai";
 import { WitnessTester } from "circomkit";
-import _ from "lodash";
 import "mocha";
 import path from "path";
 import { poseidon1, poseidon2 } from "poseidon-lite";
@@ -46,6 +45,7 @@ import {
   sampleEntries2,
   sampleEntries3
 } from "./common";
+import isEqual from "lodash/isEqual";
 
 const MAX_OBJECTS = 3;
 const MAX_ENTRIES = 10;
@@ -974,7 +974,7 @@ describe("proto-pod-gpc.ProtoPODGPC (Compiled test artifacts) should work", func
     // sizes, with truncated data as necessary.
     for (const cd of ProtoPODGPC.CIRCUIT_PARAMETERS.map((pair) => pair[0])) {
       // Skip the default (largest) config, already tested above.
-      if (_.isEqual(cd, GPC_PARAMS)) {
+      if (isEqual(cd, GPC_PARAMS)) {
         continue;
       }
 

--- a/packages/lib/passport-interface/src/FrogCrypto.ts
+++ b/packages/lib/passport-interface/src/FrogCrypto.ts
@@ -1,5 +1,5 @@
 import { Biome, EdDSAFrogPCDPackage, Rarity } from "@pcd/eddsa-frog-pcd";
-import _ from "lodash";
+import mapValues from "lodash/mapValues";
 import { z } from "zod";
 import { Feed } from "./SubscriptionManager";
 
@@ -42,7 +42,7 @@ export const FrogCryptoFeedBiomeConfigSchema = z.object({
 });
 
 export const FrogCryptoFeedBiomeConfigsSchema = z.object(
-  _.mapValues(Biome, () => FrogCryptoFeedBiomeConfigSchema.optional())
+  mapValues(Biome, () => FrogCryptoFeedBiomeConfigSchema.optional())
 );
 
 export type FrogCryptoFeedBiomeConfigs = z.infer<

--- a/packages/lib/pcd-collection/src/PCDCollection.ts
+++ b/packages/lib/pcd-collection/src/PCDCollection.ts
@@ -2,7 +2,7 @@ import { Emitter } from "@pcd/emitter";
 import { getHash } from "@pcd/passport-crypto";
 import { PCD, PCDPackage, SerializedPCD } from "@pcd/pcd-types";
 import stringify from "fast-json-stable-stringify";
-import _ from "lodash";
+import uniq from "lodash/uniq";
 import {
   AppendToFolderAction,
   DeleteFolderAction,
@@ -299,7 +299,7 @@ export class PCDCollection {
       const subFolders = Object.values(this.folders).filter((folderPath) => {
         return isFolderAncestor(folderPath, folder);
       });
-      folders.push(..._.uniq(subFolders));
+      folders.push(...uniq(subFolders));
     }
 
     for (const folderPath of folders) {

--- a/packages/lib/pcd-collection/src/util.ts
+++ b/packages/lib/pcd-collection/src/util.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import uniq from "lodash/uniq";
 
 export const PATH_SEP = "/";
 
@@ -17,11 +17,11 @@ export function getFoldersInFolder(
   folderPath: string,
   allPaths: string[]
 ): string[] {
-  const descendantsOfFolder = _.uniq(
+  const descendantsOfFolder = uniq(
     allPaths.filter((p) => isFolderAncestor(p, folderPath))
   );
 
-  const descendantsWithMissing = _.uniq([
+  const descendantsWithMissing = uniq([
     ...descendantsOfFolder.flatMap((path) => getAllAncestors(path)),
     ...descendantsOfFolder
   ]).filter((a) => a !== "");

--- a/packages/lib/zupoll-shared/src/configs/2024_eth_prague.ts
+++ b/packages/lib/zupoll-shared/src/configs/2024_eth_prague.ts
@@ -1,3 +1,4 @@
+import clone from "lodash/clone";
 import urljoin from "url-join";
 import { makePodboxGroupUrl } from "../makePodboxGroupUrl";
 import { makePodboxLoginConfigs } from "../makePodboxLoginConfigs";
@@ -95,14 +96,14 @@ export function makeEthPrague(
   ETH_PRAGUE_CONFIG[0].ballotConfigs?.splice(
     1,
     0,
-    structuredClone(hackerBallotType),
-    structuredClone(audienceBallotType)
+    clone(hackerBallotType),
+    clone(audienceBallotType)
   );
   ETH_PRAGUE_CONFIG[1].ballotConfigs?.splice(
     1,
     0,
-    Object.assign(structuredClone(hackerBallotType), { canCreate: false }),
-    Object.assign(structuredClone(audienceBallotType), { canCreate: false })
+    Object.assign(clone(hackerBallotType), { canCreate: false }),
+    Object.assign(clone(audienceBallotType), { canCreate: false })
   );
 
   return ETH_PRAGUE_CONFIG;

--- a/packages/lib/zupoll-shared/src/configs/2024_eth_prague.ts
+++ b/packages/lib/zupoll-shared/src/configs/2024_eth_prague.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import urljoin from "url-join";
 import { makePodboxGroupUrl } from "../makePodboxGroupUrl";
 import { makePodboxLoginConfigs } from "../makePodboxLoginConfigs";
@@ -96,14 +95,14 @@ export function makeEthPrague(
   ETH_PRAGUE_CONFIG[0].ballotConfigs?.splice(
     1,
     0,
-    _.clone(hackerBallotType),
-    _.clone(audienceBallotType)
+    structuredClone(hackerBallotType),
+    structuredClone(audienceBallotType)
   );
   ETH_PRAGUE_CONFIG[1].ballotConfigs?.splice(
     1,
     0,
-    Object.assign(_.clone(hackerBallotType), { canCreate: false }),
-    Object.assign(_.clone(audienceBallotType), { canCreate: false })
+    Object.assign(structuredClone(hackerBallotType), { canCreate: false }),
+    Object.assign(structuredClone(audienceBallotType), { canCreate: false })
   );
 
   return ETH_PRAGUE_CONFIG;

--- a/packages/pcd/eddsa-frog-pcd/src/EdDSAFrogPCDPackage.ts
+++ b/packages/pcd/eddsa-frog-pcd/src/EdDSAFrogPCDPackage.ts
@@ -6,7 +6,7 @@ import {
   SerializedPCD
 } from "@pcd/pcd-types";
 import JSONBig from "json-bigint";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import { v4 as uuid } from "uuid";
 import {
   EdDSAFrogPCD,
@@ -64,7 +64,7 @@ export async function verify(pcd: EdDSAFrogPCD): Promise<boolean> {
   const messageDerivedFromClaim = frogDataToBigInts(pcd.claim.data);
 
   return (
-    _.isEqual(messageDerivedFromClaim, pcd.proof.eddsaPCD.claim.message) &&
+    isEqual(messageDerivedFromClaim, pcd.proof.eddsaPCD.claim.message) &&
     EdDSAPCDPackage.verify(pcd.proof.eddsaPCD)
   );
 }

--- a/packages/pcd/eddsa-ticket-pcd/src/EdDSATicketPCDPackage.ts
+++ b/packages/pcd/eddsa-ticket-pcd/src/EdDSATicketPCDPackage.ts
@@ -6,7 +6,7 @@ import {
   SerializedPCD
 } from "@pcd/pcd-types";
 import JSONBig from "json-bigint";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import { v4 as uuid } from "uuid";
 import {
   EdDSATicketPCD,
@@ -64,7 +64,7 @@ export async function prove(args: EdDSATicketPCDArgs): Promise<EdDSATicketPCD> {
 export async function verify(pcd: EdDSATicketPCD): Promise<boolean> {
   const messageDerivedFromClaim = ticketDataToBigInts(pcd.claim.ticket);
 
-  if (!_.isEqual(messageDerivedFromClaim, pcd.proof.eddsaPCD.claim.message)) {
+  if (!isEqual(messageDerivedFromClaim, pcd.proof.eddsaPCD.claim.message)) {
     return false;
   }
 

--- a/packages/pcd/email-pcd/src/EmailPCDPackage.ts
+++ b/packages/pcd/email-pcd/src/EmailPCDPackage.ts
@@ -7,7 +7,7 @@ import {
 } from "@pcd/pcd-types";
 import { generateSnarkMessageHash } from "@pcd/util";
 import JSONBig from "json-bigint";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import { v4 as uuid } from "uuid";
 import {
   EmailPCD,
@@ -67,7 +67,7 @@ export async function verify(pcd: EmailPCD): Promise<boolean> {
   );
 
   if (
-    !_.isEqual(
+    !isEqual(
       [messageDerivedFromClaim, BigInt(pcd.claim.semaphoreId)],
       pcd.proof.eddsaPCD.claim.message
     )

--- a/packages/pcd/gpc-pcd/src/validatorChecks.ts
+++ b/packages/pcd/gpc-pcd/src/validatorChecks.ts
@@ -7,7 +7,7 @@ import {
   podValueHash
 } from "@pcd/pod";
 import { PODPCD, PODPCDTypeName } from "@pcd/pod-pcd";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import {
   FixedPODEntries,
   PODPCDArgValidatorParams,
@@ -173,7 +173,7 @@ export function checkPODAgainstPrescribedSignerPublicKeys(
   try {
     return (
       prescribedSignerPublicKeys?.[podName] === undefined ||
-      _.isEqual(
+      isEqual(
         decodePublicKey(prescribedSignerPublicKeys[podName]),
         decodePublicKey(signerPublicKey)
       )

--- a/packages/tools/eslint-config-custom/index.js
+++ b/packages/tools/eslint-config-custom/index.js
@@ -8,7 +8,7 @@ module.exports = {
     "plugin:import/typescript"
   ],
   parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint", "react", "react-hooks", "prettier"],
+  plugins: ["@typescript-eslint", "react", "react-hooks", "prettier", "lodash"],
   ignorePatterns: ["*.d.ts"],
   rules: {
     "no-case-declarations": "off",
@@ -44,7 +44,8 @@ module.exports = {
           "CallExpression[callee.name='describe'] MemberExpression[object.type='ThisExpression'][property.name='timeout']",
         message: "Manual timeouts in Mocha tests are not allowed."
       }
-    ]
+    ],
+    "lodash/import-scope": ["error", "method"]
   },
   settings: {
     "import/resolver": {

--- a/packages/tools/eslint-config-custom/package.json
+++ b/packages/tools/eslint-config-custom/package.json
@@ -16,6 +16,7 @@
     "eslint-config-turbo": "^2.0.4",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-lodash": "^8.0.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react": "7.32.2",
     "typescript": "^5.3.3"

--- a/packages/ui/eddsa-frog-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/eddsa-frog-pcd-ui/src/CardBody.tsx
@@ -14,7 +14,7 @@ import {
   styled
 } from "@pcd/passport-ui";
 import { PCDUI } from "@pcd/pcd-types";
-import _ from "lodash";
+import startCase from "lodash/startCase";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 export const EdDSAFrogPCDUI: PCDUI<EdDSAFrogPCD> = {
@@ -193,7 +193,7 @@ function temperamentValue(temperament: Temperament): string {
 }
 
 function biomeValue(biome: Biome): string {
-  return _.startCase(Biome[biome]);
+  return startCase(Biome[biome]);
 }
 
 function FrogQR({ pcd }: { pcd: EdDSAFrogPCD }): JSX.Element {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11351,6 +11351,13 @@ eslint-plugin-jsx-a11y@^6.7.1:
     object.entries "^1.1.7"
     object.fromentries "^2.0.7"
 
+eslint-plugin-lodash@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-8.0.0.tgz#d2b20ae354a260ba875d5cc6b633f8bcde37f750"
+  integrity sha512-7DA8485FolmWRzh+8t4S8Pzin2TTuWfb0ZW3j/2fYElgk82ZanFz8vDcvc4BBPceYdX1p/za+tkbO68maDBGGw==
+  dependencies:
+    lodash "^4.17.21"
+
 eslint-plugin-prettier@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz#a3b399f04378f79f066379f544e42d6b73f11515"
@@ -19640,7 +19647,16 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -19773,7 +19789,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22123,7 +22146,7 @@ workspace-tools@^0.36.4:
     js-yaml "^4.1.0"
     micromatch "^4.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -22136,6 +22159,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-1200/replace-lodash-imports-with-specific-function-imports

Importing lodash like this: `import _ from "lodash";` imports the entire lodash library, which is often not what you want if you just want to call, say, `_.isEqual()`. Instead, you can do `import isEqual from "lodash/isEqual"`, which will import only the `isEqual` function and nothing else. Eliminating the unused code reduces the bundle size. Modern ESM libraries can be "tree-shaken" to eliminate dead code automatically, but lodash is not one of these.

In this PR, we avoid importing around 500KiB of uncompressed JavaScript by replacing all of the instances of `import _ from "lodash"` with imports of the specific functions to be used. The impact on final bundle size is somewhat smaller - maybe a 60KiB reduction in the size of the `passport-client` bundle - because lodash compresses very well. However, this will be a meaningful reduction in runtime parsing of the resulting JavaScript.

In addition to changing the existing imports, I've added an ESLint rule to ensure that no new top-level imports are added.

This was prompted by noticing that, for the reference PARCNET client build, the single largest dependency was `lodash`, as a result of it being imported by `@pcd/gpc`:

<img width="909" alt="image" src="https://github.com/user-attachments/assets/6cdef865-805e-402d-aafd-3d38b27027e8">