### PR TITLE
fix bottom modal cut off on landscape

### DIFF
--- a/apps/passport-client/new-components/shared/BottomModal.tsx
+++ b/apps/passport-client/new-components/shared/BottomModal.tsx
@@ -35,6 +35,7 @@ const BottomModalContainer = styled.div<{
   max-height: 100%;
   height: ${({ $height }): string | number => ($height ? $height : "auto")};
   margin: 0 auto;
+  overflow-y: auto;
 `;
 
 export type BottomModalProps = {


### PR DESCRIPTION
after this pr:

https://github.com/user-attachments/assets/d536184e-3419-4739-b10c-f20449755f60


I think the state now is good enough to go, still, there are some weird screens like pod card:

<img width="698" alt="image" src="https://github.com/user-attachments/assets/4696c721-e35b-41b7-a5ca-ff7a0b1e9b5f">

Here the user can't  even see the whole QRcode, In case we want to support landscape fully we should have a new design for that state and it might be a big project we shouldn't do

I also tried to avoid rotation but it looks like there is no easy way to do it, one thing I tried is to use CSS https://caniuse.com/?search=orientation and then rotate <body> but it looks like it's going to be a nightmare with the swipe lib

@rrrliu - lmk what you think