### PR TITLE
Bump `@zk-kit/baby-jubjub` and `@zk-kit/lean-imt`

### DIFF
--- a/packages/lib/pod/package.json
+++ b/packages/lib/pod/package.json
@@ -29,10 +29,10 @@
   },
   "dependencies": {
     "@pcd/util": "0.5.4",
-    "@zk-kit/baby-jubjub": "1.0.1",
+    "@zk-kit/baby-jubjub": "1.0.3",
     "@zk-kit/eddsa-poseidon": "1.0.3",
     "@zk-kit/lean-imt": "2.0.1",
-    "@zk-kit/utils": "1.2.0",
+    "@zk-kit/utils": "1.2.1",
     "js-sha256": "^0.10.1",
     "json-bigint": "^1.0.0",
     "poseidon-lite": "^0.2.1"

--- a/packages/lib/pod/package.json
+++ b/packages/lib/pod/package.json
@@ -31,7 +31,7 @@
     "@pcd/util": "0.5.4",
     "@zk-kit/baby-jubjub": "1.0.3",
     "@zk-kit/eddsa-poseidon": "1.0.3",
-    "@zk-kit/lean-imt": "2.0.1",
+    "@zk-kit/lean-imt": "2.2.1",
     "@zk-kit/utils": "1.2.1",
     "js-sha256": "^0.10.1",
     "json-bigint": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8146,19 +8146,19 @@
   resolved "https://registry.yarnpkg.com/@zk-kit/incremental-merkle-tree/-/incremental-merkle-tree-1.1.0.tgz#6b0ccce56f9e05ccf73f7ea4fa746d5ef7d24b1d"
   integrity sha512-WnNR/GQse3lX8zOHMU8zwhgX8u3qPoul8w4GjJ0WDHq+VGJimo7EGheRZ/ILeBQabnlzAerdv3vBqYBehBeoKA==
 
-"@zk-kit/lean-imt@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@zk-kit/lean-imt/-/lean-imt-2.0.1.tgz#78af48b384b083e4a3f003036a40a4ea3cb102c0"
-  integrity sha512-yc0rh9BCY6VvvKrZUNejfucuWscy1iRb9JrppuJktsiA9HcEukB3oX9CB7N/CUmCtqzmdwybet6N2aglGL/SUQ==
-  dependencies:
-    "@zk-kit/utils" "1.0.0"
-
 "@zk-kit/lean-imt@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@zk-kit/lean-imt/-/lean-imt-2.1.0.tgz#ca876463a0249fc3de76b2f8821c7af31f94998a"
   integrity sha512-RbG6QmTrurken7HzrJQouKiXKyGTpcoD+czQ1jvExRIA83k9w+SEsRdB7anPE8WoMKWAandDe09BzDCk6AirSw==
   dependencies:
     "@zk-kit/utils" "1.2.0"
+
+"@zk-kit/lean-imt@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@zk-kit/lean-imt/-/lean-imt-2.2.1.tgz#aa24ed3d281cff270013c3654fa1eec6f785ccef"
+  integrity sha512-Zq5yunUYu+ztp9RR5nuqiG1GpK1wjUoAjC0+x/MB95sI/Ns7zCxpzxo/Om9E0gme74Y3jO9KM5UUh3f9tqU++w==
+  dependencies:
+    "@zk-kit/utils" "1.2.1"
 
 "@zk-kit/utils@1.0.0":
   version "1.0.0"


### PR DESCRIPTION
In #1883 I bumped the version of `@zk-kit/eddsa-poseidon` which `@pcd/pod` depends on. However, the new version of `@zk-kit/eddsa-poseidon` depends on a higher version of `@zk-kit/utils` than `@zk-kit/baby-jubjub`, and now both of those versions get included in the bundle. This seems to be because `@zk-kit` specifies their dependencies with fixed version numbers (`1.2.0` rather than `^1.2.0` or `~1.2.0`) and so it's not possible to satisfy both dependency requirements with the same version even if the difference between dependency requirements is very small.

Secondly, we also do the same thing with our dependencies on `@zk-kit/*`, specifying the exact version numbers rather than just the major version number (by prefixing the version with `^`) or the minor version number (by prefixing with `~`).

We also have a dependency on `@zk-kit/lean-imt` which pulls in a _third_ version of `@zk-kit/utils`, because we depend on `@zk-kit/lean-imt@2.0.1`, which depends on `@zk-kit/utils`.

If we think that the `@zk-kit` project is using semantic versioning correctly, we should consider changing our dependencies to use the `^` prefix, which would allow newer versions of the `@zk-kit` packages to be used in dependency resolution, and reduce the likelihood of having multiple versions of packages being included in JavaScript bundles in order to satisfy overly restrictive dependency requirements.