### PR TITLE
Remove circomlibjs dependency in favor of zk-kit

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,23 @@
       "port": 4321,
       "restart": true,
       "cwd": "${workspaceRoot}"
+    },
+    {
+      "args": [
+        "-r",
+        "ts-node/register",
+        "--config",
+        "${workspaceFolder}/.mocharc.js",
+        "--no-timeouts",
+        "--exit",
+        "${file}"
+      ],
+      "cwd": "${fileDirname}",
+      "internalConsoleOptions": "openOnSessionStart",
+      "name": "TS Mocha Test (Current File)",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "request": "launch",
+      "type": "node"
     }
   ]
 }

--- a/apps/consumer-client/package.json
+++ b/apps/consumer-client/package.json
@@ -37,7 +37,7 @@
     "@semaphore-protocol/identity": "^3.15.2",
     "@simplewebauthn/browser": "^7.2.0",
     "@simplewebauthn/server": "^7.2.0",
-    "@zk-kit/eddsa-poseidon": "1.0.2",
+    "@zk-kit/eddsa-poseidon": "1.0.3",
     "dotenv": "^16.0.3",
     "ethers": "^5.7.2",
     "json-bigint": "^1.0.0",

--- a/apps/passport-server/package.json
+++ b/apps/passport-server/package.json
@@ -52,7 +52,6 @@
     "@sendgrid/mail": "^7.7.0",
     "@types/lodash": "^4.14.191",
     "@types/pg": "^8.6.6",
-    "@zk-kit/eddsa-poseidon": "1.0.2",
     "async-lock": "^1.4.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",

--- a/apps/zupoll-client/package.json
+++ b/apps/zupoll-client/package.json
@@ -66,7 +66,6 @@
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@pcd/eslint-config-custom": "0.11.4",
     "@pcd/tsconfig": "0.11.4",
-    "@types/circomlibjs": "^0.1.5",
     "@types/expect": "^24.3.0",
     "@types/fuzzy-search": "^2.1.5",
     "@types/json-stable-stringify": "^1.0.34",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "postinstall": "patch-package"
   },
   "devDependencies": {
-    "@types/circomlibjs": "0.1.6",
     "@types/node": "^20.11.28",
     "plop": "^4.0.1",
     "prettier": "^3.0.0",

--- a/packages/lib/gpc/package.json
+++ b/packages/lib/gpc/package.json
@@ -49,7 +49,7 @@
     "eslint": "^8.57.0",
     "fix-esm-import-path": "^1.10.0",
     "mocha": "^10.2.0",
-    "poseidon-lite": "^0.2.1",
+    "poseidon-lite": "^0.3.0",
     "ts-mocha": "^10.0.0",
     "typescript": "^5.3.3"
   },

--- a/packages/lib/gpcircuits/package.json
+++ b/packages/lib/gpcircuits/package.json
@@ -56,7 +56,7 @@
     "fix-esm-import-path": "^1.10.0",
     "lodash": "^4.17.21",
     "mocha": "^10.2.0",
-    "poseidon-lite": "^0.2.1",
+    "poseidon-lite": "^0.3.0",
     "ts-mocha": "^10.0.0",
     "typescript": "^5.3.3"
   },

--- a/packages/lib/pod/package.json
+++ b/packages/lib/pod/package.json
@@ -43,6 +43,7 @@
     "@pcd/pcd-types": "0.11.4",
     "@pcd/tsconfig": "0.11.4",
     "@semaphore-protocol/identity": "^3.15.2",
+    "@types/circomlibjs": "^0.1.6",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
     "circomlibjs": "^0.1.7",

--- a/packages/lib/pod/package.json
+++ b/packages/lib/pod/package.json
@@ -35,7 +35,7 @@
     "@zk-kit/utils": "1.2.1",
     "js-sha256": "^0.10.1",
     "json-bigint": "^1.0.0",
-    "poseidon-lite": "^0.2.1"
+    "poseidon-lite": "^0.3.0"
   },
   "devDependencies": {
     "@pcd/eddsa-pcd": "0.6.5",

--- a/packages/pcd/eddsa-pcd/package.json
+++ b/packages/pcd/eddsa-pcd/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@pcd/pcd-types": "0.11.4",
     "@pcd/util": "0.5.4",
-    "circomlibjs": "^0.1.7",
+    "@zk-kit/eddsa-poseidon": "1.0.3",
     "poseidon-lite": "^0.3.0",
     "uuid": "^9.0.0"
   },

--- a/packages/pcd/eddsa-pcd/package.json
+++ b/packages/pcd/eddsa-pcd/package.json
@@ -41,7 +41,6 @@
   "devDependencies": {
     "@pcd/eslint-config-custom": "0.11.4",
     "@pcd/tsconfig": "0.11.4",
-    "@types/circomlibjs": "^0.1.6",
     "@types/mocha": "^10.0.1",
     "@types/uuid": "^9.0.0",
     "chai": "^4.3.7",

--- a/packages/pcd/eddsa-pcd/package.json
+++ b/packages/pcd/eddsa-pcd/package.json
@@ -35,6 +35,7 @@
     "@pcd/pcd-types": "0.11.4",
     "@pcd/util": "0.5.4",
     "circomlibjs": "^0.1.7",
+    "poseidon-lite": "^0.3.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/pcd/eddsa-pcd/package.json
+++ b/packages/pcd/eddsa-pcd/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@pcd/eslint-config-custom": "0.11.4",
     "@pcd/tsconfig": "0.11.4",
+    "@types/circomlibjs": "^0.1.6",
     "@types/mocha": "^10.0.1",
     "@types/uuid": "^9.0.0",
     "chai": "^4.3.7",

--- a/packages/pcd/eddsa-pcd/src/EDDSAPCDPackage.ts
+++ b/packages/pcd/eddsa-pcd/src/EDDSAPCDPackage.ts
@@ -1,6 +1,20 @@
 import { DisplayOptions, PCDPackage, SerializedPCD } from "@pcd/pcd-types";
 import { fromHexString, requireDefinedParameter, toHexString } from "@pcd/util";
-import { Eddsa, Point, buildEddsa } from "circomlibjs";
+import { Point } from "@zk-kit/baby-jubjub";
+import {
+  derivePublicKey,
+  packSignature,
+  signMessage,
+  unpackSignature,
+  verifySignature
+} from "@zk-kit/eddsa-poseidon";
+import {
+  poseidon1,
+  poseidon12,
+  poseidon13,
+  poseidon2,
+  poseidon3
+} from "poseidon-lite";
 import { v4 as uuid } from "uuid";
 import {
   EdDSAInitArgs,
@@ -12,31 +26,11 @@ import {
   EdDSAPublicKey
 } from "./EdDSAPCD";
 
-let initializedPromise: Promise<void> | undefined;
-let eddsa: Eddsa;
-
-/**
- * A promise designed to make sure that the EdDSA algorithm
- * of the `circomlibjs` package has been properly initialized.
- * It only initializes them once.
- */
-async function ensureInitialized(): Promise<void> {
-  if (!initializedPromise) {
-    initializedPromise = (async (): Promise<void> => {
-      eddsa = await buildEddsa();
-    })();
-  }
-
-  await initializedPromise;
-}
-
 /**
  * Creates a new {@link EdDSAPCD} by generating an {@link EdDSAPCDProof}
  * and deriving an {@link EdDSAPCDClaim} from the given {@link EdDSAPCDArgs}.
  */
 export async function prove(args: EdDSAPCDArgs): Promise<EdDSAPCD> {
-  await ensureInitialized();
-
   let message;
 
   if (!args.privateKey.value) throw new Error("No private key value provided");
@@ -60,16 +54,12 @@ export async function prove(args: EdDSAPCDArgs): Promise<EdDSAPCD> {
   const id = typeof args.id.value === "string" ? args.id.value : uuid();
   const prvKey = fromHexString(args.privateKey.value);
 
-  const hashedMessage = eddsa.poseidon(message);
+  const hashedMessage = poseidonHashMessage(message);
   const publicKey = await getEdDSAPublicKey(prvKey);
 
   // Make the signature on the message.
-  // Note: packSignature converts the R8 coordinates from Mongtomery form to
-  // standard form for use outside of circomlibjs.
-  // This is a reference to Montgomery form of numbers for modular
-  // multiplication, NOT Montgomery form of eliptic curves.  See https://en.wikipedia.org/wiki/Montgomery_modular_multiplication#Montgomery_form
   const signature = toHexString(
-    eddsa.packSignature(eddsa.signPoseidon(prvKey, hashedMessage))
+    packSignature(signMessage(prvKey, hashedMessage))
   );
 
   return new EdDSAPCD(id, { message, publicKey }, { signature });
@@ -81,22 +71,20 @@ export async function prove(args: EdDSAPCDArgs): Promise<EdDSAPCD> {
  */
 export async function verify(pcd: EdDSAPCD): Promise<boolean> {
   try {
-    await ensureInitialized();
-
-    const signature = eddsa.unpackSignature(fromHexString(pcd.proof.signature));
+    const signature = unpackSignature(fromHexString(pcd.proof.signature));
 
     // Note: `F.fromObject` converts a coordinate from standard format to
     // Montgomery form, which is expected by circomlibjs.  unpackSignature above
     // does the same for its R8 point.
     // This is a reference to Montgomery form of numbers for modular
     // multiplication, NOT Montgomery form of eliptic curves.  See https://en.wikipedia.org/wiki/Montgomery_modular_multiplication#Montgomery_form
-    const pubKey = pcd.claim.publicKey.map((p) =>
-      eddsa.F.fromObject(p)
+    const pubKey = pcd.claim.publicKey.map((coordinateString: string) =>
+      BigInt("0x" + coordinateString)
     ) as Point;
 
-    const hashedMessage = eddsa.poseidon(pcd.claim.message);
+    const hashedMessage = poseidonHashMessage(pcd.claim.message);
 
-    return eddsa.verifyPoseidon(hashedMessage, signature, pubKey);
+    return verifySignature(hashedMessage, signature, pubKey);
   } catch {
     return false;
   }
@@ -205,17 +193,37 @@ export const EdDSAPCDPackage: PCDPackage<
 export async function getEdDSAPublicKey(
   privateKey: string | Uint8Array
 ): Promise<EdDSAPublicKey> {
-  await ensureInitialized();
-
   if (typeof privateKey === "string") {
     privateKey = fromHexString(privateKey);
   }
 
-  return eddsa.prv2pub(privateKey).map((p) =>
-    // Note: `F.toObject` converts a point from the Montgomery format used by
-    // circomlibjs to standard form.
-    // This is a reference to Montgomery form of numbers for modular
-    // multiplication, NOT Montgomery form of eliptic curves.  See https://en.wikipedia.org/wiki/Montgomery_modular_multiplication#Montgomery_form
-    eddsa.F.toObject(p).toString(16).padStart(64, "0")
+  return derivePublicKey(privateKey).map((coordinate: bigint) =>
+    coordinate.toString(16).padStart(64, "0")
   ) as EdDSAPublicKey;
+}
+
+function poseidonHashMessage(message: bigint[]): bigint {
+  switch (message.length) {
+    case 1:
+      // Used by PODs for value hashing, so no extra bundle size impact.
+      return poseidon1(message);
+    case 2:
+      // UYsed by PODs for Merkle tree hasing, so no extra bundle size impact.
+      return poseidon2(message);
+    case 3:
+      // Needed for backward-compatibility tests.
+      // TODO(artwyman): Alter backward-compatibility test case to use a different size
+      return poseidon3(message);
+    case 12:
+      // Tailored to the size of EdDSATicketPCD.
+      return poseidon12(message);
+    case 13:
+      // Tailored to the size of EdDSAFrogPCD.
+      return poseidon13(message);
+    default:
+      break;
+  }
+  throw new Error(
+    `Unsupported EdDSAMessagePCD message size ${message.length}.`
+  );
 }

--- a/packages/pcd/eddsa-pcd/src/EDDSAPCDPackage.ts
+++ b/packages/pcd/eddsa-pcd/src/EDDSAPCDPackage.ts
@@ -7,13 +7,11 @@ import {
   unpackSignature,
   verifySignature
 } from "@zk-kit/eddsa-poseidon";
-import {
-  poseidon1,
-  poseidon12,
-  poseidon13,
-  poseidon2,
-  poseidon3
-} from "poseidon-lite";
+import { poseidon1 } from "poseidon-lite/poseidon1";
+import { poseidon12 } from "poseidon-lite/poseidon12";
+import { poseidon13 } from "poseidon-lite/poseidon13";
+import { poseidon2 } from "poseidon-lite/poseidon2";
+import { poseidon3 } from "poseidon-lite/poseidon3";
 import { v4 as uuid } from "uuid";
 import {
   EdDSAInitArgs,
@@ -207,11 +205,11 @@ function poseidonHashMessage(message: bigint[]): bigint {
       // Used by PODs for value hashing, so no extra bundle size impact.
       return poseidon1(message);
     case 2:
-      // UYsed by PODs for Merkle tree hasing, so no extra bundle size impact.
+      // Used by PODs for Merkle tree hasing, so no extra bundle size impact.
       return poseidon2(message);
     case 3:
-      // Needed for backward-compatibility tests.
-      // TODO(artwyman): Alter backward-compatibility test case to use a different size
+      // Used by unit tests, including backward-compatibility with fixed values.
+      // Used by GPCs for tuple hasing, so no extra bundle size impact.
       return poseidon3(message);
     case 12:
       // Tailored to the size of EdDSATicketPCD.

--- a/packages/pcd/eddsa-pcd/src/EDDSAPCDPackage.ts
+++ b/packages/pcd/eddsa-pcd/src/EDDSAPCDPackage.ts
@@ -1,6 +1,5 @@
 import { DisplayOptions, PCDPackage, SerializedPCD } from "@pcd/pcd-types";
 import { fromHexString, requireDefinedParameter, toHexString } from "@pcd/util";
-import { Point } from "@zk-kit/baby-jubjub";
 import {
   derivePublicKey,
   packSignature,
@@ -80,7 +79,7 @@ export async function verify(pcd: EdDSAPCD): Promise<boolean> {
     // multiplication, NOT Montgomery form of eliptic curves.  See https://en.wikipedia.org/wiki/Montgomery_modular_multiplication#Montgomery_form
     const pubKey = pcd.claim.publicKey.map((coordinateString: string) =>
       BigInt("0x" + coordinateString)
-    ) as Point;
+    ) as [bigint, bigint];
 
     const hashedMessage = poseidonHashMessage(pcd.claim.message);
 

--- a/packages/pcd/semaphore-identity-pcd/package.json
+++ b/packages/pcd/semaphore-identity-pcd/package.json
@@ -40,7 +40,7 @@
     "json-bigint": "^1.0.0",
     "@types/json-bigint": "^1.0.3",
     "@zk-kit/eddsa-poseidon": "1.0.3",
-    "@zk-kit/utils": "^1.2.0",
+    "@zk-kit/utils": "^1.2.1",
     "js-sha256": "^0.11.0",
     "poseidon-lite": "^0.3.0",
     "uuid": "^9.0.0"

--- a/packages/pcd/zk-eddsa-event-ticket-pcd/package.json
+++ b/packages/pcd/zk-eddsa-event-ticket-pcd/package.json
@@ -42,7 +42,7 @@
     "@pcd/snarkjs": "0.7.7",
     "@pcd/util": "0.5.4",
     "@semaphore-protocol/identity": "^3.15.2",
-    "circomlibjs": "^0.1.7",
+    "@zk-kit/eddsa-poseidon": "1.0.3",
     "json-bigint": "^1.0.0",
     "snarkjs": "^0.7.4",
     "uuid": "^9.0.0"
@@ -51,7 +51,6 @@
     "@pcd/artifacts": "0.4.4",
     "@pcd/eslint-config-custom": "0.11.4",
     "@pcd/tsconfig": "0.11.4",
-    "@types/circomlibjs": "^0.1.6",
     "@types/json-bigint": "^1.0.1",
     "@types/mocha": "^10.0.1",
     "@types/snarkjs": "^0.7.5",

--- a/packages/pcd/zk-eddsa-event-ticket-pcd/package.json
+++ b/packages/pcd/zk-eddsa-event-ticket-pcd/package.json
@@ -51,6 +51,7 @@
     "@pcd/artifacts": "0.4.4",
     "@pcd/eslint-config-custom": "0.11.4",
     "@pcd/tsconfig": "0.11.4",
+    "@types/circomlibjs": "^0.1.6",
     "@types/json-bigint": "^1.0.1",
     "@types/mocha": "^10.0.1",
     "@types/snarkjs": "^0.7.5",

--- a/packages/pcd/zk-eddsa-frog-pcd/package.json
+++ b/packages/pcd/zk-eddsa-frog-pcd/package.json
@@ -41,7 +41,7 @@
     "@pcd/semaphore-signature-pcd": "0.11.6",
     "@pcd/util": "0.5.4",
     "@semaphore-protocol/identity": "^3.15.2",
-    "circomlibjs": "^0.1.7",
+    "@zk-kit/eddsa-poseidon": "1.0.3",
     "json-bigint": "^1.0.0",
     "snarkjs": "^0.7.4",
     "uuid": "^9.0.0"
@@ -50,7 +50,6 @@
     "@pcd/artifacts": "0.4.4",
     "@pcd/eslint-config-custom": "0.11.4",
     "@pcd/tsconfig": "0.11.4",
-    "@types/circomlibjs": "^0.1.6",
     "@types/json-bigint": "^1.0.1",
     "@types/mocha": "^10.0.1",
     "@types/snarkjs": "^0.7.5",

--- a/packages/pcd/zk-eddsa-frog-pcd/package.json
+++ b/packages/pcd/zk-eddsa-frog-pcd/package.json
@@ -50,6 +50,7 @@
     "@pcd/artifacts": "0.4.4",
     "@pcd/eslint-config-custom": "0.11.4",
     "@pcd/tsconfig": "0.11.4",
+    "@types/circomlibjs": "^0.1.6",
     "@types/json-bigint": "^1.0.1",
     "@types/mocha": "^10.0.1",
     "@types/snarkjs": "^0.7.5",

--- a/test-packaging/zupass-feed-server/package.json
+++ b/test-packaging/zupass-feed-server/package.json
@@ -9,7 +9,6 @@
   "private": true,
   "devDependencies": {
     "@pcd/eslint-config-custom": "*",
-    "@types/circomlibjs": "^0.1.6",
     "@types/cors": "^2.8.14",
     "@types/express": "^4.17.17",
     "@types/json-bigint": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18010,11 +18010,6 @@ poseidon-lite@^0.0.2:
   resolved "https://registry.yarnpkg.com/poseidon-lite/-/poseidon-lite-0.0.2.tgz#dc1a7c57f9393a586c5c9efc21b72b77e2c1acb6"
   integrity sha512-bGdDPTOQkJbBjbtSEWc3gY+YhqlGTxGlZ8041F8TGGg5QyGGp1Cfs4b8AEnFFjHbkPg6WdWXUgEjU1GKOKWAPw==
 
-poseidon-lite@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/poseidon-lite/-/poseidon-lite-0.2.1.tgz#7ad98e3a3aa5b91a1fd3a61a87460e9e46fd76d6"
-  integrity sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==
-
 poseidon-lite@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/poseidon-lite/-/poseidon-lite-0.3.0.tgz#93c42f6f9b870f154f2722dfd686b909c4285765"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8171,14 +8171,14 @@
   dependencies:
     buffer "^6.0.3"
 
-"@zk-kit/utils@1.2.0", "@zk-kit/utils@^1.2.0":
+"@zk-kit/utils@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@zk-kit/utils/-/utils-1.2.0.tgz#7f5dfadb9512f1a090639c912395a6684b560ba2"
   integrity sha512-Ut9zfnlBVpopZG/s600Ds/FPSWXiPhO4q8949kmXTzwDXytjnvFbDZIFdWqE/lA7/NZjvykiTnnVwmanMxv2+w==
   dependencies:
     buffer "^6.0.3"
 
-"@zk-kit/utils@1.2.1":
+"@zk-kit/utils@1.2.1", "@zk-kit/utils@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@zk-kit/utils/-/utils-1.2.1.tgz#6cb38120535c73ab68cd0f09684882af148f256d"
   integrity sha512-H2nTsyWdicVOyvqC5AjgU7tsTgmR6PDrruFJNmlmdhKp7RxEia/E1B1swMZjaasYa2QMp4Zc6oB7cWchty7B2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6664,7 +6664,7 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.11.tgz#e95050bf79a932cb7305dd130254ccdf9bde671c"
   integrity sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==
 
-"@types/circomlibjs@0.1.6", "@types/circomlibjs@^0.1.5":
+"@types/circomlibjs@^0.1.6":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@types/circomlibjs/-/circomlibjs-0.1.6.tgz#dba1b9cc68ae4f75da045b8b14c50f3444b31d7f"
   integrity sha512-yF174bPDaiKgejlZzCSqKwZaqXhlxMcVEHrAtstFohwP05OjtvHXOdxO6HQeTg8WwIdgMg7MJb1WyWZdUCGlPQ==
@@ -20285,7 +20285,16 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -20418,7 +20427,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22827,7 +22843,7 @@ workspace-tools@^0.36.4:
     js-yaml "^4.1.0"
     micromatch "^4.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -22840,6 +22856,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Minimalist approach to switching away from circomlibjs in order to eliminate its massive poseidon_constants from our bundle size.  This drops the bundle size in my measurements from 9.4MB to 6.4MB.

Functionality remains unchanged (validated by pre-existing backward compatibility tests), with one known exception.  The EdDSA PCD now only supports "messages" (bigint arrays) of sizes in the set {1, 2, 3, 12, 13}.  Other sizes will throw an error at proving time.  This is because poseidon-lite also has a set of constants (albeit much smaller than circomlibjs) needed for each size.  There are comments in the code explaining why each size was selected.

Two things explicitly not done, given the minimalist approach:

- This PR doesn't attempt to unify/centralize uses of zk-kit/poseidon-lite into a single package.  Instead the old EdDSA PCDs use the appropriate zk-kit/poseidon-lite libraries directly.
- This PR also doesn't change the format (in code, or in serialization) of EdDSA keys to match the new form used by PODs.  All externally-visible formats are kept unchanged.