### PR TITLE
Add missing lodash dependency to gpc package

### DIFF
--- a/packages/lib/gpc/package.json
+++ b/packages/lib/gpc/package.json
@@ -33,7 +33,7 @@
     "@pcd/util": "0.5.4",
     "@semaphore-protocol/identity": "^3.15.2",
     "@semaphore-protocol/core": "^4.0.3",
-    "@types/lodash": "^4.17.1",
+    "lodash": "^4.17.21",
     "json-bigint": "^1.0.0",
     "snarkjs": "^0.7.4",
     "url-join": "^4.0.1"
@@ -42,6 +42,7 @@
     "@pcd/eslint-config-custom": "0.11.4",
     "@pcd/tsconfig": "0.11.4",
     "@types/chai": "^4.3.5",
+    "@types/lodash": "^4.17.1",
     "@types/mocha": "^10.0.1",
     "@types/snarkjs": "^0.7.5",
     "circomkit": "^0.0.24",


### PR DESCRIPTION
Adds a missing `lodash` dependency to `@pcd/gpc`, which I noticed when installing `@pcd/gpc` in a fresh repo.

Annoying that the `no-extraneous-dependencies` ESLint rule didn't catch it, I assume that the presence of the `@types/lodash` package was satisfying the requirement that the module be declared, even if the implementation was missing.