### PR TITLE
Add pass-through query parameter for embedded Zapps

### DIFF
--- a/apps/passport-client/components/screens/ZappScreens/ZappScreen.tsx
+++ b/apps/passport-client/components/screens/ZappScreens/ZappScreen.tsx
@@ -1,16 +1,24 @@
 import { ReactNode } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useDispatch, useEmbeddedScreenState } from "../../../src/appHooks";
 import { ListenMode, useZappServer } from "../../../src/zapp/useZappServer";
 import { AdhocModal } from "../../modals/AdhocModal";
 import { EmbeddedScreen } from "../EmbeddedScreens/EmbeddedScreen";
 
 export function ZappScreen({ url }: { url: string }): ReactNode {
+  const [searchParams] = useSearchParams();
+  const queryParam = searchParams.get("q");
+  const urlWithOptionalParameter = new URL(url);
+  if (queryParam) {
+    urlWithOptionalParameter.searchParams.set("q", queryParam);
+  }
+
   return (
     <>
       <ZappModal />
       <iframe
         style={{ width: "100%", height: "100%", borderRadius: "10px" }}
-        src={url}
+        src={urlWithOptionalParameter.toString()}
         sandbox="allow-downloads allow-same-origin allow-scripts allow-popups allow-modals allow-forms allow-storage-access-by-user-activation allow-popups-to-escape-sandbox"
       />
     </>


### PR DESCRIPTION
This PR adds a pass-through query parameter, `q`. If `q` is present on the query string when viewing a Zapp, then `q` will be added to the query string used to load the Zapp inside an iframe.

@saurfang does this satisfy FrogCrypto's requirement?