### PR TITLE
Replace external constant which has side-effects with internal constant declaration that does not

### DIFF
--- a/packages/lib/pod/package.json
+++ b/packages/lib/pod/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@pcd/util": "0.5.4",
-    "@zk-kit/baby-jubjub": "1.0.3",
     "@zk-kit/eddsa-poseidon": "1.0.3",
     "@zk-kit/lean-imt": "2.2.1",
     "@zk-kit/utils": "1.2.1",
@@ -46,6 +45,7 @@
     "@types/circomlibjs": "^0.1.6",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
+    "@zk-kit/baby-jubjub": "1.0.3",
     "circomlibjs": "^0.1.7",
     "eslint": "^8.57.0",
     "fix-esm-import-path": "^1.10.0",

--- a/packages/lib/pod/src/podTypes.ts
+++ b/packages/lib/pod/src/podTypes.ts
@@ -1,9 +1,3 @@
-// Prime order of the alt_bn128 curve.
-// Should always be equal to the `r` constant in @zk-kit/baby-jubjub.
-export const BabyJubjubR = BigInt(
-  "21888242871839275222246405745257275088548364400416034343698204186575808495617"
-);
-
 /**
  * Name of a POD entry is a string with a limited character set, checked using
  * {@link POD_NAME_REGEX}.
@@ -62,7 +56,11 @@ export const POD_CRYPTOGRAPHIC_MIN = 0n;
 /**
  * Maximum legal value of a `cryptographic` entry value.
  */
-export const POD_CRYPTOGRAPHIC_MAX = BabyJubjubR - 1n;
+export const POD_CRYPTOGRAPHIC_MAX =
+  // Prime order of the alt_bn128 curve.
+  // Should always be equal to the `r` constant in @zk-kit/baby-jubjub.
+  21888242871839275222246405745257275088548364400416034343698204186575808495617n -
+  1n;
 
 /**
  * POD value for constrained integer values intended for comparison and

--- a/packages/lib/pod/src/podTypes.ts
+++ b/packages/lib/pod/src/podTypes.ts
@@ -1,4 +1,8 @@
-import { r as BabyJubjubR } from "@zk-kit/baby-jubjub";
+// Prime order of the alt_bn128 curve.
+// Should always be equal to the `r` constant in @zk-kit/baby-jubjub.
+export const BabyJubjubR = BigInt(
+  "21888242871839275222246405745257275088548364400416034343698204186575808495617"
+);
 
 /**
  * Name of a POD entry is a string with a limited character set, checked using

--- a/packages/lib/pod/test/podTypes.spec.ts
+++ b/packages/lib/pod/test/podTypes.spec.ts
@@ -1,0 +1,10 @@
+import { r } from "@zk-kit/baby-jubjub";
+import { expect } from "chai";
+import "mocha";
+import { BabyJubjubR } from "../src/podTypes";
+
+describe("POD type values should be correct", () => {
+  it("should have the correct BabyJubjubR constant", () => {
+    expect(BabyJubjubR).to.equal(r);
+  });
+});

--- a/packages/lib/pod/test/podTypes.spec.ts
+++ b/packages/lib/pod/test/podTypes.spec.ts
@@ -2,11 +2,11 @@ import { BABY_JUB_PRIME } from "@pcd/util";
 import { r } from "@zk-kit/baby-jubjub";
 import { expect } from "chai";
 import "mocha";
-import { BabyJubjubR } from "../src/podTypes";
+import { POD_CRYPTOGRAPHIC_MAX } from "../src/podTypes";
 
 describe("POD type values should be correct", () => {
   it("should have the correct BabyJubjubR constant", () => {
-    expect(BabyJubjubR).to.equal(r);
-    expect(BabyJubjubR).to.equal(BABY_JUB_PRIME);
+    expect(POD_CRYPTOGRAPHIC_MAX + 1n).to.equal(r);
+    expect(POD_CRYPTOGRAPHIC_MAX + 1n).to.equal(BABY_JUB_PRIME);
   });
 });

--- a/packages/lib/pod/test/podTypes.spec.ts
+++ b/packages/lib/pod/test/podTypes.spec.ts
@@ -1,3 +1,4 @@
+import { BABY_JUB_PRIME } from "@pcd/util";
 import { r } from "@zk-kit/baby-jubjub";
 import { expect } from "chai";
 import "mocha";
@@ -6,5 +7,6 @@ import { BabyJubjubR } from "../src/podTypes";
 describe("POD type values should be correct", () => {
   it("should have the correct BabyJubjubR constant", () => {
     expect(BabyJubjubR).to.equal(r);
+    expect(BabyJubjubR).to.equal(BABY_JUB_PRIME);
   });
 });


### PR DESCRIPTION
In `podTypes.ts` we import the `r` constant from `@zk-kit/baby-jubjub`. This is declared [here](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/packages/baby-jubjub/src/baby-jubjub.ts) in `@zk-kit/baby-jubjub`, in a file which contains a mix of constant declarations and side-effecting imports. In particular, it imports and instantiates the `F1Field` class, which means that it's also necessary to import `@zk-kit/utils/f1-field`, and it also imports `leBigIntToBuffer`, which depends on the Buffer polyfill.

I'm a bit disappointed that neither Rollup nor esbuild are capable of detecting that we only want this single constant and not any of the other things imported or instantiated in the same file that the constant is declared in, but after testing various confgurations it seems that they truly are not.

Therefore, to avoid consumers of `@pcd/pod` having to import these external dependencies, we can re-declare the constant and verify that it has the correct value using tests.