### PR TITLE
Turbo dependencies for gpcircuits

### DIFF
--- a/packages/lib/gpcircuits/package.json
+++ b/packages/lib/gpcircuits/package.json
@@ -31,7 +31,7 @@
     "clean": "rm -rf dist node_modules *.tsbuildinfo build circuits/test ptau && yarn clean-test-artifacts",
     "gen-circuit-parameters": "npx tsx scripts/gen-circuit-parameters.ts",
     "gen-test-artifacts": "npx tsx scripts/gen-test-artifacts.ts",
-    "clean-test-artifacts": "rm -rf artifacts/test",
+    "clean-test-artifacts": "rm -rf artifacts/test circuits/main",
     "copy-test-to-snark-artifacts": "./scripts/copy-test-to-snark-artifacts.sh"
   },
   "dependencies": {

--- a/packages/lib/gpcircuits/turbo.json
+++ b/packages/lib/gpcircuits/turbo.json
@@ -10,10 +10,12 @@
         "../../../node_modules/@zk-kit/circuits/**",
         "scripts/gen-test-artifacts.ts",
         "circuits/**",
+        "!circuits/test/**",
+        "!circuits/main/**",
         "circomkit.json",
         "circuits.json"
       ],
-      "outputs": ["artifacts/**"],
+      "outputs": ["artifacts/**", "circuits/main/**"],
       "outputLogs": "new-only",
       "cache": true
     },
@@ -23,6 +25,8 @@
         "$TURBO_DEFAULT$",
         "src/**",
         "circuits/**",
+        "!circuits/test/**",
+        "!circuits/main/**",
         "circomkit.json",
         "circuits.json"
       ],
@@ -31,7 +35,13 @@
     },
     "test": {
       "dependsOn": ["build", "^gen-test-artifacts", "gen-test-artifacts"],
-      "inputs": ["$TURBO_DEFAULT$", "test/**", "artifacts/**"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "test/**",
+        "artifacts/**",
+        "circuits/**",
+        "!circuits/test/**"
+      ],
       "outputs": [],
       "cache": true
     }


### PR DESCRIPTION
Fixed some cases I saw where Turbo caching wasn't effective.  The observed behavior was that gpcircuits tests had to run an extra time before "settling" and using the cache.  This seems to have been due to the generated circuit files in circuits/main and circuits/test.  Including or excluding those in inputs/outputs appropriately seems to have solved the problem.
