### PR TITLE
[wip] remove external snarkjs imports to reduce bundle size

### DIFF
--- a/examples/pod-gpc-example/package.json
+++ b/examples/pod-gpc-example/package.json
@@ -34,7 +34,7 @@
     "@pcd/semaphore-identity-pcd": "0.11.6",
     "@semaphore-protocol/identity": "^3.15.2",
     "lodash": "^4.17.21",
-    "snarkjs": "^0.7.4",
+    "@pcd/snarkjs": "0.7.7",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/lib/gpc/package.json
+++ b/packages/lib/gpc/package.json
@@ -35,7 +35,7 @@
     "@semaphore-protocol/core": "^4.0.3",
     "lodash": "^4.17.21",
     "json-bigint": "^1.0.0",
-    "snarkjs": "^0.7.4",
+    "@pcd/snarkjs": "0.7.7",
     "url-join": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/lib/gpc/src/gpcTypes.ts
+++ b/packages/lib/gpc/src/gpcTypes.ts
@@ -1,7 +1,7 @@
 import { POD, PODEntries, PODName, PODValue, PODValueTuple } from "@pcd/pod";
+import { Groth16Proof } from "@pcd/snarkjs";
 import { Identity as IdentityV4 } from "@semaphore-protocol/core";
 import { Identity } from "@semaphore-protocol/identity";
-import { Groth16Proof } from "snarkjs";
 import { ClosedInterval } from "./gpcUtil";
 
 /**

--- a/packages/lib/gpcircuits/package.json
+++ b/packages/lib/gpcircuits/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@pcd/pod": "0.1.7",
     "fastfile": "0.0.20",
-    "snarkjs": "^0.7.4",
+    "@pcd/snarkjs": "0.7.7",
     "url-join": "4.0.1"
   },
   "devDependencies": {

--- a/packages/lib/gpcircuits/src/proto-pod-gpc.ts
+++ b/packages/lib/gpcircuits/src/proto-pod-gpc.ts
@@ -1,5 +1,5 @@
+import { Groth16Proof, groth16 } from "@pcd/snarkjs";
 import { BABY_JUB_PRIME } from "@pcd/util";
-import { Groth16Proof, groth16 } from "snarkjs";
 import { loadVerificationKey } from "./artifacts";
 import circuitParamJson from "./circuitParameters.json";
 import { CircuitDesc, CircuitSignal } from "./types";

--- a/packages/patched/snarkjs/smart_contract_tests/test/smart_contracts.test.js
+++ b/packages/patched/snarkjs/smart_contract_tests/test/smart_contracts.test.js
@@ -5,7 +5,7 @@ import path from "path";
 import hardhat from "hardhat";
 const { ethers, run } = hardhat;
 
-import * as snarkjs from "snarkjs";
+import * as snarkjs from "@pcd/snarkjs";
 
 import fs from "fs";
 

--- a/packages/pcd/gpc-pcd/package.json
+++ b/packages/pcd/gpc-pcd/package.json
@@ -36,7 +36,7 @@
     "@types/lodash": "^4.17.5",
     "json-bigint": "^1.0.0",
     "lodash": "^4.17.21",
-    "snarkjs": "^0.7.4",
+    "@pcd/snarkjs": "0.7.7",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/pcd/gpc-pcd/src/GPCPCD.ts
+++ b/packages/pcd/gpc-pcd/src/GPCPCD.ts
@@ -8,7 +8,7 @@ import {
 import { PODEntries, PODName } from "@pcd/pod";
 import { PODPCD } from "@pcd/pod-pcd";
 import { SemaphoreIdentityPCD } from "@pcd/semaphore-identity-pcd";
-import { Groth16Proof } from "snarkjs";
+import { Groth16Proof } from "@pcd/snarkjs";
 
 /**
  * Types representing the claims and proof of a GPCPCD, re-exported from the

--- a/packages/pcd/zk-eddsa-event-ticket-pcd/package.json
+++ b/packages/pcd/zk-eddsa-event-ticket-pcd/package.json
@@ -44,7 +44,6 @@
     "@semaphore-protocol/identity": "^3.15.2",
     "@zk-kit/eddsa-poseidon": "1.0.3",
     "json-bigint": "^1.0.0",
-    "snarkjs": "^0.7.4",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/pcd/zk-eddsa-frog-pcd/package.json
+++ b/packages/pcd/zk-eddsa-frog-pcd/package.json
@@ -43,7 +43,7 @@
     "@semaphore-protocol/identity": "^3.15.2",
     "@zk-kit/eddsa-poseidon": "1.0.3",
     "json-bigint": "^1.0.0",
-    "snarkjs": "^0.7.4",
+    "@pcd/snarkjs": "0.7.7",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/pcd/zk-eddsa-frog-pcd/src/ZKEdDSAFrogPCD.ts
+++ b/packages/pcd/zk-eddsa-frog-pcd/src/ZKEdDSAFrogPCD.ts
@@ -2,7 +2,7 @@ import { EdDSAFrogPCD, IFrogData } from "@pcd/eddsa-frog-pcd";
 import type { EdDSAPublicKey } from "@pcd/eddsa-pcd";
 import { BigIntArgument, PCD, PCDArgument } from "@pcd/pcd-types";
 import { SemaphoreIdentityPCD } from "@pcd/semaphore-identity-pcd";
-import { Groth16Proof } from "snarkjs";
+import { Groth16Proof } from "@pcd/snarkjs";
 
 /**
  * The global unique type name of the {@link ZKEdDSAFrogPCD}.

--- a/packages/pcd/zk-eddsa-frog-pcd/src/ZKEdDSAFrogPCDPackage.ts
+++ b/packages/pcd/zk-eddsa-frog-pcd/src/ZKEdDSAFrogPCDPackage.ts
@@ -18,6 +18,7 @@ import {
   SemaphoreIdentityPCDPackage
 } from "@pcd/semaphore-identity-pcd";
 import { STATIC_SIGNATURE_PCD_NULLIFIER } from "@pcd/semaphore-signature-pcd";
+import { Groth16Proof, groth16 } from "@pcd/snarkjs";
 import {
   fromHexString,
   generateSnarkMessageHash,
@@ -26,7 +27,6 @@ import {
 } from "@pcd/util";
 import { unpackSignature } from "@zk-kit/eddsa-poseidon";
 import JSONBig from "json-bigint";
-import { Groth16Proof, groth16 } from "snarkjs";
 import { v4 as uuid } from "uuid";
 import vkey from "../artifacts/circuit.json";
 import {

--- a/packages/tools/artifacts/package.json
+++ b/packages/tools/artifacts/package.json
@@ -27,7 +27,7 @@
     "js-logger": "^1.6.1",
     "log-symbols": "^5.1.0",
     "ora": "^7.0.1",
-    "snarkjs": "^0.7.4"
+    "@pcd/snarkjs": "0.7.7"
   },
   "devDependencies": {
     "@pcd/eslint-config-custom": "0.11.4",

--- a/packages/tools/artifacts/src/commands/generate.js
+++ b/packages/tools/artifacts/src/commands/generate.js
@@ -4,7 +4,7 @@ import { existsSync, writeFileSync } from "fs";
 import logger from "js-logger";
 import logSymbols from "log-symbols";
 import { tmpdir } from "os";
-import { zKey } from "snarkjs";
+import { zKey } from "@pcd/snarkjs";
 import { pkg } from "../config.js";
 import Spinner from "../spinner.js";
 import { executeCommand, confirm } from "../utils.js";

--- a/yarn.lock
+++ b/yarn.lock
@@ -19892,7 +19892,7 @@ snarkjs@0.5.0, snarkjs@^0.5.0:
     logplease "^1.2.15"
     r1csfile "0.0.41"
 
-snarkjs@0.7.4, snarkjs@^0.7.4:
+snarkjs@0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/snarkjs/-/snarkjs-0.7.4.tgz#b9ad5813f055ab84d33f1831a6f1f34a71b6cd46"
   integrity sha512-x4cOCR4YXSyBlLtfnUUwfbZrw8wFd/Y0lk83eexJzKwZB8ELdpH+10ts8YtDsm2/a3WK7c7p514bbE8NpqxW8w==
@@ -20275,16 +20275,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -20417,14 +20408,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22833,7 +22817,7 @@ workspace-tools@^0.36.4:
     js-yaml "^4.1.0"
     micromatch "^4.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -22846,15 +22830,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
should shave off ~300KB off bundle size

- [x] replace direct imports of snarkjs from pcd packages and apps
- [ ] replace indirect imports of snarkjs from dependencies such as semaphore (this is a bit trickier because it probably means we need to vendor semaphore)