### PR TITLE
chore(examples): fixes small bug in `pod-gcp-example`

### DIFF
--- a/examples/pod-gpc-example/src/podExample.ts
+++ b/examples/pod-gpc-example/src/podExample.ts
@@ -128,8 +128,11 @@ export async function podDemo(): Promise<boolean> {
   console.log("PODContent ID", podContent.contentID);
 
   // PODContent is a Map-like class with accessors for getting values.
-  console.log("PODContent value (with type)", podContent.getValue("someNumer"));
-  console.log("PODContent raw value", podContent.getRawValue("someNumer"));
+  console.log(
+    "PODContent value (with type)",
+    podContent.getValue("someNumber")
+  );
+  console.log("PODContent raw value", podContent.getRawValue("someNumber"));
 
   // PODContent can generate Merkle membership proofs which prove that an entry
   // is contained in a given root.  This is the basis of the ZK proofs which
@@ -149,7 +152,7 @@ export async function podDemo(): Promise<boolean> {
   const signature = pod.signature;
 
   // You can get the underlying PODContent from a POD if you need it.
-  console.log("POD value", pod.content.getValue("someNumer"));
+  console.log("POD value", pod.content.getValue("someNumber"));
 
   // If you already have the signature from a saved POD, you can
   // recreate it without signing again.

--- a/examples/pod-gpc-example/src/podExample.ts
+++ b/examples/pod-gpc-example/src/podExample.ts
@@ -69,7 +69,7 @@ export async function podDemo(): Promise<boolean> {
   // to use as variable identifiers.
   //
   // Entry values are represented by a PODValue, which includes a value and type.
-  // The type controls how the value is hashed and inclued in ZK proofs.
+  // The type controls how the value is hashed and included in ZK proofs.
   // The type itself is not part of the value, and is not hashed.
   // Currently supported types are "string", "int", and "cryptographic".
   //
@@ -85,11 +85,11 @@ export async function podDemo(): Promise<boolean> {
     // supported in future.
     someNumber: { type: "int", value: -123n },
 
-    // "cryptographic" is a bigint type for values like hashes or uniquue
+    // "cryptographic" is a bigint type for values like hashes or unique
     // IDs.  Each is a single field element which fits in a circuit signal,
     // meaning an integer mod p for a large (254 bit) prime.
     // In proofs, these values can be compared for equality, but not manipulated
-    // arithmatically (no addition, less-than, etc).
+    // arithmetically (no addition, less-than, etc).
     mySemaphoreID: {
       type: "cryptographic",
 
@@ -235,10 +235,10 @@ export async function podDemo(): Promise<boolean> {
 
   // All PCDs can be verified, which makes use of cryptographic info in the
   // proof field.  In this case, it's checking the signature on the content ID
-  // deroved from the entries.
+  // derived from the entries.
   console.log("PCD is valid?", await PODPCDPackage.verify(pcd));
 
-  // PCDs can also be creatd by the "prove" interface.  This uses a more generic
+  // PCDs can also be created by the "prove" interface.  This uses a more generic
   // (and more verbose) argument specification which allows requests to prove
   // to be transmitted to apps like Zupass.
   const pcd2 = await PODPCDPackage.prove({


### PR DESCRIPTION
### Description

1. fixes small bug in variable name 64d367aa66c1e200cfeacba2c2538a1e4f9cbdb6

### Other changes

1. fixes small typo in code comments eb735e8be7886e32c62e0e356ea7679089be222a

### Tested

Yes

1. Build top-level directory

   ```sh
   # in zupass directory
   yarn
   ```

1. Build `pod-gpc-example`

   ```sh
   # in zupass/examples/pod-gpc-example
   yarn build
   ```

1. Run example

   ```sh
   # in zupass/examples/pod-gpc-example
   yarn test
   ```

    Before:
        
    ```sh
    yarn test
    # ...
    PODContent value (with type) undefined
    PODContent raw value undefined
    # ...
    ```
    
    After:
    
    ```sh
    yarn test
    # ...
    PODContent value (with type) { type: 'int', value: -123n }
    PODContent raw value -123n
    # ...
    ```

### Related issues

None

### Backwards compatibility

Yes, only improves what is printed to the console.

### Documentation

None