### PR TITLE
automatically resize iframe for zapp screen

### DIFF
--- a/apps/passport-client/components/screens/ZappScreens/ZappScreen.tsx
+++ b/apps/passport-client/components/screens/ZappScreens/ZappScreen.tsx
@@ -1,3 +1,4 @@
+import IframeResizer from "iframe-resizer-react";
 import { ReactNode } from "react";
 import { useDispatch, useEmbeddedScreenState } from "../../../src/appHooks";
 import { ListenMode, useZappServer } from "../../../src/zapp/useZappServer";
@@ -8,8 +9,14 @@ export function ZappScreen({ url }: { url: string }): ReactNode {
   return (
     <>
       <ZappModal />
-      <iframe
-        style={{ width: "100%", height: "100%", borderRadius: "10px" }}
+      <IframeResizer
+        style={{
+          // NB: Using min-width to set the width of the iFrame, works around an issue in iOS that can prevent the iFrame from sizing correctly.
+          width: "1px",
+          minWidth: "calc(100% - 16px)",
+          borderRadius: "12px",
+          margin: "0 8px"
+        }}
         src={url}
         sandbox="allow-downloads allow-same-origin allow-scripts allow-popups allow-modals allow-forms allow-storage-access-by-user-activation allow-popups-to-escape-sandbox"
       />

--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@babel/runtime": "^7.24.0",
     "@heroicons/react": "^2.1.5",
+    "iframe-resizer-react": "1.1.0",
     "@parcnet-js/client-helpers": "^0.0.5",
     "@parcnet-js/client-rpc": "^0.0.4",
     "@parcnet-js/podspec": "^0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13923,6 +13923,19 @@ ieee754@^1.1.13, ieee754@^1.2.1:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
+iframe-resizer-react@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/iframe-resizer-react/-/iframe-resizer-react-1.1.0.tgz#5009e019b7a5c7f1c009bff5bcdf0dbf33557465"
+  integrity sha512-FrytSq91AIJaDgE+6uK/Vdd6IR8CrwLoZ6eGmL2qQMPTzF0xlSV2jaSzRRUh5V2fttD7vzl21jvBl97bV40eBw==
+  dependencies:
+    iframe-resizer "^4.3.0"
+    warning "^4.0.3"
+
+iframe-resizer@^4.3.0:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/iframe-resizer/-/iframe-resizer-4.4.5.tgz#f5048636e7f2fb5d9a09cc2ae78eb2da55ad555c"
+  integrity sha512-U8bCywf/Gh07O69RXo6dXAzTtODQrxaHGHRI7Nt4ipXsuq6EMxVsOP/jjaP43YtXz/ibESS0uSVDN3sOGCzSmw==
+
 ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
@@ -22326,6 +22339,13 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 wasmbuilder@0.0.16:
   version "0.0.16"


### PR DESCRIPTION
Resize embedded Zapp iframe so it grows and shrinks based on content height. 

Update Zapp container style to match the button width. This styling will probably be updated in a future Zupass UI redesign.

<img width="465" alt="image" src="https://github.com/user-attachments/assets/c9428758-783b-429d-b226-3af9998642db">
