### PR TITLE
Vertical scroll for POD & GPC PCDs

### DIFF
--- a/packages/ui/gpc-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/gpc-pcd-ui/src/CardBody.tsx
@@ -48,14 +48,18 @@ function GPCCardBody({ pcd }: { pcd: GPCPCD }): JSX.Element {
 
       <FieldLabel>Proof Config</FieldLabel>
       <p>This specifies what has been proven and revealed.</p>
-      <TextContainer style={{ overflowX: "auto" }}>
+      <TextContainer
+        style={{ overflowX: "auto", maxHeight: "200px", overflowY: "auto" }}
+      >
         <pre>{serializeGPCBoundConfig(pcd.claim.config, 2)}</pre>
       </TextContainer>
       <Spacer h={8} />
 
       <FieldLabel>Revealed Claims</FieldLabel>
       <p>These are the entries and metadata revealed in the proof.</p>
-      <TextContainer style={{ overflowX: "auto" }}>
+      <TextContainer
+        style={{ overflowX: "auto", maxHeight: "200px", overflowY: "auto" }}
+      >
         <pre>{serializeGPCRevealedClaims(pcd.claim.revealed, 2)}</pre>
       </TextContainer>
       <Spacer h={8} />

--- a/packages/ui/pod-pcd-ui/src/renderers/DefaultPODPCDCardBody.tsx
+++ b/packages/ui/pod-pcd-ui/src/renderers/DefaultPODPCDCardBody.tsx
@@ -18,7 +18,9 @@ export function DefaultPODPCDCardBody({ pcd }: { pcd: PODPCD }): JSX.Element {
       </p>
       <Separator />
       <FieldLabel>POD Entries</FieldLabel>
-      <TextContainer style={{ overflowX: "auto" }}>
+      <TextContainer
+        style={{ overflowX: "auto", maxHeight: "300px", overflowY: "auto" }}
+      >
         <pre>{podEntriesToSimplifiedJSON(pcd.claim.entries, 2)}</pre>
       </TextContainer>
       <Spacer h={8} />


### PR DESCRIPTION
Add vertical scrolling to POD-PCD and GPC-PCD
Closes https://linear.app/0xparc-pcd/issue/0XP-1087/vertical-scrolling-for-podgpc-display-text

Note this PR is dependent on #1881.  This happened because my local test server is broken without UnknownPCD.  Which I could ignore, but I see this is a reasonable test case to see how to get stacked PRs to work.  I've marked this as merging into the parent PR's branch, and I'll figure out later how to update it when the parent PR merges.