### PR TITLE
Replace existing Zapp PODs when approving new permissions

### DIFF
--- a/apps/passport-client/src/dispatch.ts
+++ b/apps/passport-client/src/dispatch.ts
@@ -1630,7 +1630,7 @@ async function zappApproval(
 
     const newZappSerialized = await PODPCDPackage.serialize(newZapp);
     update({ zappApproved: true });
-    return addPCDs(state, update, [newZappSerialized], false, "Zapps");
+    return addPCDs(state, update, [newZappSerialized], true, "Zapps");
   } else {
     update({ zappApproved: false });
   }

--- a/apps/passport-client/src/zapp/useZappServer.ts
+++ b/apps/passport-client/src/zapp/useZappServer.ts
@@ -89,8 +89,6 @@ function isAlreadyAuthorized(
           existingPODQuery.matches[0].content.asEntries().permissions.value
         )
       );
-      console.log("existingPermissions", existingPermissions);
-      console.log("zapp.permissions", zapp.permissions);
       if (isEqual(existingPermissions, zapp.permissions)) {
         return true;
       }


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-1351/zapp-pods-dont-get-replaced-by-new-ones-when-agreeing-new-permissions

