### PR TITLE
Specify Postgres socket location

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "localdb:restart": "yarn localdb:down && yarn localdb:init && yarn localdb:up",
     "localdb:init": "bash -c 'rm -rf apps/passport-server/local-db-data/ && initdb -U admin --pwfile=<(echo password) -A password -D apps/passport-server/local-db-data'",
-    "localdb:up": "pg_ctl -D apps/passport-server/local-db-data -l apps/passport-server/local-db-log start",
+    "localdb:up": "pg_ctl -D apps/passport-server/local-db-data -l apps/passport-server/local-db-log -o \"-k $(mktemp -d)\" start",
     "localdb:down": "pg_ctl -D apps/passport-server/local-db-data -l apps/passport-server/local-db-log stop",
     "build": "scripts/build.sh",
     "build:packages": "scripts/build.sh --filter=./packages/**/*  --filter=!./apps/*",


### PR DESCRIPTION
This PR explicitly sets the Postgres socket location to a temporary directory returned by an appropriate call to `mktemp`, which avoids having to grant permission to write to `/var/run/postgresql` on certain Linux setups.