### PR TITLE
isolate server queries w/ transactions

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,7 +1,7 @@
 module.exports = {
   // TODO: override this to always be true in CI
-  forbidOnly: true,
-  forbidPending: true,
+  forbidOnly: false,
+  forbidPending: false,
   failZero: true,
   bail: true,
   timeout: "120000"

--- a/apps/passport-server/scripts/scratch.ts
+++ b/apps/passport-server/scripts/scratch.ts
@@ -146,7 +146,8 @@ yargs
         `Creating event with org: ${argv.orgUrl} id: ${argv.eventId} and active items: ${argv.activeItemIds}`
       );
 
-      const db = await getDB();
+      const pool = await getDB();
+      const db = await pool.connect();
 
       const organizerConfigId = await insertPretixOrganizerConfig(
         db,
@@ -247,7 +248,8 @@ yargs
       const activeItemIds = [itemId];
       const checkinListId = "0";
 
-      const db = await getDB();
+      const pool = await getDB();
+      const db = await pool.connect();
 
       const organizerConfigId = await insertPretixOrganizerConfig(
         db,

--- a/apps/passport-server/src/apis/devconnect/organizer.ts
+++ b/apps/passport-server/src/apis/devconnect/organizer.ts
@@ -1,14 +1,14 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { PretixOrganizersConfig } from "../../database/models";
 import { fetchPretixConfiguration } from "../../database/queries/pretix_config/fetchPretixConfiguration";
 import { logger } from "../../util/logger";
 
 export async function getDevconnectPretixConfig(
-  dbClient: Pool
+  client: PoolClient
 ): Promise<DevconnectPretixConfig | null> {
   try {
     const pretixConfig = pretixConfigDBToDevconnectPretixConfig(
-      await fetchPretixConfiguration(dbClient)
+      await fetchPretixConfiguration(client)
     );
     logger(
       "[DEVCONNECT PRETIX] read config: " +

--- a/apps/passport-server/src/database/queries/cache.ts
+++ b/apps/passport-server/src/database/queries/cache.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../sqlQuery";
 
 export interface CacheEntry {
@@ -9,12 +9,12 @@ export interface CacheEntry {
 }
 
 export async function setCacheValue(
-  db: Pool,
+  client: PoolClient,
   key: string,
   value: string
 ): Promise<CacheEntry> {
   const result = await sqlQuery(
-    db,
+    client,
     `
 insert into cache(
   cache_key,
@@ -33,11 +33,11 @@ returning *;`,
 }
 
 export async function getCacheValue(
-  db: Pool,
+  client: PoolClient,
   key: string
 ): Promise<CacheEntry | undefined> {
   const result = await sqlQuery(
-    db,
+    client,
     `select * from cache where cache_key = $1`,
     [key]
   );
@@ -49,8 +49,8 @@ export async function getCacheValue(
   return result.rows[0];
 }
 
-export async function getCacheSize(db: Pool): Promise<number> {
-  const result = await sqlQuery(db, `select count(*) from cache;`);
+export async function getCacheSize(client: PoolClient): Promise<number> {
+  const result = await sqlQuery(client, `select count(*) from cache;`);
   return parseInt(result.rows[0].count);
 }
 
@@ -63,12 +63,12 @@ export async function getCacheSize(db: Pool): Promise<number> {
  * @returns the amount of entries deleted
  */
 export async function deleteExpiredCacheEntries(
-  db: Pool,
+  client: PoolClient,
   maxAgeInDays: number,
   maxEntries: number
 ): Promise<number> {
   const result = await sqlQuery(
-    db,
+    client,
     `
 with deleted as (
   with nonExpired as (

--- a/apps/passport-server/src/database/queries/devconnect_pretix_tickets/devconnectPretixRedactedTickets.ts
+++ b/apps/passport-server/src/database/queries/devconnect_pretix_tickets/devconnectPretixRedactedTickets.ts
@@ -1,19 +1,12 @@
-import { Pool, PoolClient } from "postgres-pool";
-import { sqlTransaction } from "../../sqlQuery";
+import { PoolClient } from "postgres-pool";
 
 export async function agreeTermsAndUnredactTickets(
-  client: Pool,
+  client: PoolClient,
   userUUID: string,
   version: number
 ): Promise<void> {
-  await sqlTransaction<void>(
-    client,
-    "agree terms and unredact tickets",
-    async (txClient: PoolClient) => {
-      await txClient.query(
-        "UPDATE users SET terms_agreed = $1 WHERE uuid = $2",
-        [version, userUUID]
-      );
-    }
-  );
+  await client.query("UPDATE users SET terms_agreed = $1 WHERE uuid = $2", [
+    version,
+    userUUID
+  ]);
 }

--- a/apps/passport-server/src/database/queries/devconnect_pretix_tickets/fetchDevconnectPretixTicket.ts
+++ b/apps/passport-server/src/database/queries/devconnect_pretix_tickets/fetchDevconnectPretixTicket.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import {
   DevconnectPretixTicketDB,
   DevconnectPretixTicketDBWithCheckinListID,
@@ -13,7 +13,7 @@ import { sqlQuery } from "../../sqlQuery";
  * in and accepted legal/privacy terms.
  */
 export async function fetchAllNonDeletedDevconnectPretixTickets(
-  client: Pool
+  client: PoolClient
 ): Promise<Array<DevconnectPretixTicketDB>> {
   const result = await sqlQuery(
     client,
@@ -30,7 +30,7 @@ export async function fetchAllNonDeletedDevconnectPretixTickets(
  * would be redacted.
  */
 export async function fetchDevconnectPretixTicketsByEvent(
-  client: Pool,
+  client: PoolClient,
   eventConfigID: string
 ): Promise<Array<DevconnectPretixTicketDBWithEmailAndItem>> {
   const result = await sqlQuery(
@@ -51,7 +51,7 @@ export async function fetchDevconnectPretixTicketsByEvent(
  * Fetch a devconnect ticket by its unique internal id.
  */
 export async function fetchDevconnectPretixTicketByTicketId(
-  client: Pool,
+  client: PoolClient,
   ticketId: string
 ): Promise<DevconnectPretixTicketDBWithEmailAndItem | undefined> {
   const result = await sqlQuery(
@@ -69,7 +69,7 @@ export async function fetchDevconnectPretixTicketByTicketId(
 }
 
 export async function fetchDevconnectPretixTicketsByEmail(
-  client: Pool,
+  client: PoolClient,
   email: string
 ): Promise<Array<DevconnectPretixTicketDBWithEmailAndItem>> {
   const result = await sqlQuery(
@@ -88,7 +88,7 @@ export async function fetchDevconnectPretixTicketsByEmail(
 }
 
 export async function fetchDevconnectSuperusers(
-  client: Pool
+  client: PoolClient
 ): Promise<Array<DevconnectSuperuser>> {
   const result = await sqlQuery(
     client,
@@ -105,7 +105,7 @@ and t.is_deleted = false;
 }
 
 export async function fetchDevconnectSuperusersForEvent(
-  client: Pool,
+  client: PoolClient,
   eventConfigID: string
 ): Promise<Array<DevconnectSuperuser>> {
   const result = await sqlQuery(
@@ -125,7 +125,7 @@ and t.is_deleted = false
 }
 
 export async function fetchDevconnectSuperusersForEmail(
-  client: Pool,
+  client: PoolClient,
   email: string
 ): Promise<Array<DevconnectSuperuser>> {
   const result = await sqlQuery(
@@ -149,7 +149,7 @@ and t.is_deleted = false
  * on Pretix.
  */
 export async function fetchDevconnectTicketsAwaitingSync(
-  client: Pool,
+  client: PoolClient,
   orgUrl: string
 ): Promise<Array<DevconnectPretixTicketDBWithCheckinListID>> {
   const result = await sqlQuery(
@@ -172,7 +172,7 @@ export async function fetchDevconnectTicketsAwaitingSync(
 }
 
 export async function fetchDevconnectProducts(
-  client: Pool
+  client: PoolClient
 ): Promise<DevconnectProduct[]> {
   const result = await sqlQuery(
     client,

--- a/apps/passport-server/src/database/queries/devconnect_pretix_tickets/insertDevconnectPretixTicket.ts
+++ b/apps/passport-server/src/database/queries/devconnect_pretix_tickets/insertDevconnectPretixTicket.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import {
   DevconnectPretixTicketWithCheckin,
   DevconnectPretixTicketWithCheckinDB
@@ -10,7 +10,7 @@ import { sqlQuery } from "../../sqlQuery";
  * inserted yet. This does not insert an identity commitment for them.
  */
 export async function insertDevconnectPretixTicket(
-  client: Pool,
+  client: PoolClient,
   params: DevconnectPretixTicketWithCheckin
 ): Promise<DevconnectPretixTicketWithCheckinDB> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/database/queries/devconnect_pretix_tickets/softDeleteDevconnectPretixTicket.ts
+++ b/apps/passport-server/src/database/queries/devconnect_pretix_tickets/softDeleteDevconnectPretixTicket.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { DevconnectPretixTicket } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
@@ -6,7 +6,7 @@ import { sqlQuery } from "../../sqlQuery";
  * Soft delete a Devconnect ticket.
  */
 export async function softDeleteDevconnectPretixTicket(
-  client: Pool,
+  client: PoolClient,
   params: DevconnectPretixTicket
 ): Promise<void> {
   await sqlQuery(

--- a/apps/passport-server/src/database/queries/devconnect_pretix_tickets/updateDevconnectPretixTicket.ts
+++ b/apps/passport-server/src/database/queries/devconnect_pretix_tickets/updateDevconnectPretixTicket.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { DevconnectPretixTicketWithCheckin } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
@@ -6,7 +6,7 @@ import { sqlQuery } from "../../sqlQuery";
  * Updates a pretix ticket in our database.
  */
 export async function updateDevconnectPretixTicket(
-  client: Pool,
+  client: PoolClient,
   params: DevconnectPretixTicketWithCheckin
 ): Promise<DevconnectPretixTicketWithCheckin> {
   const result = await sqlQuery(
@@ -38,7 +38,7 @@ returning *`,
  * to toggle on `is_consumed` state, returning the row if it exists.
  */
 export async function consumeDevconnectPretixTicket(
-  client: Pool,
+  client: PoolClient,
   id: string,
   checkerEmail: string
 ): Promise<boolean> {

--- a/apps/passport-server/src/database/queries/emailToken.ts
+++ b/apps/passport-server/src/database/queries/emailToken.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../sqlQuery";
 
 /**
@@ -6,7 +6,7 @@ import { sqlQuery } from "../sqlQuery";
  * if we have sent them a token, null otherwise.
  */
 export async function fetchEmailToken(
-  client: Pool,
+  client: PoolClient,
   email: string
 ): Promise<string | null> {
   const result = await sqlQuery(
@@ -22,7 +22,7 @@ export async function fetchEmailToken(
  * Sets the email auth token for a given user.
  */
 export async function insertEmailToken(
-  client: Pool,
+  client: PoolClient,
   params: {
     email: string;
     token: string;

--- a/apps/passport-server/src/database/queries/getEdgeCityBalances.ts
+++ b/apps/passport-server/src/database/queries/getEdgeCityBalances.ts
@@ -1,12 +1,12 @@
 import { EdgeCityBalance } from "@pcd/passport-interface";
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../sqlQuery";
 
 export async function getEdgeCityBalances(
-  pool: Pool
+  client: PoolClient
 ): Promise<EdgeCityBalance[]> {
   const { rows } = await sqlQuery(
-    pool,
+    client,
     `
     SELECT '0x' || encode(sha256('edgecity' || email::bytea), 'hex') as email_hash, balance, RANK() OVER (ORDER BY balance DESC) AS rank
     FROM (

--- a/apps/passport-server/src/database/queries/historicSemaphore.ts
+++ b/apps/passport-server/src/database/queries/historicSemaphore.ts
@@ -1,5 +1,5 @@
 import { QueryResultRow } from "pg";
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { HistoricSemaphoreGroup } from "../models";
 import { sqlQuery } from "../sqlQuery";
 
@@ -7,7 +7,7 @@ import { sqlQuery } from "../sqlQuery";
  * Fetches all the latest semaphore group states from the database.
  */
 export async function fetchLatestHistoricSemaphoreGroups(
-  client: Pool
+  client: PoolClient
 ): Promise<HistoricSemaphoreGroup[]> {
   const latestGroups = await sqlQuery(
     client,
@@ -28,7 +28,7 @@ export async function fetchLatestHistoricSemaphoreGroups(
  * a given group.
  */
 export async function insertNewHistoricSemaphoreGroup(
-  client: Pool,
+  client: PoolClient,
   groupId: string,
   rootHash: string,
   group: string
@@ -41,7 +41,7 @@ export async function insertNewHistoricSemaphoreGroup(
 }
 
 export async function fetchHistoricGroupByRoot(
-  client: Pool,
+  client: PoolClient,
   groupId: string,
   rootHash: string
 ): Promise<HistoricSemaphoreGroup | undefined> {

--- a/apps/passport-server/src/database/queries/knownTicketTypes.ts
+++ b/apps/passport-server/src/database/queries/knownTicketTypes.ts
@@ -1,5 +1,5 @@
 import { KnownPublicKeyType, KnownTicketGroup } from "@pcd/passport-interface";
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import {
   KnownPublicKeyDB,
   KnownTicketType,
@@ -11,7 +11,7 @@ import { sqlQuery } from "../sqlQuery";
  * Fetches known public keys from the database.
  */
 export async function fetchKnownPublicKeys(
-  client: Pool
+  client: PoolClient
 ): Promise<KnownPublicKeyDB[]> {
   const result = await sqlQuery(client, `SELECT * FROM known_public_keys`);
 
@@ -23,7 +23,7 @@ export async function fetchKnownPublicKeys(
  * same name and type already exists.
  */
 export async function setKnownPublicKey(
-  client: Pool,
+  client: PoolClient,
   publicKeyName: string,
   publicKeyType: KnownPublicKeyType,
   publicKey: string
@@ -46,7 +46,7 @@ export async function setKnownPublicKey(
  * check that the public key matches the one that they expect.
  */
 export async function fetchKnownTicketByEventAndProductId(
-  client: Pool,
+  client: PoolClient,
   eventId: string,
   productId: string
 ): Promise<KnownTicketTypeWithKey | null> {
@@ -66,7 +66,7 @@ export async function fetchKnownTicketByEventAndProductId(
  * List all of the known tickets.
  */
 export async function fetchKnownTicketTypes(
-  client: Pool
+  client: PoolClient
 ): Promise<KnownTicketTypeWithKey[]> {
   const result = await sqlQuery(
     client,
@@ -86,7 +86,7 @@ export async function fetchKnownTicketTypes(
  * identifier already exists, will replace existing values.
  */
 export async function setKnownTicketType(
-  client: Pool,
+  client: PoolClient,
   identifier: string,
   eventId: string,
   productId: string,
@@ -119,7 +119,7 @@ export async function setKnownTicketType(
  * Deletes a known ticket type.
  */
 export async function deleteKnownTicketType(
-  client: Pool,
+  client: PoolClient,
   identifier: string
 ): Promise<void> {
   await sqlQuery(
@@ -133,7 +133,7 @@ export async function deleteKnownTicketType(
  * Fetch ticket types belonging to a group.
  */
 export async function fetchKnownTicketTypesByGroup(
-  client: Pool,
+  client: PoolClient,
   ticketGroup: KnownTicketGroup
 ): Promise<KnownTicketType[]> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/database/queries/kv.ts
+++ b/apps/passport-server/src/database/queries/kv.ts
@@ -1,25 +1,31 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../sqlQuery";
 
-export function kvGet(db: Pool, key: string): Promise<unknown | undefined> {
-  return sqlQuery(db, `select v from kv where k = $1;`, [key]).then(
+export function kvGet(
+  client: PoolClient,
+  key: string
+): Promise<unknown | undefined> {
+  return sqlQuery(client, `select v from kv where k = $1;`, [key]).then(
     (res) => res.rows[0]?.v
   );
 }
 
-export function kvGetByPrefix(db: Pool, prefix: string): Promise<unknown[]> {
-  return sqlQuery(db, `select v from kv where k like $1;`, [`${prefix}%`]).then(
-    (res) => res.rows.map((row) => row.v)
-  );
+export function kvGetByPrefix(
+  client: PoolClient,
+  prefix: string
+): Promise<unknown[]> {
+  return sqlQuery(client, `select v from kv where k like $1;`, [
+    `${prefix}%`
+  ]).then((res) => res.rows.map((row) => row.v));
 }
 
 export function kvSet(
-  db: Pool,
+  client: PoolClient,
   key: string,
   value: unknown
 ): Promise<string | undefined> {
   return sqlQuery(
-    db,
+    client,
     `
 insert into kv (k, v) values ($1, $2)
 on conflict (k) do update set v = $2;

--- a/apps/passport-server/src/database/queries/pipelineUserDB.ts
+++ b/apps/passport-server/src/database/queries/pipelineUserDB.ts
@@ -1,33 +1,38 @@
 import { normalizeEmail } from "@pcd/util";
 import { validate } from "email-validator";
-import { Pool, PoolClient } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { v4 as uuid } from "uuid";
 import { traceUser } from "../../services/generic-issuance/honeycombQueries";
 import { PipelineUser } from "../../services/generic-issuance/pipelines/types";
 import { traced } from "../../services/telemetryService";
 import { GenericIssuanceUserRow } from "../models";
-import { sqlQuery, sqlTransaction } from "../sqlQuery";
+import { sqlQuery } from "../sqlQuery";
 
 export interface IPipelineUserDB {
-  loadAllUsers(): Promise<PipelineUser[]>;
-  clearAllUsers(): Promise<void>;
-  getUserById(userID: string): Promise<PipelineUser | undefined>;
-  getUserByEmail(email: string): Promise<PipelineUser | undefined>;
-  getOrCreateUser(email: string): Promise<PipelineUser>;
+  loadAllUsers(client: PoolClient): Promise<PipelineUser[]>;
+  clearAllUsers(client: PoolClient): Promise<void>;
+  getUserById(
+    client: PoolClient,
+    userID: string
+  ): Promise<PipelineUser | undefined>;
+  getUserByEmail(
+    client: PoolClient,
+    email: string
+  ): Promise<PipelineUser | undefined>;
+  getOrCreateUser(client: PoolClient, email: string): Promise<PipelineUser>;
   updateUserById(
+    client: PoolClient,
     user: Omit<PipelineUser, "timeCreated" | "timeUpdated">
   ): Promise<PipelineUser>;
-  setUserIsAdmin(email: string, isAdmin: boolean): Promise<void>;
-  getEnvAdminEmails(): string[];
+  setUserIsAdmin(
+    client: PoolClient,
+    email: string,
+    isAdmin: boolean
+  ): Promise<void>;
+  getEnvAdminEmails(client: PoolClient): string[];
 }
 
 export class PipelineUserDB implements IPipelineUserDB {
-  private db: Pool;
-
-  public constructor(db: Pool) {
-    this.db = db;
-  }
-
   public getEnvAdminEmails(): string[] {
     if (!process.env.GENERIC_ISSUANCE_ADMINS) {
       return [];
@@ -51,40 +56,41 @@ export class PipelineUserDB implements IPipelineUserDB {
     }
   }
 
-  public async getOrCreateUser(email: string): Promise<PipelineUser> {
+  public async getOrCreateUser(
+    client: PoolClient,
+    email: string
+  ): Promise<PipelineUser> {
     return traced("PipelineUserDB", "createOrGetUser", async (span) => {
-      return sqlTransaction<PipelineUser>(
-        this.db,
-        "createOrGetUser",
-        async (client): Promise<PipelineUser> => {
-          if (!validate(email)) {
-            throw new Error(`Invalid email: ${email}`);
-          }
+      if (!validate(email)) {
+        throw new Error(`Invalid email: ${email}`);
+      }
 
-          span?.setAttribute("email", email);
-          const existingUser = await this.getUserByEmail(email, client);
-          if (existingUser) {
-            span?.setAttribute("is_new", false);
-            traceUser(existingUser);
-            return existingUser;
-          }
-          span?.setAttribute("is_new", true);
-          const newUser = {
-            id: uuid(),
-            email,
-            isAdmin: this.getEnvAdminEmails().includes(email)
-          };
-          const savedNewUser = await this.updateUserById(newUser, client);
-          traceUser(savedNewUser);
-          return savedNewUser;
-        }
-      );
+      span?.setAttribute("email", email);
+      const existingUser = await this.getUserByEmail(client, email);
+      if (existingUser) {
+        span?.setAttribute("is_new", false);
+        traceUser(existingUser);
+        return existingUser;
+      }
+      span?.setAttribute("is_new", true);
+      const newUser = {
+        id: uuid(),
+        email,
+        isAdmin: this.getEnvAdminEmails().includes(email)
+      };
+      const savedNewUser = await this.updateUserById(client, newUser);
+      traceUser(savedNewUser);
+      return savedNewUser;
     });
   }
 
-  public async setUserIsAdmin(email: string, isAdmin: boolean): Promise<void> {
+  public async setUserIsAdmin(
+    client: PoolClient,
+    email: string,
+    isAdmin: boolean
+  ): Promise<void> {
     await sqlQuery(
-      this.db,
+      client,
       "update generic_issuance_users set is_admin=$1 where email=$2",
       [isAdmin, normalizeEmail(email)]
     );
@@ -100,21 +106,24 @@ export class PipelineUserDB implements IPipelineUserDB {
     };
   }
 
-  public async loadAllUsers(): Promise<PipelineUser[]> {
+  public async loadAllUsers(client: PoolClient): Promise<PipelineUser[]> {
     const result = await sqlQuery(
-      this.db,
+      client,
       "SELECT * FROM generic_issuance_users"
     );
     return result.rows.map(this.dbRowToPipelineUser);
   }
 
-  public async clearAllUsers(): Promise<void> {
-    await sqlQuery(this.db, "DELETE FROM generic_issuance_users");
+  public async clearAllUsers(client: PoolClient): Promise<void> {
+    await sqlQuery(client, "DELETE FROM generic_issuance_users");
   }
 
-  public async getUserById(userID: string): Promise<PipelineUser | undefined> {
+  public async getUserById(
+    client: PoolClient,
+    userID: string
+  ): Promise<PipelineUser | undefined> {
     const result = await sqlQuery(
-      this.db,
+      client,
       "SELECT * FROM generic_issuance_users WHERE id = $1",
       [userID]
     );
@@ -126,11 +135,11 @@ export class PipelineUserDB implements IPipelineUserDB {
   }
 
   public async getUserByEmail(
-    email: string,
-    db?: PoolClient
+    client: PoolClient,
+    email: string
   ): Promise<PipelineUser | undefined> {
     const res = await sqlQuery(
-      db ?? this.db,
+      client,
       `select * from generic_issuance_users where email = $1`,
       [normalizeEmail(email)]
     );
@@ -143,11 +152,11 @@ export class PipelineUserDB implements IPipelineUserDB {
   }
 
   public async updateUserById(
-    user: Omit<PipelineUser, "timeCreated" | "timeUpdated">,
-    db?: PoolClient
+    client: PoolClient,
+    user: Omit<PipelineUser, "timeCreated" | "timeUpdated">
   ): Promise<PipelineUser> {
     const res = await sqlQuery(
-      db ?? this.db,
+      client,
       `
     INSERT INTO generic_issuance_users (id, email, is_admin) VALUES($1, $2, $3)
     ON CONFLICT(id) DO UPDATE

--- a/apps/passport-server/src/database/queries/poap.ts
+++ b/apps/passport-server/src/database/queries/poap.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { PoapEvent } from "../models";
 import { sqlQuery } from "../sqlQuery";
 
@@ -12,7 +12,7 @@ import { sqlQuery } from "../sqlQuery";
  * redirected to this POAP claim URL.
  */
 export async function claimNewPoapUrl(
-  client: Pool,
+  client: PoolClient,
   poapEvent: PoapEvent,
   hashedTicketId: string
 ): Promise<string | null> {
@@ -36,7 +36,7 @@ WHERE claim_url =
  * Insert a new POAP claim URL.
  */
 export async function insertNewPoapUrl(
-  client: Pool,
+  client: PoolClient,
   claimUrl: string,
   poapEvent: PoapEvent
 ): Promise<void> {
@@ -56,7 +56,7 @@ VALUES
  * if it exists; otherwise, return NULL.
  */
 export async function getExistingClaimUrlByTicketId(
-  client: Pool,
+  client: PoolClient,
   hashedTicketId: string
 ): Promise<string | null> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/database/queries/pretixEventInfo.ts
+++ b/apps/passport-server/src/database/queries/pretixEventInfo.ts
@@ -1,9 +1,9 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { PretixEventInfo, PretixItemInfo } from "../models";
 import { sqlQuery } from "../sqlQuery";
 
 export async function fetchPretixEventInfo(
-  client: Pool,
+  client: PoolClient,
   eventConfigID: string
 ): Promise<PretixEventInfo | null> {
   const result = await sqlQuery(
@@ -19,7 +19,7 @@ export async function fetchPretixEventInfo(
 }
 
 export async function insertPretixEventsInfo(
-  client: Pool,
+  client: PoolClient,
   eventName: string,
   eventsConfigID: string,
   checkinListId: string
@@ -37,7 +37,7 @@ export async function insertPretixEventsInfo(
 }
 
 export async function updatePretixEventsInfo(
-  client: Pool,
+  client: PoolClient,
   id: string,
   eventName: string,
   isDeleted: boolean,
@@ -55,7 +55,7 @@ export async function updatePretixEventsInfo(
 }
 
 export async function softDeletePretixEventsInfo(
-  client: Pool,
+  client: PoolClient,
   id: number
 ): Promise<void> {
   await sqlQuery(
@@ -66,7 +66,7 @@ export async function softDeletePretixEventsInfo(
 }
 
 export async function fetchPretixEventInfoByName(
-  client: Pool,
+  client: PoolClient,
   eventName: string
 ): Promise<PretixEventInfo | null> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/database/queries/pretixItemInfo.ts
+++ b/apps/passport-server/src/database/queries/pretixItemInfo.ts
@@ -1,9 +1,9 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { PretixItemInfo } from "../models";
 import { sqlQuery } from "../sqlQuery";
 
 export async function fetchPretixItemsInfoByEvent(
-  client: Pool,
+  client: PoolClient,
   eventInfoId: string
 ): Promise<Array<PretixItemInfo>> {
   const result = await sqlQuery(
@@ -19,7 +19,7 @@ export async function fetchPretixItemsInfoByEvent(
 }
 
 export async function insertPretixItemsInfo(
-  client: Pool,
+  client: PoolClient,
   item_id: string,
   eventInfoId: string,
   item_name: string
@@ -36,7 +36,7 @@ export async function insertPretixItemsInfo(
 }
 
 export async function updatePretixItemsInfo(
-  client: Pool,
+  client: PoolClient,
   id: string,
   item_name: string,
   isDeleted: boolean
@@ -53,7 +53,7 @@ export async function updatePretixItemsInfo(
 }
 
 export async function softDeletePretixItemInfo(
-  client: Pool,
+  client: PoolClient,
   id: string
 ): Promise<void> {
   await sqlQuery(

--- a/apps/passport-server/src/database/queries/pretix_config/fetchPretixConfiguration.ts
+++ b/apps/passport-server/src/database/queries/pretix_config/fetchPretixConfiguration.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { PretixOrganizersConfig } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
@@ -6,7 +6,7 @@ import { sqlQuery } from "../../sqlQuery";
  * Fetch the list of Pretix organizers from the database.
  */
 export async function fetchPretixConfiguration(
-  client: Pool
+  client: PoolClient
 ): Promise<Array<PretixOrganizersConfig>> {
   const result = await sqlQuery(
     client,
@@ -24,7 +24,7 @@ export async function fetchPretixConfiguration(
  * Fetch the list of Pretix organizers from the database.
  */
 export async function fetchEventConfiguration(
-  client: Pool,
+  client: PoolClient,
   orgURL: string,
   eventID: string
 ): Promise<Array<PretixOrganizersConfig>> {

--- a/apps/passport-server/src/database/queries/pretix_config/insertConfiguration.ts
+++ b/apps/passport-server/src/database/queries/pretix_config/insertConfiguration.ts
@@ -1,15 +1,15 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { PretixOrganizerRow } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
 export async function insertPretixOrganizerConfig(
-  db: Pool,
+  client: PoolClient,
   organizerUrl: string,
   token: string,
   disabled: boolean
 ): Promise<string> {
   const id = await sqlQuery(
-    db,
+    client,
     `insert into pretix_organizers_config(organizer_url, token, disabled) ` +
       `values ($1, $2, $3) ` +
       `on conflict (organizer_url) do update set token = $2 ` +
@@ -21,14 +21,17 @@ export async function insertPretixOrganizerConfig(
 }
 
 export async function getAllOrganizers(
-  db: Pool
+  client: PoolClient
 ): Promise<PretixOrganizerRow[]> {
-  const result = await sqlQuery(db, `select * from pretix_organizers_config`);
+  const result = await sqlQuery(
+    client,
+    `select * from pretix_organizers_config`
+  );
   return result.rows as PretixOrganizerRow[];
 }
 
 export async function insertPretixEventConfig(
-  db: Pool,
+  client: PoolClient,
   organizerConfigId: string,
   activeItemIds: string[],
   superuserItemIds: string[],
@@ -44,7 +47,7 @@ export async function insertPretixEventConfig(
   });
 
   const result = await sqlQuery(
-    db,
+    client,
     `insert into pretix_events_config(pretix_organizers_config_id, active_item_ids, event_id, superuser_item_ids) ` +
       `values ($1, $2, $3, $4) ` +
       `on conflict (event_id, pretix_organizers_config_id) do update set pretix_organizers_config_id = $1, active_item_ids = $2, superuser_item_ids = $4 ` +

--- a/apps/passport-server/src/database/queries/rateLimit.ts
+++ b/apps/passport-server/src/database/queries/rateLimit.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { RateLimitBucket } from "../models";
 import { sqlQuery } from "../sqlQuery";
 
@@ -31,7 +31,7 @@ import { sqlQuery } from "../sqlQuery";
  * @returns the RateLimitBucket
  */
 export async function consumeRateLimitToken(
-  client: Pool,
+  client: PoolClient,
   actionType: string,
   actionId: string,
   maxActions: number,
@@ -117,7 +117,7 @@ export async function consumeRateLimitToken(
  * Delete multiple rate limit buckets
  */
 export async function pruneRateLimitBuckets(
-  client: Pool,
+  client: PoolClient,
   actionType: string,
   // Expire all buckets whose last_take is less than or equal to this timestamp
   // Appropriate timestamps must be calculated by the caller, using the bucket
@@ -135,7 +135,7 @@ export async function pruneRateLimitBuckets(
  * Delete rate limit buckets not of given action types
  */
 export async function deleteUnsupportedRateLimitBuckets(
-  client: Pool,
+  client: PoolClient,
   supportedActionTypes: string[]
 ): Promise<void> {
   await sqlQuery(

--- a/apps/passport-server/src/database/queries/saveUser.ts
+++ b/apps/passport-server/src/database/queries/saveUser.ts
@@ -1,6 +1,6 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { logger } from "../../util/logger";
-import { sqlQuery, sqlTransaction } from "../sqlQuery";
+import { sqlQuery } from "../sqlQuery";
 
 export interface SaveUserParams {
   uuid: string;
@@ -22,7 +22,7 @@ export interface SaveUserParams {
  * @param params is a partial {@link UserRow}.
  */
 export async function upsertUser(
-  client: Pool,
+  client: PoolClient,
   params: SaveUserParams
 ): Promise<string> {
   logger("[DB] upsertUser", params);
@@ -37,25 +37,21 @@ export async function upsertUser(
     );
   }
 
-  return sqlTransaction(
-    client,
-    "save user",
-    async (client) => {
-      const {
-        commitment,
-        salt,
-        encryption_key,
-        terms_agreed,
-        extra_issuance,
-        uuid,
-        emails,
-        semaphore_v4_commitment,
-        semaphore_v4_pubkey
-      } = params;
+  const {
+    commitment,
+    salt,
+    encryption_key,
+    terms_agreed,
+    extra_issuance,
+    uuid,
+    emails,
+    semaphore_v4_commitment,
+    semaphore_v4_pubkey
+  } = params;
 
-      const upsertUserResult = await sqlQuery(
-        client,
-        `\
+  const upsertUserResult = await sqlQuery(
+    client,
+    `\
 INSERT INTO users 
 (uuid, commitment, salt, encryption_key, terms_agreed, extra_issuance, semaphore_v4_commitment, semaphore_v4_pubkey)
 VALUES 
@@ -63,46 +59,43 @@ VALUES
 ON CONFLICT (uuid) DO UPDATE SET 
 commitment = $2, salt = $3, encryption_key = $4, terms_agreed = $5, extra_issuance=$6, time_updated=$7, semaphore_v4_commitment=$8, semaphore_v4_pubkey=$9
 returning *`,
-        [
-          uuid,
-          commitment,
-          salt,
-          encryption_key,
-          terms_agreed,
-          extra_issuance,
-          new Date(),
-          semaphore_v4_commitment,
-          semaphore_v4_pubkey
-        ],
-        0
-      );
-
-      const user = upsertUserResult.rows[0];
-      if (!user) {
-        throw new Error(`Failed to save user.`);
-      }
-
-      // Update the user's associated emails
-      await sqlQuery(
-        client,
-        `DELETE FROM user_emails WHERE user_id = $1`,
-        [uuid],
-        0
-      );
-
-      const emailValues = emails
-        .map((_, index) => `($1, $${index + 2})`)
-        .join(", ");
-
-      await sqlQuery(
-        client,
-        `INSERT INTO user_emails (user_id, email) VALUES ${emailValues}`,
-        [uuid, ...emails],
-        0
-      );
-
-      return uuid;
-    },
-    3
+    [
+      uuid,
+      commitment,
+      salt,
+      encryption_key,
+      terms_agreed,
+      extra_issuance,
+      new Date(),
+      semaphore_v4_commitment,
+      semaphore_v4_pubkey
+    ],
+    0
   );
+
+  const user = upsertUserResult.rows[0];
+  if (!user) {
+    throw new Error(`Failed to save user.`);
+  }
+
+  // Update the user's associated emails
+  await sqlQuery(
+    client,
+    `DELETE FROM user_emails WHERE user_id = $1`,
+    [uuid],
+    0
+  );
+
+  const emailValues = emails
+    .map((_, index) => `($1, $${index + 2})`)
+    .join(", ");
+
+  await sqlQuery(
+    client,
+    `INSERT INTO user_emails (user_id, email) VALUES ${emailValues}`,
+    [uuid, ...emails],
+    0
+  );
+
+  return uuid;
 }

--- a/apps/passport-server/src/database/queries/telegram/deleteTelegramEvent.ts
+++ b/apps/passport-server/src/database/queries/telegram/deleteTelegramEvent.ts
@@ -1,11 +1,11 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../../sqlQuery";
 
 /**
  * Delete an event <> telegram chat entry.
  */
 export async function deleteTelegramEvent(
-  client: Pool,
+  client: PoolClient,
   ticketEventId: string
 ): Promise<void> {
   await sqlQuery(
@@ -19,7 +19,7 @@ export async function deleteTelegramEvent(
 }
 
 export async function deleteTelegramChat(
-  client: Pool,
+  client: PoolClient,
   telegramChatId: number
 ): Promise<void> {
   await sqlQuery(
@@ -33,7 +33,7 @@ export async function deleteTelegramChat(
 }
 
 export async function deleteTelegramChatTopic(
-  client: Pool,
+  client: PoolClient,
   telegramChatId: number,
   telegramTopicId: number
 ): Promise<void> {
@@ -48,7 +48,7 @@ export async function deleteTelegramChatTopic(
 }
 
 export async function deleteTelegramForward(
-  client: Pool,
+  client: PoolClient,
   receiverChatTopicID: number,
   senderChatTopicID: number | null
 ): Promise<void> {

--- a/apps/passport-server/src/database/queries/telegram/deleteTelegramVerification.ts
+++ b/apps/passport-server/src/database/queries/telegram/deleteTelegramVerification.ts
@@ -1,11 +1,11 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../../sqlQuery";
 
 /**
  * Delete a verification.
  */
 export async function deleteTelegramVerification(
-  client: Pool,
+  client: PoolClient,
   telegramUserId: number,
   telegramChatId: number
 ): Promise<void> {

--- a/apps/passport-server/src/database/queries/telegram/fetchSemaphoreId.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchSemaphoreId.ts
@@ -1,8 +1,8 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../../sqlQuery";
 
 export async function fetchSemaphoreIdFromTelegramUsername(
-  client: Pool,
+  client: PoolClient,
   telegramUsername: string
 ): Promise<string | null> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramConversation.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramConversation.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { AnonNullifierInfo, TelegramConversation } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
@@ -6,7 +6,7 @@ import { sqlQuery } from "../../sqlQuery";
  * Fetch the list of Telegram conversations for a user from the database.
  */
 export async function fetchTelegramConversation(
-  client: Pool,
+  client: PoolClient,
   telegramUserId: number
 ): Promise<TelegramConversation | null> {
   const result = await sqlQuery(
@@ -22,7 +22,7 @@ export async function fetchTelegramConversation(
 }
 
 export async function fetchTelegramConversationsByChatId(
-  client: Pool,
+  client: PoolClient,
   telegramChatId: number
 ): Promise<TelegramConversation[]> {
   const result = await sqlQuery(
@@ -37,11 +37,8 @@ export async function fetchTelegramConversationsByChatId(
   return result.rows;
 }
 
-/**
- *
- */
 export async function fetchTelegramVerificationStatus(
-  client: Pool,
+  client: PoolClient,
   telegramUserId: number,
   telegramChatId: number
 ): Promise<boolean> {
@@ -59,7 +56,7 @@ export async function fetchTelegramVerificationStatus(
 }
 
 export async function fetchAnonTopicNullifier(
-  client: Pool,
+  client: PoolClient,
   nullifierHash: string,
   chatTopicId: number
 ): Promise<AnonNullifierInfo | undefined> {

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramEvent.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import {
   AnonMessage,
   AnonMessageWithDetails,
@@ -18,7 +18,7 @@ import { sqlQuery } from "../../sqlQuery";
  * Fetch the list of Telegram conversations from the database.
  */
 export async function fetchTelegramEventByEventId(
-  client: Pool,
+  client: PoolClient,
   eventId: string
 ): Promise<TelegramEvent[]> {
   const result = await sqlQuery(
@@ -34,7 +34,7 @@ export async function fetchTelegramEventByEventId(
 }
 
 export async function fetchTelegramBotEvent(
-  client: Pool,
+  client: PoolClient,
   eventId: string,
   telegramChatID: string | number
 ): Promise<TelegramEvent> {
@@ -51,7 +51,7 @@ export async function fetchTelegramBotEvent(
 }
 
 export async function fetchTelegramChat(
-  client: Pool,
+  client: PoolClient,
   telegramChatId: number
 ): Promise<TelegramChat> {
   const result = await sqlQuery(
@@ -67,7 +67,7 @@ export async function fetchTelegramChat(
 }
 
 export async function fetchTelegramEventsByChatId(
-  client: Pool,
+  client: PoolClient,
   telegramChatId: number | string
 ): Promise<TelegramEvent[]> {
   const result = await sqlQuery(
@@ -83,7 +83,7 @@ export async function fetchTelegramEventsByChatId(
 }
 
 export async function fetchEventsWithTelegramChats(
-  client: Pool,
+  client: PoolClient,
   distinct = true,
   currentTelegramChatId?: number
 ): Promise<LinkedPretixTelegramEvent[]> {
@@ -115,7 +115,7 @@ export async function fetchEventsWithTelegramChats(
 }
 
 export async function fetchEventsPerChat(
-  client: Pool
+  client: PoolClient
 ): Promise<ChatIDWithEventIDs[]> {
   const result = await sqlQuery(
     client,
@@ -132,7 +132,7 @@ export async function fetchEventsPerChat(
 }
 
 export async function fetchTelegramAnonTopicsByChatId(
-  client: Pool,
+  client: PoolClient,
   telegramChatId: number
 ): Promise<TelegramTopicFetch[]> {
   const result = await sqlQuery(
@@ -147,7 +147,7 @@ export async function fetchTelegramAnonTopicsByChatId(
 }
 
 export async function fetchTelegramTopicsByChatId(
-  client: Pool,
+  client: PoolClient,
   telegramChatId: number
 ): Promise<TelegramTopicFetch[]> {
   const result = await sqlQuery(
@@ -162,7 +162,7 @@ export async function fetchTelegramTopicsByChatId(
 }
 
 export async function fetchUserTelegramChats(
-  client: Pool,
+  client: PoolClient,
   telegramUserID: number
 ): Promise<UserIDWithChatIDs | null> {
   const result = await sqlQuery(
@@ -187,7 +187,7 @@ export async function fetchUserTelegramChats(
 // The list is sorted such that chat a user hasn't joined are returned first
 // If a chatId is provided, only chats with that id are returned.
 export async function fetchTelegramChatsWithMembershipStatus(
-  client: Pool,
+  client: PoolClient,
   userId: number,
   chatId?: number
 ): Promise<ChatIDWithEventsAndMembership[]> {
@@ -222,7 +222,7 @@ export async function fetchTelegramChatsWithMembershipStatus(
 }
 
 export async function fetchTelegramTopic(
-  client: Pool,
+  client: PoolClient,
   telegramChatId: number | string,
   topicId?: number | string
 ): Promise<TelegramTopicFetch | null> {
@@ -241,7 +241,7 @@ export async function fetchTelegramTopic(
 }
 
 export async function fetchTelegramTopicsReceiving(
-  client: Pool
+  client: PoolClient
 ): Promise<TelegramTopicWithFwdInfo[]> {
   const result = await sqlQuery(
     client,
@@ -261,7 +261,7 @@ export async function fetchTelegramTopicsReceiving(
  * The resulting value can be used to determine the source and destination for the forwarded message.
  */
 export async function fetchTelegramTopicForwarding(
-  client: Pool,
+  client: PoolClient,
   sendingChatID: string | number,
   sendingTopicID?: string | number
 ): Promise<TelegramForwardFetch[]> {
@@ -291,7 +291,7 @@ export async function fetchTelegramTopicForwarding(
 }
 
 export async function fetchTelegramAnonMessagesByNullifier(
-  client: Pool,
+  client: PoolClient,
   nullifierHash: string
 ): Promise<AnonMessage[]> {
   const result = await sqlQuery(
@@ -306,7 +306,7 @@ export async function fetchTelegramAnonMessagesByNullifier(
 }
 
 export async function fetchTelegramAnonMessagesById(
-  client: Pool,
+  client: PoolClient,
   id: string
 ): Promise<(AnonMessage & { telegram_chat_id: string }) | null> {
   const result = await sqlQuery(
@@ -323,7 +323,7 @@ export async function fetchTelegramAnonMessagesById(
 }
 
 export async function fetchTelegramChatTopicById(
-  client: Pool,
+  client: PoolClient,
   chatTopicId: number
 ): Promise<TelegramTopicFetch> {
   const result = await sqlQuery(
@@ -338,7 +338,7 @@ export async function fetchTelegramChatTopicById(
 }
 
 export async function fetchTelegramAnonMessagesWithTopicByNullifier(
-  client: Pool,
+  client: PoolClient,
   nullifierHash: string
 ): Promise<AnonMessageWithDetails[]> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramReactions.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramReactions.ts
@@ -1,9 +1,9 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { TelegramReactionCount } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
 export async function fetchTelegramReactionsForMessage(
-  client: Pool,
+  client: PoolClient,
   anonMessageId: string
 ): Promise<TelegramReactionCount[]> {
   const result = await sqlQuery(
@@ -27,7 +27,7 @@ export async function fetchTelegramReactionsForMessage(
 }
 
 export async function fetchTelegramTotalKarmaForNullifier(
-  client: Pool,
+  client: PoolClient,
   nulliferHash: string
 ): Promise<number> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/database/queries/telegram/fetchTelegramUsername.ts
+++ b/apps/passport-server/src/database/queries/telegram/fetchTelegramUsername.ts
@@ -1,8 +1,8 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../../sqlQuery";
 
 export async function fetchTelegramUsernameFromSemaphoreId(
-  client: Pool,
+  client: PoolClient,
   sempahoreId: string
 ): Promise<string | null> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/database/queries/telegram/insertTelegramConversation.ts
+++ b/apps/passport-server/src/database/queries/telegram/insertTelegramConversation.ts
@@ -1,11 +1,11 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../../sqlQuery";
 
 /**
  * Insert a Telegram conversation into the database.
  */
 export async function insertTelegramVerification(
-  client: Pool,
+  client: PoolClient,
   telegramUserId: number,
   telegramChatId: number,
   semaphoreId: string,
@@ -23,7 +23,7 @@ export async function insertTelegramVerification(
 }
 
 export async function insertTelegramChat(
-  client: Pool,
+  client: PoolClient,
   telegramChatId: number
 ): Promise<number> {
   const result = await sqlQuery(
@@ -38,7 +38,7 @@ export async function insertTelegramChat(
 }
 
 export async function insertTelegramEvent(
-  client: Pool,
+  client: PoolClient,
   ticketEventId: string,
   telegramChatId: number
 ): Promise<number> {
@@ -54,7 +54,7 @@ on conflict (ticket_event_id, telegram_chat_id) do nothing;`,
 }
 
 export async function insertTelegramTopic(
-  client: Pool,
+  client: PoolClient,
   telegramChatId: string | number,
   topicName: string,
   topicId?: string | number | null,
@@ -73,7 +73,7 @@ set topic_name = $3, is_anon_topic = $4;`,
 }
 
 export async function insertOrUpdateTelegramNullifier(
-  client: Pool,
+  client: PoolClient,
   nullifierHash: string,
   messageTimestamps: string[],
   chatTopicId: number
@@ -93,7 +93,7 @@ export async function insertOrUpdateTelegramNullifier(
 }
 
 export async function updateTelegramUsername(
-  client: Pool,
+  client: PoolClient,
   telegramUserId: string,
   telegramUsername: string
 ): Promise<void> {
@@ -108,7 +108,7 @@ export async function updateTelegramUsername(
 }
 
 export async function insertTelegramForward(
-  client: Pool,
+  client: PoolClient,
   senderChatTopicID: number | null,
   receiverChatTopicID: number | null
 ): Promise<number> {
@@ -124,7 +124,7 @@ on conflict (sender_chat_topic_id, receiver_chat_topic_id) do nothing`,
 }
 
 export async function insertTelegramAnonMessage(
-  client: Pool,
+  client: PoolClient,
   id: string,
   nullifierHash: string,
   chatTopicId: number,

--- a/apps/passport-server/src/database/queries/telegram/insertTelegramReaction.ts
+++ b/apps/passport-server/src/database/queries/telegram/insertTelegramReaction.ts
@@ -1,8 +1,8 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../../sqlQuery";
 
 export async function insertTelegramReaction(
-  client: Pool,
+  client: PoolClient,
   proof: string,
   anonMessageId: string,
   reaction: string,

--- a/apps/passport-server/src/database/queries/users.ts
+++ b/apps/passport-server/src/database/queries/users.ts
@@ -1,5 +1,5 @@
 import { VerifiedCredential } from "@pcd/passport-interface";
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { UserRow } from "../models";
 import { sqlQuery } from "../sqlQuery";
 
@@ -8,7 +8,7 @@ import { sqlQuery } from "../sqlQuery";
  * email from the database.
  */
 export async function fetchUserByEmail(
-  client: Pool,
+  client: PoolClient,
   email: string
 ): Promise<UserRow | null> {
   const result = await sqlQuery(
@@ -27,7 +27,7 @@ export async function fetchUserByEmail(
  * Fetches the user row corresponding to a particular uuid from the database.
  */
 export async function fetchUserByUUID(
-  client: Pool,
+  client: PoolClient,
   uuid: string
 ): Promise<UserRow | null> {
   const result = await sqlQuery(
@@ -46,7 +46,7 @@ export async function fetchUserByUUID(
 /**
  * Fetches all the users from the database.
  */
-export async function fetchAllUsers(client: Pool): Promise<UserRow[]> {
+export async function fetchAllUsers(client: PoolClient): Promise<UserRow[]> {
   const result = await sqlQuery(
     client,
     `SELECT u.*, array_agg(ue.email) as emails
@@ -63,7 +63,7 @@ export async function fetchAllUsers(client: Pool): Promise<UserRow[]> {
  * on an interval.
  */
 export async function deleteUserByEmail(
-  client: Pool,
+  client: PoolClient,
   email: string
 ): Promise<void> {
   await sqlQuery(
@@ -81,7 +81,7 @@ export async function deleteUserByEmail(
  * on an interval.
  */
 export async function deleteUserByUUID(
-  client: Pool,
+  client: PoolClient,
   uuid: string
 ): Promise<void> {
   await sqlQuery(client, `DELETE FROM users WHERE uuid = $1`, [uuid]);
@@ -90,7 +90,7 @@ export async function deleteUserByUUID(
 /**
  * Fetches the quantity of users.
  */
-export async function fetchUserCount(client: Pool): Promise<number> {
+export async function fetchUserCount(client: PoolClient): Promise<number> {
   const result = await sqlQuery(client, "SELECT COUNT(*) AS count FROM users");
   return parseInt(result.rows[0].count, 10);
 }
@@ -99,7 +99,7 @@ export async function fetchUserCount(client: Pool): Promise<number> {
  * Fetches a user given a verified credential.
  */
 export async function fetchUserForCredential(
-  client: Pool,
+  client: PoolClient,
   credential?: VerifiedCredential | null
 ): Promise<UserRow | null> {
   if (!credential) {
@@ -113,7 +113,7 @@ export async function fetchUserForCredential(
  * Fetches a user by their semaphore v3 commitment.
  */
 export async function fetchUserByV3Commitment(
-  client: Pool,
+  client: PoolClient,
   v3Commitment: string
 ): Promise<UserRow | null> {
   const result = await sqlQuery(
@@ -137,7 +137,7 @@ export async function fetchUserByV3Commitment(
  * Fetches a user by their semaphore v4 commitment.
  */
 export async function fetchUserByV4Commitment(
-  client: Pool,
+  client: PoolClient,
   v4Commitment: string
 ): Promise<UserRow | null> {
   const result = await sqlQuery(
@@ -161,7 +161,7 @@ export async function fetchUserByV4Commitment(
  * Fetches users who have agreed to minimum legal terms.
  */
 export async function fetchUsersByMinimumAgreedTerms(
-  client: Pool,
+  client: PoolClient,
   version: number
 ): Promise<UserRow[]> {
   const result = await sqlQuery(
@@ -181,7 +181,7 @@ export async function fetchUsersByMinimumAgreedTerms(
  * Fetch all users with Devconnect tickets
  */
 export async function fetchAllUsersWithDevconnectTickets(
-  client: Pool
+  client: PoolClient
 ): Promise<UserRow[]> {
   const result = await sqlQuery(
     client,
@@ -202,7 +202,7 @@ export async function fetchAllUsersWithDevconnectTickets(
  * Fetch all users with superuser Devconnect tickets
  */
 export async function fetchAllUsersWithDevconnectSuperuserTickets(
-  client: Pool
+  client: PoolClient
 ): Promise<UserRow[]> {
   const result = await sqlQuery(
     client,

--- a/apps/passport-server/src/database/queries/zuconnect/fetchZuconnectTickets.ts
+++ b/apps/passport-server/src/database/queries/zuconnect/fetchZuconnectTickets.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { ZuconnectTicketDB } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
@@ -6,7 +6,7 @@ import { sqlQuery } from "../../sqlQuery";
  * Fetches all non-deleted Zuconnect Tickets.
  */
 export async function fetchAllZuconnectTickets(
-  client: Pool
+  client: PoolClient
 ): Promise<ZuconnectTicketDB[]> {
   const result = await sqlQuery(
     client,
@@ -21,7 +21,7 @@ export async function fetchAllZuconnectTickets(
  * Fetches the IDs of all non-deleted Zuconnect tickets.
  */
 export async function fetchAllZuconnectTicketIds(
-  client: Pool
+  client: PoolClient
 ): Promise<ZuconnectTicketDB["id"][]> {
   const result = await sqlQuery(
     client,
@@ -37,7 +37,7 @@ export async function fetchAllZuconnectTicketIds(
  * Fetches all Zuconnect tickets with a given email address.
  */
 export async function fetchZuconnectTicketsByEmail(
-  client: Pool,
+  client: PoolClient,
   email: string
 ): Promise<ZuconnectTicketDB[]> {
   const result = await sqlQuery(
@@ -55,7 +55,7 @@ export async function fetchZuconnectTicketsByEmail(
  * Fetches a Zuconnect ticket by ID.
  */
 export async function fetchZuconnectTicketById(
-  client: Pool,
+  client: PoolClient,
   id: string
 ): Promise<ZuconnectTicketDB | undefined> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/database/queries/zuconnect/fetchZuconnectUsers.ts
+++ b/apps/passport-server/src/database/queries/zuconnect/fetchZuconnectUsers.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { UserRow, ZuconnectTicketDB } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
@@ -15,7 +15,7 @@ export type LoggedInZuconnectUser = UserRow & {
  * Fetches all logged-in users with a non-deleted Zuconnect ticket.
  */
 export async function fetchAllLoggedInZuconnectUsers(
-  client: Pool
+  client: PoolClient
 ): Promise<LoggedInZuconnectUser[]> {
   const result = await sqlQuery(
     client,

--- a/apps/passport-server/src/database/queries/zuzalu_pretix_tickets/deleteZuzaluUser.ts
+++ b/apps/passport-server/src/database/queries/zuzalu_pretix_tickets/deleteZuzaluUser.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { sqlQuery } from "../../sqlQuery";
 
 /**
@@ -6,7 +6,7 @@ import { sqlQuery } from "../../sqlQuery";
  * identity commitment, if they have logged into the passport.
  */
 export async function deleteZuzaluTicket(
-  client: Pool,
+  client: PoolClient,
   email: string
 ): Promise<void> {
   await sqlQuery(client, `delete from zuzalu_pretix_tickets where email = $1`, [

--- a/apps/passport-server/src/database/queries/zuzalu_pretix_tickets/fetchZuzaluUser.ts
+++ b/apps/passport-server/src/database/queries/zuzalu_pretix_tickets/fetchZuzaluUser.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { UserRow, ZuzaluPretixTicket } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
@@ -11,7 +11,7 @@ export type UserWithZuzaluTickets = UserRow & {
  * an array of their Zuzalu pretix tickets.
  */
 export async function fetchAllUsersWithZuzaluTickets(
-  client: Pool
+  client: PoolClient
 ): Promise<UserWithZuzaluTickets[]> {
   const result = await sqlQuery(
     client,
@@ -71,7 +71,7 @@ group by u.uuid;`
  * Zupass users in any way.
  */
 export async function fetchAllZuzaluPretixTickets(
-  client: Pool
+  client: PoolClient
 ): Promise<ZuzaluPretixTicket[]> {
   const result = await sqlQuery(
     client,

--- a/apps/passport-server/src/database/queries/zuzalu_pretix_tickets/insertZuzaluPretixTicket.ts
+++ b/apps/passport-server/src/database/queries/zuzalu_pretix_tickets/insertZuzaluPretixTicket.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { ZuzaluPretixTicket } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
@@ -7,7 +7,7 @@ import { sqlQuery } from "../../sqlQuery";
  * inserted yet. This does not insert an identity commitment for them.
  */
 export async function insertZuzaluPretixTicket(
-  client: Pool,
+  client: PoolClient,
   params: ZuzaluPretixTicket
 ): Promise<number> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/database/queries/zuzalu_pretix_tickets/updateZuzaluPretixTicket.ts
+++ b/apps/passport-server/src/database/queries/zuzalu_pretix_tickets/updateZuzaluPretixTicket.ts
@@ -1,4 +1,4 @@
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { ZuzaluPretixTicket } from "../../models";
 import { sqlQuery } from "../../sqlQuery";
 
@@ -6,7 +6,7 @@ import { sqlQuery } from "../../sqlQuery";
  * Updates a pretix ticket in our database.
  */
 export async function updateZuzaluPretixTicket(
-  client: Pool,
+  client: PoolClient,
   params: ZuzaluPretixTicket
 ): Promise<number> {
   const result = await sqlQuery(

--- a/apps/passport-server/src/routing/pcdHttpError.ts
+++ b/apps/passport-server/src/routing/pcdHttpError.ts
@@ -15,6 +15,22 @@ export class PCDHTTPError extends Error {
 }
 
 /**
+ * Throw an instance of this error in server application within an express
+ * request handler to to return a custom status code, and optionally an object
+ * that is returned a JSON response.
+ */
+export class PCDHTTPJSONError extends Error {
+  public readonly code: number;
+  public readonly json?: object;
+
+  public constructor(code: number, json?: object, options?: ErrorOptions) {
+    super(JSON.stringify(json), options);
+    this.code = code;
+    this.json = json;
+  }
+}
+
+/**
  * If {@link e} is an instance of {@link PCDHTTPError}, returns with the error code
  * and message specified in the error.
  *
@@ -24,7 +40,7 @@ export class PCDHTTPError extends Error {
  * If {@link e} is not an {@link PCDHTTPError}, returns with a generic 500 server error.
  */
 export function respondWithError(
-  e: PCDHTTPError | Error | unknown,
+  e: PCDHTTPError | PCDHTTPJSONError | Error | unknown,
   res: Response
 ): void {
   if (e instanceof PCDHTTPError) {
@@ -33,6 +49,8 @@ export function respondWithError(
     } else {
       res.status(e.code).send(e.message);
     }
+  } else if (e instanceof PCDHTTPJSONError) {
+    res.status(e.code).json(e.json);
   } else {
     res.sendStatus(500);
   }

--- a/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
+++ b/apps/passport-server/src/routing/routes/frogcryptoRoutes.ts
@@ -15,6 +15,7 @@ import {
 } from "@pcd/passport-interface";
 import express, { Request, Response } from "express";
 import urljoin from "url-join";
+import { namedSqlTransaction } from "../../database/sqlQuery";
 import { FrogcryptoService } from "../../services/frogcryptoService";
 import { ApplicationContext, GlobalServices } from "../../types";
 import { logger } from "../../util/logger";
@@ -23,7 +24,7 @@ import { PCDHTTPError } from "../pcdHttpError";
 
 export function initFrogcryptoRoutes(
   app: express.Application,
-  _context: ApplicationContext,
+  context: ApplicationContext,
   { frogcryptoService }: GlobalServices
 ): void {
   logger("[INIT] initializing frogcrypto routes");
@@ -77,22 +78,38 @@ export function initFrogcryptoRoutes(
 
   app.get("/frogcrypto/scoreboard", async (req, res) => {
     checkFrogcryptoServiceStarted(frogcryptoService);
-    const result = await frogcryptoService.getScoreboard();
+    const result = await namedSqlTransaction(
+      context.dbPool,
+      "/frogcrypto/scoreboard",
+      (client) => frogcryptoService.getScoreboard(client)
+    );
     res.json(result);
   });
 
   app.post("/frogcrypto/telegram-handle-sharing", async (req, res) => {
     checkFrogcryptoServiceStarted(frogcryptoService);
-    const result = await frogcryptoService.updateTelegramHandleSharing(
-      req.body as FrogCryptoShareTelegramHandleRequest
+    const result = await namedSqlTransaction(
+      context.dbPool,
+      "/frogcrypto/telegram-handle-sharing",
+      (client) =>
+        frogcryptoService.updateTelegramHandleSharing(
+          client,
+          req.body as FrogCryptoShareTelegramHandleRequest
+        )
     );
     res.json(result satisfies FrogCryptoShareTelegramHandleResponseValue);
   });
 
   app.post("/frogcrypto/user-state", async (req, res) => {
     checkFrogcryptoServiceStarted(frogcryptoService);
-    const result = await frogcryptoService.getUserState(
-      req.body as FrogCryptoUserStateRequest
+    const result = await namedSqlTransaction(
+      context.dbPool,
+      "/frogcrypto/user-state",
+      (client) =>
+        frogcryptoService.getUserState(
+          client,
+          req.body as FrogCryptoUserStateRequest
+        )
     );
     res.json(result satisfies FrogCryptoUserStateResponseValue);
   });
@@ -109,24 +126,42 @@ export function initFrogcryptoRoutes(
 
   app.post("/frogcrypto/admin/frogs", async (req, res) => {
     checkFrogcryptoServiceStarted(frogcryptoService);
-    const result = await frogcryptoService.updateFrogData(
-      req.body as FrogCryptoUpdateFrogsRequest
+    const result = await namedSqlTransaction(
+      context.dbPool,
+      "/frogcrypto/admin/frogs",
+      (client) =>
+        frogcryptoService.updateFrogData(
+          client,
+          req.body as FrogCryptoUpdateFrogsRequest
+        )
     );
     res.json(result satisfies FrogCryptoUpdateFrogsResponseValue);
   });
 
   app.post("/frogcrypto/admin/delete-frogs", async (req, res) => {
     checkFrogcryptoServiceStarted(frogcryptoService);
-    const result = await frogcryptoService.deleteFrogData(
-      req.body as FrogCryptoDeleteFrogsRequest
+    const result = await namedSqlTransaction(
+      context.dbPool,
+      "/frogcrypto/admin/delete-frogs",
+      (client) =>
+        frogcryptoService.deleteFrogData(
+          client,
+          req.body as FrogCryptoDeleteFrogsRequest
+        )
     );
     res.json(result satisfies FrogCryptoDeleteFrogsResponseValue);
   });
 
   app.post("/frogcrypto/admin/feeds", async (req, res) => {
     checkFrogcryptoServiceStarted(frogcryptoService);
-    const result = await frogcryptoService.updateFeedData(
-      req.body as FrogCryptoUpdateFeedsRequest
+    const result = await namedSqlTransaction(
+      context.dbPool,
+      "/frogcrypto/admin/feeds",
+      (client) =>
+        frogcryptoService.updateFeedData(
+          client,
+          req.body as FrogCryptoUpdateFeedsRequest
+        )
     );
     res.json(result satisfies FrogCryptoUpdateFeedsResponseValue);
   });

--- a/apps/passport-server/src/routing/routes/miscRoutes.ts
+++ b/apps/passport-server/src/routing/routes/miscRoutes.ts
@@ -1,6 +1,7 @@
 import { bigintToPseudonymNumber, emailToBigint } from "@pcd/util";
 import express, { Request, Response } from "express";
 import { kvGetByPrefix } from "../../database/queries/kv";
+import { sqlTransaction } from "../../database/sqlQuery";
 import { ApplicationContext, GlobalServices } from "../../types";
 import { logger } from "../../util/logger";
 
@@ -14,9 +15,8 @@ export function initMiscRoutes(
   app.get(
     "/misc/protocol-worlds-scoreboard",
     async (req: Request, res: Response) => {
-      const scores = (await kvGetByPrefix(
-        context.dbPool,
-        "protocol_worlds_score:"
+      const scores = (await sqlTransaction(context.dbPool, (client) =>
+        kvGetByPrefix(client, "protocol_worlds_score:")
       )) as Array<{ email: string; score: number }>;
 
       scores.sort((a, b) => b.score - a.score);

--- a/apps/passport-server/src/routing/routes/poapRoutes.ts
+++ b/apps/passport-server/src/routing/routes/poapRoutes.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response } from "express";
+import { namedSqlTransaction } from "../../database/sqlQuery";
 import { ApplicationContext, GlobalServices } from "../../types";
 import { logger } from "../../util/logger";
 import { checkQueryParam } from "../params";
@@ -6,7 +7,7 @@ import { PCDHTTPError } from "../pcdHttpError";
 
 export function initPoapRoutes(
   app: express.Application,
-  _context: ApplicationContext,
+  context: ApplicationContext,
   { poapService }: GlobalServices
 ): void {
   logger("[INIT] initializing poap routes");
@@ -20,7 +21,15 @@ export function initPoapRoutes(
       );
     }
 
-    res.redirect(await poapService.getDevconnectPoapRedirectUrl(proof));
+    await namedSqlTransaction(
+      context.dbPool,
+      "/poap/devconnect/callback",
+      async (client) => {
+        res.redirect(
+          await poapService.getDevconnectPoapRedirectUrl(client, proof)
+        );
+      }
+    );
   });
 
   app.get("/poap/zuzalu23/callback", async (req: Request, res: Response) => {
@@ -32,7 +41,15 @@ export function initPoapRoutes(
       );
     }
 
-    res.redirect(await poapService.getZuzalu23PoapRedirectUrl(proof));
+    await namedSqlTransaction(
+      context.dbPool,
+      "/poap/zuzalu23/callback",
+      async (client) => {
+        res.redirect(
+          await poapService.getZuzalu23PoapRedirectUrl(client, proof)
+        );
+      }
+    );
   });
 
   app.get("/poap/zuconnect/callback", async (req: Request, res: Response) => {
@@ -44,7 +61,15 @@ export function initPoapRoutes(
       );
     }
 
-    res.redirect(await poapService.getZuConnectPoapRedirectUrl(proof));
+    await namedSqlTransaction(
+      context.dbPool,
+      "/poap/devconnect/callback",
+      async (client) => {
+        res.redirect(
+          await poapService.getZuConnectPoapRedirectUrl(client, proof)
+        );
+      }
+    );
   });
 
   app.get("/poap/vitalia/callback", async (req: Request, res: Response) => {
@@ -56,7 +81,15 @@ export function initPoapRoutes(
       );
     }
 
-    res.redirect(await poapService.getVitaliaPoapRedirectUrl(proof));
+    await namedSqlTransaction(
+      context.dbPool,
+      "/poap/vitalia/callback",
+      async (client) => {
+        res.redirect(
+          await poapService.getVitaliaPoapRedirectUrl(client, proof)
+        );
+      }
+    );
   });
 
   app.get(
@@ -70,7 +103,15 @@ export function initPoapRoutes(
         );
       }
 
-      res.redirect(await poapService.getEdgeCityDenverPoapRedirectUrl(proof));
+      await namedSqlTransaction(
+        context.dbPool,
+        "/poap/edgecitydenver/callback",
+        async (client) => {
+          res.redirect(
+            await poapService.getEdgeCityDenverPoapRedirectUrl(client, proof)
+          );
+        }
+      );
     }
   );
 
@@ -83,6 +124,14 @@ export function initPoapRoutes(
       );
     }
 
-    res.redirect(await poapService.getETHLatamPoapRedirectUrl(proof));
+    await namedSqlTransaction(
+      context.dbPool,
+      "/poap/ethlatam/callback",
+      async (client) => {
+        res.redirect(
+          await poapService.getETHLatamPoapRedirectUrl(client, proof)
+        );
+      }
+    );
   });
 }

--- a/apps/passport-server/src/services.ts
+++ b/apps/passport-server/src/services.ts
@@ -41,7 +41,7 @@ export async function startServices(
   const credentialSubservice = await startCredentialSubservice(context.dbPool);
   const provingService = await startProvingService(rollbarService);
   const emailService = startEmailService(context, apis.emailAPI);
-  const emailTokenService = startEmailTokenService(context);
+  const emailTokenService = startEmailTokenService();
   const semaphoreService = startSemaphoreService(context);
   const zuzaluPretixSyncService = startZuzaluPretixSyncService(
     context,
@@ -56,7 +56,7 @@ export async function startServices(
     apis.devconnectPretixAPIFactory
   );
 
-  const e2eeService = startE2EEService(context, credentialSubservice);
+  const e2eeService = startE2EEService(credentialSubservice);
   const metricsService = startMetricsService(context, rollbarService);
   const persistentCacheService = startPersistentCacheService(
     context.dbPool,

--- a/apps/passport-server/src/services/devconnectPretixSyncService.ts
+++ b/apps/passport-server/src/services/devconnectPretixSyncService.ts
@@ -12,6 +12,7 @@ import {
   fetchKnownTicketTypesByGroup,
   setKnownTicketType
 } from "../database/queries/knownTicketTypes";
+import { namedSqlTransaction, sqlTransaction } from "../database/sqlQuery";
 import { ApplicationContext } from "../types";
 import { logger } from "../util/logger";
 import { OrganizerSync } from "./devconnect/organizerSync";
@@ -31,7 +32,7 @@ export class DevconnectPretixSyncService {
 
   private rollbarService: RollbarService | null;
   private semaphoreService: SemaphoreService;
-  private db: Pool;
+  private pool: Pool;
   private timeout: NodeJS.Timeout | undefined;
   private _hasCompletedSyncSinceStarting: boolean;
   private organizers: Map<string, OrganizerSync>;
@@ -47,7 +48,7 @@ export class DevconnectPretixSyncService {
     rollbarService: RollbarService | null,
     semaphoreService: SemaphoreService
   ) {
-    this.db = context.dbPool;
+    this.pool = context.dbPool;
     this.rollbarService = rollbarService;
     this.semaphoreService = semaphoreService;
     this.pretixAPIFactory = pretixAPIFactory;
@@ -106,7 +107,9 @@ export class DevconnectPretixSyncService {
    * (Re)load Pretix configuration, and set up organizers.
    */
   private async setupOrganizers(): Promise<void> {
-    const devconnectPretixConfig = await getDevconnectPretixConfig(this.db);
+    const devconnectPretixConfig = await sqlTransaction(this.pool, (client) =>
+      getDevconnectPretixConfig(client)
+    );
 
     if (!devconnectPretixConfig) {
       throw new Error("Pretix Config could not be loaded");
@@ -129,7 +132,7 @@ export class DevconnectPretixSyncService {
       const org = new OrganizerSync(
         config,
         await this.pretixAPIFactory(),
-        this.db
+        this.pool
       );
       this.organizers.set(id, org);
     }
@@ -210,36 +213,42 @@ export class DevconnectPretixSyncService {
    * See also {@link setupKnownTicketTypes} in the issuance service.
    */
   public async setDevconnectTicketTypes(): Promise<void> {
-    const products = await fetchDevconnectProducts(this.db);
-    const savedProductIds = [];
+    return namedSqlTransaction(
+      this.pool,
+      "setDevconnectTicketTypes",
+      async (client) => {
+        const products = await fetchDevconnectProducts(client);
+        const savedProductIds = [];
 
-    for (const product of products) {
-      await setKnownTicketType(
-        this.db,
-        `sync-${product.product_id}`,
-        product.event_id,
-        product.product_id,
-        ZUPASS_TICKET_PUBLIC_KEY_NAME,
-        KnownPublicKeyType.EdDSA,
-        // This works since we're only using this sync service for Devconnect
-        KnownTicketGroup.Devconnect23,
-        "Devconnect '23"
-      );
+        for (const product of products) {
+          await setKnownTicketType(
+            client,
+            `sync-${product.product_id}`,
+            product.event_id,
+            product.product_id,
+            ZUPASS_TICKET_PUBLIC_KEY_NAME,
+            KnownPublicKeyType.EdDSA,
+            // This works since we're only using this sync service for Devconnect
+            KnownTicketGroup.Devconnect23,
+            "Devconnect '23"
+          );
 
-      savedProductIds.push(product.product_id);
-    }
+          savedProductIds.push(product.product_id);
+        }
 
-    // Check to see if there are any tickets in the DB which were not present
-    // in the sync, and delete them.
-    const existingTicketTypes = await fetchKnownTicketTypesByGroup(
-      this.db,
-      KnownTicketGroup.Devconnect23
-    );
-    for (const existingType of existingTicketTypes) {
-      if (!savedProductIds.find((p) => p === existingType.product_id)) {
-        await deleteKnownTicketType(this.db, existingType.identifier);
+        // Check to see if there are any tickets in the DB which were not present
+        // in the sync, and delete them.
+        const existingTicketTypes = await fetchKnownTicketTypesByGroup(
+          client,
+          KnownTicketGroup.Devconnect23
+        );
+        for (const existingType of existingTicketTypes) {
+          if (!savedProductIds.find((p) => p === existingType.product_id)) {
+            await deleteKnownTicketType(client, existingType.identifier);
+          }
+        }
       }
-    }
+    );
   }
 }
 

--- a/apps/passport-server/src/services/e2eeService.ts
+++ b/apps/passport-server/src/services/e2eeService.ts
@@ -7,7 +7,7 @@ import {
 } from "@pcd/passport-interface";
 import { SerializedPCD } from "@pcd/pcd-types";
 import { SemaphoreSignaturePCD } from "@pcd/semaphore-signature-pcd";
-import { Response } from "express";
+import { PoolClient } from "postgres-pool";
 import {
   UpdateEncryptedStorageResult,
   fetchEncryptedStorage,
@@ -16,8 +16,7 @@ import {
   updateEncryptedStorage
 } from "../database/queries/e2ee";
 import { fetchUserByUUID } from "../database/queries/users";
-import { PCDHTTPError } from "../routing/pcdHttpError";
-import { ApplicationContext } from "../types";
+import { PCDHTTPError, PCDHTTPJSONError } from "../routing/pcdHttpError";
 import { logger } from "../util/logger";
 import { CredentialSubservice } from "./generic-issuance/subservices/CredentialSubservice";
 
@@ -26,28 +25,20 @@ import { CredentialSubservice } from "./generic-issuance/subservices/CredentialS
  * backups of users' PCDs.
  */
 export class E2EEService {
-  private readonly context: ApplicationContext;
   private readonly credentialSubservice: CredentialSubservice;
 
-  public constructor(
-    context: ApplicationContext,
-    credentialsubservice: CredentialSubservice
-  ) {
-    this.context = context;
+  public constructor(credentialsubservice: CredentialSubservice) {
     this.credentialSubservice = credentialsubservice;
   }
 
   public async handleLoad(
+    client: PoolClient,
     blobKey: string,
-    knownRevision: string | undefined,
-    res: Response
-  ): Promise<void> {
+    knownRevision: string | undefined
+  ): Promise<DownloadEncryptedStorageResponseValue> {
     logger(`[E2EE] Loading ${blobKey}`);
 
-    const storageModel = await fetchEncryptedStorage(
-      this.context.dbPool,
-      blobKey
-    );
+    const storageModel = await fetchEncryptedStorage(client, blobKey);
 
     if (!storageModel) {
       throw new PCDHTTPError(
@@ -63,7 +54,8 @@ export class E2EEService {
     if (foundRevision !== knownRevision) {
       result.encryptedBlob = storageModel.encrypted_blob;
     }
-    res.json(result);
+
+    return result;
   }
 
   private checkUpdateResult(
@@ -89,9 +81,9 @@ export class E2EEService {
   }
 
   public async handleSave(
-    request: UploadEncryptedStorageRequest,
-    res: Response
-  ): Promise<void> {
+    client: PoolClient,
+    request: UploadEncryptedStorageRequest
+  ): Promise<UploadEncryptedStorageResponseValue> {
     logger(`[E2EE] Saving ${request.blobKey}`);
 
     if (!request.blobKey || !request.encryptedBlob) {
@@ -114,14 +106,14 @@ export class E2EEService {
     let resultRevision = undefined;
     if (request.knownRevision === undefined) {
       resultRevision = await setEncryptedStorage(
-        this.context.dbPool,
+        client,
         request.blobKey,
         request.encryptedBlob,
         commitment
       );
     } else {
       const updateResult = await updateEncryptedStorage(
-        this.context.dbPool,
+        client,
         request.blobKey,
         request.encryptedBlob,
         request.knownRevision,
@@ -134,42 +126,40 @@ export class E2EEService {
       );
     }
 
-    res.json({
+    return {
       revision: resultRevision
-    } satisfies UploadEncryptedStorageResponseValue);
+    } satisfies UploadEncryptedStorageResponseValue;
   }
 
   private setRekeyResult(
     blobKey: string,
     knownRevision: string | undefined,
-    updateResult: UpdateEncryptedStorageResult,
-    res: Response
-  ): void {
+    updateResult: UpdateEncryptedStorageResult
+  ): ChangeBlobKeyResponseValue {
     switch (updateResult.status) {
       case "updated":
-        res.json({
+        return {
           revision: updateResult.revision
-        } as ChangeBlobKeyResponseValue);
-        break;
+        } as ChangeBlobKeyResponseValue;
       case "conflict":
-        res.status(409).json({
+        throw new PCDHTTPJSONError(409, {
           error: {
             name: "Conflict",
             detailedMessage: `Can't rekey e2ee due to conflict: expected 
               revision ${knownRevision}, found ${updateResult.revision}`
           }
         });
-        break;
       case "missing":
-        res.status(401).json({ error: { name: "PasswordIncorrect" } });
-        break;
+        throw new PCDHTTPJSONError(401, {
+          error: { name: "PasswordIncorrect" }
+        });
     }
   }
 
   public async handleChangeBlobKey(
-    request: ChangeBlobKeyRequest,
-    res: Response
-  ): Promise<void> {
+    client: PoolClient,
+    request: ChangeBlobKeyRequest
+  ): Promise<ChangeBlobKeyResponseValue> {
     logger(
       `[E2EE] Rekeying ${request.oldBlobKey} to ${request.newBlobKey} for ${request.uuid}`
     );
@@ -196,31 +186,28 @@ export class E2EEService {
     }
 
     // Validate user.  User must exist, and new salt must be different.
-    const user = await fetchUserByUUID(this.context.dbPool, request.uuid);
+    const user = await fetchUserByUUID(client, request.uuid);
     if (!user) {
-      // @todo: make {@link PCDHTTPError} be able to return JSON, not just plain text
-      res.status(404).json({
+      throw new PCDHTTPJSONError(404, {
         error: {
           name: "UserNotFound",
           detailedMessage: "User with this uuid was not found"
         }
       });
-      return;
     }
 
     const { salt: oldSalt } = user;
     if (oldSalt === request.newSalt) {
-      res.status(400).json({
+      throw new PCDHTTPJSONError(400, {
         error: {
           name: "RequiresNewSalt",
           detailedMessage: "Updated salt must be different than existing salt"
         }
       });
-      return;
     }
 
     const rekeyResult = await rekeyEncryptedStorage(
-      this.context.dbPool,
+      client,
       request.oldBlobKey,
       request.newBlobKey,
       request.uuid,
@@ -229,18 +216,17 @@ export class E2EEService {
       request.knownRevision,
       commitment
     );
-    this.setRekeyResult(
+
+    return this.setRekeyResult(
       request.oldBlobKey,
       request.knownRevision,
-      rekeyResult,
-      res
+      rekeyResult
     );
   }
 }
 
 export function startE2EEService(
-  context: ApplicationContext,
   credentialSubservice: CredentialSubservice
 ): E2EEService {
-  return new E2EEService(context, credentialSubservice);
+  return new E2EEService(credentialSubservice);
 }

--- a/apps/passport-server/src/services/generic-issuance/AutoIssuanceProvider.ts
+++ b/apps/passport-server/src/services/generic-issuance/AutoIssuanceProvider.ts
@@ -4,6 +4,7 @@ import {
   MemberCriteria
 } from "@pcd/passport-interface";
 import { randomUUID } from "@pcd/util";
+import { PoolClient } from "postgres-pool";
 import { IPipelineConsumerDB } from "../../database/queries/pipelineConsumerDB";
 import { logger } from "../../util/logger";
 import { PretixAtom } from "./pipelines/PretixPipeline";
@@ -21,11 +22,12 @@ export class AutoIssuanceProvider {
   }
 
   public async dripNewManualTickets(
+    client: PoolClient,
     consumerDB: IPipelineConsumerDB,
     existingManualTickets: ManualTicket[],
     realTickets: PretixAtom[]
   ): Promise<ManualTicket[]> {
-    const allConsumers = await consumerDB.loadAll(this.pipelineId);
+    const allConsumers = await consumerDB.loadAll(client, this.pipelineId);
     const newManualTickets: ManualTicket[] = [];
 
     for (const consumer of allConsumers) {

--- a/apps/passport-server/src/services/generic-issuance/SemaphoreGroupProvider.ts
+++ b/apps/passport-server/src/services/generic-issuance/SemaphoreGroupProvider.ts
@@ -10,8 +10,11 @@ import {
 import { uuidToBigInt } from "@pcd/util";
 import { Group } from "@semaphore-protocol/group";
 import _ from "lodash";
+import { PoolClient } from "postgres-pool";
 import { IPipelineConsumerDB } from "../../database/queries/pipelineConsumerDB";
 import { IPipelineSemaphoreHistoryDB } from "../../database/queries/pipelineSemaphoreHistoryDB";
+import { sqlTransaction } from "../../database/sqlQuery";
+import { ApplicationContext } from "../../types";
 import { traced } from "../telemetryService";
 import { makeGenericIssuanceSemaphoreGroupUrl } from "./capabilities/SemaphoreGroupCapability";
 
@@ -39,6 +42,7 @@ const LOG_NAME = "SemaphoreGroupProvider";
  * Provides reusable Semaphore group features for pipelines.
  */
 export class SemaphoreGroupProvider {
+  private context: ApplicationContext;
   // The semaphore group configuration from the pipeline definition.
   private groupConfigs: SemaphoreGroupConfig[];
   private consumerDB: IPipelineConsumerDB;
@@ -48,11 +52,13 @@ export class SemaphoreGroupProvider {
   private groups: Map<string, Group>;
 
   public constructor(
+    context: ApplicationContext,
     pipelineId: string,
     groupConfigs: SemaphoreGroupConfig[],
     consumerDB: IPipelineConsumerDB,
     semaphoreHistoryDB: IPipelineSemaphoreHistoryDB
   ) {
+    this.context = context;
     this.groupConfigs = groupConfigs;
     this.consumerDB = consumerDB;
     this.pipelineId = pipelineId;
@@ -73,9 +79,11 @@ export class SemaphoreGroupProvider {
    * Get the latest group as a {@link SerializedSemaphoreGroup}.
    */
   public async getSerializedLatestGroup(
+    client: PoolClient,
     groupId: string
   ): Promise<SerializedSemaphoreGroup | undefined> {
     const group = await this.semaphoreHistoryDB.getLatestHistoryForGroup(
+      client,
       this.pipelineId,
       groupId
     );
@@ -90,9 +98,11 @@ export class SemaphoreGroupProvider {
    * Get the latest root hash for a group.
    */
   public async getLatestGroupRoot(
+    client: PoolClient,
     groupId: string
   ): Promise<string | undefined> {
     const group = await this.semaphoreHistoryDB.getLatestHistoryForGroup(
+      client,
       this.pipelineId,
       groupId
     );
@@ -106,10 +116,12 @@ export class SemaphoreGroupProvider {
    * Get a historical group as a {@link SerializedSemaphoreGroup}.
    */
   public async getSerializedHistoricalGroup(
+    client: PoolClient,
     groupId: string,
     rootHash: string
   ): Promise<SerializedSemaphoreGroup | undefined> {
     const group = await this.semaphoreHistoryDB.getHistoricalGroup(
+      client,
       this.pipelineId,
       groupId,
       rootHash
@@ -134,43 +146,51 @@ export class SemaphoreGroupProvider {
     return traced(LOG_NAME, "start", async (span) => {
       span?.setAttribute("pipeline_id", this.pipelineId);
 
-      // This should be called during pipeline startup.
-      // If an exception throws, it will stop the pipeline from starting.
-      const latestGroups =
-        await this.semaphoreHistoryDB.getLatestGroupsForPipeline(
-          this.pipelineId
+      sqlTransaction(this.context.dbPool, async (client) => {
+        // This should be called during pipeline startup.
+        // If an exception throws, it will stop the pipeline from starting.
+        const latestGroups =
+          await this.semaphoreHistoryDB.getLatestGroupsForPipeline(
+            client,
+            this.pipelineId
+          );
+
+        const latestGroupMap = new Map(
+          latestGroups.map((group) => [group.groupId, group])
         );
-      const latestGroupMap = new Map(
-        latestGroups.map((group) => [group.groupId, group])
-      );
 
-      for (const groupConfig of this.groupConfigs) {
-        const historicalGroup = latestGroupMap.get(groupConfig.groupId);
+        for (const groupConfig of this.groupConfigs) {
+          const historicalGroup = latestGroupMap.get(groupConfig.groupId);
 
-        this.groups.set(
-          groupConfig.groupId,
-          historicalGroup
-            ? await deserializeSemaphoreGroup(
-                JSON.parse(historicalGroup.serializedGroup)
-              )
-            : new Group(
-                uuidToBigInt(groupConfig.groupId),
-                SEMAPHORE_GROUP_DEPTH
-              )
-        );
-      }
-
-      span?.setAttribute("groups_in_db_count", latestGroupMap.size);
-      span?.setAttribute("configured_groups_count", this.groupConfigs.length);
-
-      const configuredGroupIds = new Set(
-        this.groupConfigs.map((gc) => gc.groupId)
-      );
-      for (const groupId of latestGroupMap.keys()) {
-        if (!configuredGroupIds.has(groupId)) {
-          this.semaphoreHistoryDB.deleteGroupHistory(this.pipelineId, groupId);
+          this.groups.set(
+            groupConfig.groupId,
+            historicalGroup
+              ? await deserializeSemaphoreGroup(
+                  JSON.parse(historicalGroup.serializedGroup)
+                )
+              : new Group(
+                  uuidToBigInt(groupConfig.groupId),
+                  SEMAPHORE_GROUP_DEPTH
+                )
+          );
         }
-      }
+
+        span?.setAttribute("groups_in_db_count", latestGroupMap.size);
+        span?.setAttribute("configured_groups_count", this.groupConfigs.length);
+
+        const configuredGroupIds = new Set(
+          this.groupConfigs.map((gc) => gc.groupId)
+        );
+        for (const groupId of latestGroupMap.keys()) {
+          if (!configuredGroupIds.has(groupId)) {
+            this.semaphoreHistoryDB.deleteGroupHistory(
+              client,
+              this.pipelineId,
+              groupId
+            );
+          }
+        }
+      });
     });
   }
 
@@ -178,7 +198,10 @@ export class SemaphoreGroupProvider {
    * Updates the in-memory Semaphore groups using data on the current ticket
    * set.
    */
-  public async update(data: SemaphoreGroupTicketInfo[]): Promise<void> {
+  public async update(
+    client: PoolClient,
+    data: SemaphoreGroupTicketInfo[]
+  ): Promise<void> {
     return traced(LOG_NAME, "update", async (span) => {
       const groups = this.groupEmailsFromTicketData(data);
 
@@ -186,7 +209,7 @@ export class SemaphoreGroupProvider {
       span?.setAttribute("group_count", groups.size);
 
       for (const [groupConfig, emails] of groups.entries()) {
-        await this.updateGroup(groupConfig, emails);
+        await this.updateGroup(client, groupConfig, emails);
       }
     });
   }
@@ -203,13 +226,14 @@ export class SemaphoreGroupProvider {
    * representation as required.
    */
   private async updateGroup(
+    client: PoolClient,
     groupConfig: SemaphoreGroupConfig,
     emails: string[]
   ): Promise<void> {
     return traced(LOG_NAME, "updateGroup", async (span) => {
       const consumers =
         emails.length > 0
-          ? await this.consumerDB.loadByEmails(this.pipelineId, emails)
+          ? await this.consumerDB.loadByEmails(client, this.pipelineId, emails)
           : [];
 
       const semaphoreIds = _.uniq(
@@ -237,6 +261,7 @@ export class SemaphoreGroupProvider {
         }
 
         await this.semaphoreHistoryDB.addGroupHistoryEntry(
+          client,
           this.pipelineId,
           groupConfig.groupId,
           group.root.toString(),

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
@@ -17,6 +17,7 @@ import { SerializedPCD } from "@pcd/pcd-types";
 import { SerializedSemaphoreGroup } from "@pcd/semaphore-group-pcd";
 import { parse } from "csv-parse";
 import PQueue from "p-queue";
+import { PoolClient } from "postgres-pool";
 import { v4 as uuid, v5 as uuidv5 } from "uuid";
 import {
   IPipelineAtomDB,
@@ -24,6 +25,8 @@ import {
 } from "../../../../database/queries/pipelineAtomDB";
 import { IPipelineConsumerDB } from "../../../../database/queries/pipelineConsumerDB";
 import { IPipelineSemaphoreHistoryDB } from "../../../../database/queries/pipelineSemaphoreHistoryDB";
+import { sqlTransaction } from "../../../../database/sqlQuery";
+import { ApplicationContext } from "../../../../types";
 import { logger } from "../../../../util/logger";
 import { setError, traced } from "../../../telemetryService";
 import {
@@ -60,6 +63,7 @@ export class CSVPipeline implements BasePipeline {
   public type = PipelineType.CSV;
   public capabilities: BasePipelineCapability[] = [];
 
+  private context: ApplicationContext;
   private eddsaPrivateKey: string;
   private db: IPipelineAtomDB<CSVAtom>;
   private definition: CSVPipelineDefinition;
@@ -77,6 +81,7 @@ export class CSVPipeline implements BasePipeline {
   }
 
   public constructor(
+    context: ApplicationContext,
     eddsaPrivateKey: string,
     definition: CSVPipelineDefinition,
     db: IPipelineAtomDB,
@@ -84,6 +89,7 @@ export class CSVPipeline implements BasePipeline {
     consumerDB: IPipelineConsumerDB,
     semaphoreHistoryDB: IPipelineSemaphoreHistoryDB
   ) {
+    this.context = context;
     this.eddsaPrivateKey = eddsaPrivateKey;
     this.definition = definition;
     this.db = db as IPipelineAtomDB<CSVAtom>;
@@ -103,20 +109,36 @@ export class CSVPipeline implements BasePipeline {
         getSerializedLatestGroup: async (
           groupId: string
         ): Promise<SerializedSemaphoreGroup | undefined> => {
-          return this.semaphoreGroupProvider?.getSerializedLatestGroup(groupId);
+          return sqlTransaction(
+            this.context.dbPool,
+            async (client) =>
+              this.semaphoreGroupProvider?.getSerializedLatestGroup(
+                client,
+                groupId
+              )
+          );
         },
         getLatestGroupRoot: async (
           groupId: string
         ): Promise<string | undefined> => {
-          return this.semaphoreGroupProvider?.getLatestGroupRoot(groupId);
+          return sqlTransaction(
+            this.context.dbPool,
+            async (client) =>
+              this.semaphoreGroupProvider?.getLatestGroupRoot(client, groupId)
+          );
         },
         getSerializedHistoricalGroup: async (
           groupId: string,
           rootHash: string
         ): Promise<SerializedSemaphoreGroup | undefined> => {
-          return this.semaphoreGroupProvider?.getSerializedHistoricalGroup(
-            groupId,
-            rootHash
+          return sqlTransaction(
+            this.context.dbPool,
+            async (client) =>
+              this.semaphoreGroupProvider?.getSerializedHistoricalGroup(
+                client,
+                groupId,
+                rootHash
+              )
           );
         },
         getSupportedGroups: (): PipelineSemaphoreGroupInfo[] => {
@@ -128,6 +150,7 @@ export class CSVPipeline implements BasePipeline {
     this.consumerDB = consumerDB;
     if (definition.options.semaphoreGroupName) {
       this.semaphoreGroupProvider = new SemaphoreGroupProvider(
+        this.context,
         this.id,
         [
           {
@@ -171,26 +194,31 @@ export class CSVPipeline implements BasePipeline {
           requesterSemaphoreId = semaphoreId;
           requesterSemaphoreV4Id = semaphoreV4Id;
           // Consumer is validated, so save them in the consumer list
-          let didUpdate = false;
-          for (const email of emails) {
-            didUpdate =
-              didUpdate ||
-              (await this.consumerDB.save(
-                this.id,
-                email.email,
-                semaphoreId,
-                new Date()
-              ));
-          }
 
-          if (this.definition.options.semaphoreGroupName) {
-            // If the user's Semaphore commitment has changed, `didUpdate` will be
-            // true, and we need to update the Semaphore groups
-            if (didUpdate) {
-              span?.setAttribute("semaphore_groups_updated", true);
-              await this.triggerSemaphoreGroupUpdate();
+          let didUpdate = false;
+
+          await sqlTransaction(this.context.dbPool, async (client) => {
+            for (const email of emails) {
+              didUpdate =
+                didUpdate ||
+                (await this.consumerDB.save(
+                  client,
+                  this.id,
+                  email.email,
+                  semaphoreId,
+                  new Date()
+                ));
             }
-          }
+
+            if (this.definition.options.semaphoreGroupName) {
+              // If the user's Semaphore commitment has changed, `didUpdate` will be
+              // true, and we need to update the Semaphore groups
+              if (didUpdate) {
+                span?.setAttribute("semaphore_groups_updated", true);
+                await this.triggerSemaphoreGroupUpdate(client);
+              }
+            }
+          });
         } catch (e) {
           logger(LOG_TAG, "credential PCD not verified for req", req);
         }
@@ -409,7 +437,7 @@ export class CSVPipeline implements BasePipeline {
    * Marked as public so that it can be called from tests, but otherwise should
    * not be called from outside the class.
    */
-  public async triggerSemaphoreGroupUpdate(): Promise<void> {
+  public async triggerSemaphoreGroupUpdate(client: PoolClient): Promise<void> {
     return traced(LOG_NAME, "triggerSemaphoreGroupUpdate", async (_span) => {
       tracePipeline(this.definition);
       // Whenever an update is triggered, we want to make sure that the
@@ -424,7 +452,7 @@ export class CSVPipeline implements BasePipeline {
       // having been processed.
       return this.semaphoreUpdateQueue.add(async () => {
         const data = await this.semaphoreGroupData();
-        await this.semaphoreGroupProvider?.update(data);
+        await this.semaphoreGroupProvider?.update(client, data);
       });
     });
   }

--- a/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/LemonadePipeline.ts
@@ -43,6 +43,7 @@ import stable_stringify from "fast-json-stable-stringify";
 import _ from "lodash";
 import PQueue from "p-queue";
 import { DatabaseError } from "pg";
+import { PoolClient } from "postgres-pool";
 import urljoin from "url-join";
 import { v5 as uuidv5 } from "uuid";
 import { LemonadeOAuthCredentials } from "../../../apis/lemonade/auth";
@@ -60,6 +61,10 @@ import {
   IBadgeGiftingDB,
   IContactSharingDB
 } from "../../../database/queries/ticketActionDBs";
+import {
+  namedSqlTransaction,
+  sqlTransaction
+} from "../../../database/sqlQuery";
 import { PCDHTTPError } from "../../../routing/pcdHttpError";
 import { ApplicationContext } from "../../../types";
 import { logger } from "../../../util/logger";
@@ -177,6 +182,7 @@ export class LemonadePipeline implements BasePipeline {
 
     if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
       this.semaphoreGroupProvider = new SemaphoreGroupProvider(
+        this.context,
         this.id,
         this.definition.options.semaphoreGroups ?? [],
         consumerDB,
@@ -214,20 +220,36 @@ export class LemonadePipeline implements BasePipeline {
         getSerializedLatestGroup: async (
           groupId: string
         ): Promise<SerializedSemaphoreGroup | undefined> => {
-          return this.semaphoreGroupProvider?.getSerializedLatestGroup(groupId);
+          return sqlTransaction(
+            this.context.dbPool,
+            async (client) =>
+              this.semaphoreGroupProvider?.getSerializedLatestGroup(
+                client,
+                groupId
+              )
+          );
         },
         getLatestGroupRoot: async (
           groupId: string
         ): Promise<string | undefined> => {
-          return this.semaphoreGroupProvider?.getLatestGroupRoot(groupId);
+          return sqlTransaction(
+            this.context.dbPool,
+            async (client) =>
+              this.semaphoreGroupProvider?.getLatestGroupRoot(client, groupId)
+          );
         },
         getSerializedHistoricalGroup: async (
           groupId: string,
           rootHash: string
         ): Promise<SerializedSemaphoreGroup | undefined> => {
-          return this.semaphoreGroupProvider?.getSerializedHistoricalGroup(
-            groupId,
-            rootHash
+          return sqlTransaction(
+            this.context.dbPool,
+            async (client) =>
+              this.semaphoreGroupProvider?.getSerializedHistoricalGroup(
+                client,
+                groupId,
+                rootHash
+              )
           );
         },
         getSupportedGroups: (): PipelineSemaphoreGroupInfo[] => {
@@ -459,7 +481,9 @@ export class LemonadePipeline implements BasePipeline {
       );
 
       if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
-        await this.triggerSemaphoreGroupUpdate();
+        await sqlTransaction(this.context.dbPool, (client) =>
+          this.triggerSemaphoreGroupUpdate(client)
+        );
       }
 
       return {
@@ -511,7 +535,7 @@ export class LemonadePipeline implements BasePipeline {
    * Marked as public so that it can be called from tests, but otherwise should
    * not be called from outside the class.
    */
-  public async triggerSemaphoreGroupUpdate(): Promise<void> {
+  public async triggerSemaphoreGroupUpdate(client: PoolClient): Promise<void> {
     return traced(LOG_NAME, "triggerSemaphoreGroupUpdate", async (_span) => {
       tracePipeline(this.definition);
       // Whenever an update is triggered, we want to make sure that the
@@ -526,7 +550,7 @@ export class LemonadePipeline implements BasePipeline {
       // having been processed.
       return this.semaphoreUpdateQueue.add(async () => {
         const data = await this.semaphoreGroupData();
-        await this.semaphoreGroupProvider?.update(data);
+        await this.semaphoreGroupProvider?.update(client, data);
       });
     });
   }
@@ -535,14 +559,14 @@ export class LemonadePipeline implements BasePipeline {
    * If manual tickets are removed after being checked in, they can leave
    * orphaned check-in data behind. This method cleans those up.
    */
-  private async cleanUpManualCheckins(): Promise<void> {
+  private async cleanUpManualCheckins(client: PoolClient): Promise<void> {
     return traced(LOG_NAME, "cleanUpManualCheckins", async (span) => {
       const ticketIds = new Set(
         (this.definition.options.manualTickets ?? []).map(
           (manualTicket) => manualTicket.id
         )
       );
-      const checkIns = await this.checkinDB.getByPipelineId(this.id);
+      const checkIns = await this.checkinDB.getByPipelineId(client, this.id);
       for (const checkIn of checkIns) {
         if (!ticketIds.has(checkIn.ticketId)) {
           logger(
@@ -550,13 +574,14 @@ export class LemonadePipeline implements BasePipeline {
           );
           span?.setAttribute("deleted_checkin_ticket_id", checkIn.ticketId);
 
-          this.checkinDB.deleteCheckIn(this.id, checkIn.ticketId);
+          this.checkinDB.deleteCheckIn(client, this.id, checkIn.ticketId);
         }
       }
     });
   }
 
   private async manualTicketToTicketData(
+    client: PoolClient,
     manualTicket: ManualTicket,
     sempahoreId: string
   ): Promise<ITicketData> {
@@ -564,6 +589,7 @@ export class LemonadePipeline implements BasePipeline {
     const product = this.getTicketTypeById(event, manualTicket.productId);
 
     const checkIn = await this.checkinDB.getByTicketId(
+      client,
       this.id,
       manualTicket.id
     );
@@ -601,9 +627,10 @@ export class LemonadePipeline implements BasePipeline {
   }
 
   private async getReceivedBadgesForEmail(
+    client: PoolClient,
     email: string
   ): Promise<SerializedPCD<EdDSATicketPCD>[]> {
-    const badges = await this.badgeDB.getBadges(this.id, email);
+    const badges = await this.badgeDB.getBadges(client, this.id, email);
 
     const badgePCDs = await Promise.all(
       badges.map(async (b, i) => {
@@ -618,7 +645,7 @@ export class LemonadePipeline implements BasePipeline {
 
         // semaphore id intentially left blank, as I'm just trying to get the ticket
         // so that I can link to it, not issue it/make proofs about it
-        const tickets = await this.getTicketsForEmail(b.giver, "");
+        const tickets = await this.getTicketsForEmail(client, b.giver, "");
         const ticket = tickets?.[0]?.claim?.ticket;
         const encodedLink = linkToTicket(
           urljoin(process.env.PASSPORT_CLIENT_URL ?? "", "/#/generic-checkin"),
@@ -680,14 +707,15 @@ export class LemonadePipeline implements BasePipeline {
   }
 
   private async getReceivedContactsForEmail(
+    client: PoolClient,
     email: string
   ): Promise<SerializedPCD<EdDSATicketPCD>[]> {
-    const contacts = await this.contactDB.getContacts(this.id, email);
+    const contacts = await this.contactDB.getContacts(client, this.id, email);
     return Promise.all(
       contacts.map(async (contact) => {
         // semaphore id intentially left blank, as I'm just trying to get the ticket
         // so that I can link to it, not issue it/make proofs about it
-        const tickets = await this.getTicketsForEmail(contact, "");
+        const tickets = await this.getTicketsForEmail(client, contact, "");
         const ticket: ITicketData | undefined = tickets?.[0]?.claim?.ticket;
         const encodedLink = linkToTicket(
           urljoin(process.env.PASSPORT_CLIENT_URL ?? "", "/#/generic-checkin"),
@@ -743,6 +771,7 @@ export class LemonadePipeline implements BasePipeline {
    * definition.
    */
   private async getTicketsForEmail(
+    client: PoolClient,
     email: string,
     identityCommitment: string
   ): Promise<EdDSATicketPCD[]> {
@@ -751,6 +780,7 @@ export class LemonadePipeline implements BasePipeline {
 
     // Load check-in data
     const checkIns = await this.checkinDB.getByTicketIds(
+      client,
       this.id,
       relevantTickets.map((ticket) => ticket.id)
     );
@@ -769,7 +799,11 @@ export class LemonadePipeline implements BasePipeline {
     ticketDatas.push(
       ...(await Promise.all(
         manualTickets.map((manualTicket) =>
-          this.manualTicketToTicketData(manualTicket, identityCommitment)
+          this.manualTicketToTicketData(
+            client,
+            manualTicket,
+            identityCommitment
+          )
         )
       ))
     );
@@ -786,125 +820,136 @@ export class LemonadePipeline implements BasePipeline {
     req: PollFeedRequest
   ): Promise<PollFeedResponseValue> {
     return traced(LOG_NAME, "issueLemonadeTicketPCDs", async (span) => {
-      tracePipeline(this.definition);
+      return namedSqlTransaction(
+        this.context.dbPool,
+        "issueLemonadeTicketPCDs",
+        async (client) => {
+          tracePipeline(this.definition);
 
-      if (!req.pcd) {
-        throw new Error("missing credential pcd");
-      }
+          if (!req.pcd) {
+            throw new Error("missing credential pcd");
+          }
 
-      if (this.definition.options.paused) {
-        return { actions: [] };
-      }
+          if (this.definition.options.paused) {
+            return { actions: [] };
+          }
 
-      const credential =
-        await this.credentialSubservice.verifyAndExpectZupassEmail(req.pcd);
+          const credential =
+            await this.credentialSubservice.verifyAndExpectZupassEmail(req.pcd);
 
-      const { emails, semaphoreId } = credential;
+          const { emails, semaphoreId } = credential;
 
-      if (!emails || emails.length === 0) {
-        throw new Error("missing emails in credential");
-      }
+          if (!emails || emails.length === 0) {
+            throw new Error("missing emails in credential");
+          }
 
-      span?.setAttribute("emails", emails.map((e) => e.email).join(","));
-      span?.setAttribute("semaphore_id", semaphoreId);
+          span?.setAttribute("emails", emails.map((e) => e.email).join(","));
+          span?.setAttribute("semaphore_id", semaphoreId);
 
-      let didUpdate = false;
-      for (const email of emails) {
-        // Consumer is validated, so save them in the consumer list
-        didUpdate =
-          didUpdate ||
-          (await this.consumerDB.save(
-            this.id,
-            email.email,
-            semaphoreId,
-            new Date()
-          ));
-      }
+          let didUpdate = false;
+          for (const email of emails) {
+            // Consumer is validated, so save them in the consumer list
+            didUpdate =
+              didUpdate ||
+              (await this.consumerDB.save(
+                client,
+                this.id,
+                email.email,
+                semaphoreId,
+                new Date()
+              ));
+          }
 
-      if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
-        // If the user's Semaphore commitment has changed, `didUpdate` will be
-        // true, and we need to update the Semaphore groups
-        if (didUpdate) {
-          span?.setAttribute("semaphore_groups_updated", true);
-          await this.triggerSemaphoreGroupUpdate();
+          if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
+            // If the user's Semaphore commitment has changed, `didUpdate` will be
+            // true, and we need to update the Semaphore groups
+            if (didUpdate) {
+              span?.setAttribute("semaphore_groups_updated", true);
+              await this.triggerSemaphoreGroupUpdate(client);
+            }
+          }
+
+          const tickets = (
+            await Promise.all(
+              emails.map((e) =>
+                this.getTicketsForEmail(client, e.email, semaphoreId)
+              )
+            )
+          ).flat();
+
+          const ticketActions: PCDAction[] = [];
+
+          if (await this.db.hasLoaded(this.id)) {
+            ticketActions.push({
+              type: PCDActionType.DeleteFolder,
+              folder: this.definition.options.feedOptions.feedFolder,
+              recursive: true
+            });
+          }
+
+          const ticketPCDs = await Promise.all(
+            tickets.map((t) => EdDSATicketPCDPackage.serialize(t))
+          );
+
+          ticketActions.push({
+            type: PCDActionType.ReplaceInFolder,
+            folder: this.definition.options.feedOptions.feedFolder,
+            pcds: ticketPCDs
+          });
+
+          const contactsFolder = `${this.definition.options.feedOptions.feedFolder}/contacts`;
+          const contacts = (
+            await Promise.all(
+              emails.map((e) =>
+                this.getReceivedContactsForEmail(client, e.email)
+              )
+            )
+          ).flat();
+          const contactActions: PCDAction[] = [
+            {
+              type: PCDActionType.DeleteFolder,
+              folder: contactsFolder,
+              recursive: true
+            },
+            {
+              type: PCDActionType.ReplaceInFolder,
+              folder: contactsFolder,
+              pcds: contacts
+            }
+          ];
+
+          const badgeFolder = `${this.definition.options.feedOptions.feedFolder}/badges`;
+
+          const badges = (
+            await Promise.all(
+              emails.map((e) => this.getReceivedBadgesForEmail(client, e.email))
+            )
+          ).flat();
+          const badgeActions: PCDAction[] = [
+            {
+              type: PCDActionType.DeleteFolder,
+              folder: badgeFolder,
+              recursive: true
+            },
+            {
+              type: PCDActionType.ReplaceInFolder,
+              folder: badgeFolder,
+              pcds: badges
+            }
+          ];
+
+          traceFlattenedObject(span, {
+            pcds_issued: tickets.length + badges.length + contacts.length,
+            tickets_issued: tickets.length,
+            badges_issued: badges.length,
+            contacts_issued: contacts.length
+          });
+
+          return {
+            actions: [...ticketActions, ...contactActions, ...badgeActions]
+          };
         }
-      }
-
-      const tickets = (
-        await Promise.all(
-          emails.map((e) => this.getTicketsForEmail(e.email, semaphoreId))
-        )
-      ).flat();
-
-      const ticketActions: PCDAction[] = [];
-
-      if (await this.db.hasLoaded(this.id)) {
-        ticketActions.push({
-          type: PCDActionType.DeleteFolder,
-          folder: this.definition.options.feedOptions.feedFolder,
-          recursive: true
-        });
-      }
-
-      const ticketPCDs = await Promise.all(
-        tickets.map((t) => EdDSATicketPCDPackage.serialize(t))
       );
-
-      ticketActions.push({
-        type: PCDActionType.ReplaceInFolder,
-        folder: this.definition.options.feedOptions.feedFolder,
-        pcds: ticketPCDs
-      });
-
-      const contactsFolder = `${this.definition.options.feedOptions.feedFolder}/contacts`;
-      const contacts = (
-        await Promise.all(
-          emails.map((e) => this.getReceivedContactsForEmail(e.email))
-        )
-      ).flat();
-      const contactActions: PCDAction[] = [
-        {
-          type: PCDActionType.DeleteFolder,
-          folder: contactsFolder,
-          recursive: true
-        },
-        {
-          type: PCDActionType.ReplaceInFolder,
-          folder: contactsFolder,
-          pcds: contacts
-        }
-      ];
-
-      const badgeFolder = `${this.definition.options.feedOptions.feedFolder}/badges`;
-
-      const badges = (
-        await Promise.all(
-          emails.map((e) => this.getReceivedBadgesForEmail(e.email))
-        )
-      ).flat();
-      const badgeActions: PCDAction[] = [
-        {
-          type: PCDActionType.DeleteFolder,
-          folder: badgeFolder,
-          recursive: true
-        },
-        {
-          type: PCDActionType.ReplaceInFolder,
-          folder: badgeFolder,
-          pcds: badges
-        }
-      ];
-
-      traceFlattenedObject(span, {
-        pcds_issued: tickets.length + badges.length + contacts.length,
-        tickets_issued: tickets.length,
-        badges_issued: badges.length,
-        contacts_issued: contacts.length
-      });
-
-      return {
-        actions: [...ticketActions, ...contactActions, ...badgeActions]
-      };
     });
   }
 
@@ -1267,11 +1312,13 @@ export class LemonadePipeline implements BasePipeline {
    * is a pending check-in.
    */
   private async notCheckedInManual(
+    client: PoolClient,
     manualTicket: ManualTicket
   ): Promise<true | PodboxTicketActionError> {
     return traced(LOG_NAME, "canCheckInManualTicket", async (span) => {
       // Is the ticket already checked in?
       const checkIn = await this.checkinDB.getByTicketId(
+        client,
         this.id,
         manualTicket.id
       );
@@ -1314,200 +1361,219 @@ export class LemonadePipeline implements BasePipeline {
       LOG_NAME,
       "precheckTicketAction",
       async (span): Promise<ActionConfigResponseValue> => {
-        tracePipeline(this.definition);
+        return namedSqlTransaction(
+          this.context.dbPool,
+          "precheckTicketAction",
+          async (client) => {
+            tracePipeline(this.definition);
 
-        let actorEmails: string[];
+            let actorEmails: string[];
 
-        // This method can only be used to pre-check for check-ins.
-        // There is no pre-check for any other kind of action at this time.
-        if (request.action.checkin !== true) {
-          throw new PCDHTTPError(400, "Not supported");
-        }
+            // This method can only be used to pre-check for check-ins.
+            // There is no pre-check for any other kind of action at this time.
+            if (request.action.checkin !== true) {
+              throw new PCDHTTPError(400, "Not supported");
+            }
 
-        const result: ActionConfigResponseValue = {
-          success: true,
-          giveBadgeActionInfo: undefined,
-          checkinActionInfo: undefined,
-          getContactActionInfo: undefined
-        };
+            const result: ActionConfigResponseValue = {
+              success: true,
+              giveBadgeActionInfo: undefined,
+              checkinActionInfo: undefined,
+              getContactActionInfo: undefined
+            };
 
-        // 1) verify that the requester is who they say they are
-        try {
-          span?.setAttribute("ticket_id", request.ticketId);
-          const credential =
-            await this.credentialSubservice.verifyAndExpectZupassEmail(
-              request.credential
+            // 1) verify that the requester is who they say they are
+            try {
+              span?.setAttribute("ticket_id", request.ticketId);
+              const credential =
+                await this.credentialSubservice.verifyAndExpectZupassEmail(
+                  request.credential
+                );
+
+              const { emails, semaphoreId } = credential;
+              if (!emails || emails.length === 0) {
+                throw new Error("missing emails in credential");
+              }
+
+              span?.setAttribute(
+                "checker_emails",
+                emails.map((e) => e.email)
+              );
+              span?.setAttribute("checked_semaphore_id", semaphoreId);
+
+              actorEmails = emails.map((e) => e.email);
+            } catch (e) {
+              logger(
+                `${LOG_TAG} Failed to verify credential due to error: `,
+                e
+              );
+              setError(e, span);
+              span?.setAttribute("precheck_error", "InvalidSignature");
+              return {
+                success: false,
+                error: { name: "InvalidSignature" }
+              };
+            }
+
+            let eventConfig: LemonadePipelineEventConfig;
+            const manualTicket = this.getManualTicketById(request.ticketId);
+            const ticketAtom = await this.db.loadById(
+              this.id,
+              request.ticketId
             );
+            let ticketInfo: TicketInfo;
+            let notCheckedIn;
 
-          const { emails, semaphoreId } = credential;
-          if (!emails || emails.length === 0) {
-            throw new Error("missing emails in credential");
-          }
+            if (ticketAtom) {
+              eventConfig = this.lemonadeAtomToEvent(ticketAtom);
+              ticketInfo = {
+                eventName: eventConfig.name,
+                ticketName: this.lemonadeAtomToTicketName(ticketAtom),
+                attendeeEmail: ticketAtom.email,
+                attendeeName: ticketAtom.name
+              };
+              notCheckedIn = await this.notCheckedIn(ticketAtom);
+            } else if (manualTicket) {
+              eventConfig = this.getEventById(manualTicket.eventId);
+              const ticketType = this.getTicketTypeById(
+                eventConfig,
+                manualTicket.productId
+              );
+              ticketInfo = {
+                eventName: eventConfig.name,
+                ticketName: ticketType.name,
+                attendeeEmail: manualTicket.attendeeEmail,
+                attendeeName: manualTicket.attendeeName
+              };
+              notCheckedIn = await this.notCheckedInManual(
+                client,
+                manualTicket
+              );
+            } else {
+              return {
+                success: false,
+                error: { name: "InvalidTicket" }
+              };
+            }
 
-          span?.setAttribute(
-            "checker_emails",
-            emails.map((e) => e.email)
-          );
-          span?.setAttribute("checked_semaphore_id", semaphoreId);
+            // 1) checkin action
+            const canCheckIn = await this.canCheckInForEvent(
+              request.eventId,
+              actorEmails
+            );
+            if (canCheckIn !== true) {
+              result.checkinActionInfo = {
+                permissioned: false,
+                canCheckIn: false,
+                reason: { name: "NotSuperuser" }
+              };
+            } else if (notCheckedIn !== true) {
+              result.checkinActionInfo = {
+                permissioned: true,
+                canCheckIn: false,
+                reason: notCheckedIn,
+                ticket: ticketInfo
+              };
+            } else {
+              result.checkinActionInfo = {
+                permissioned: true,
+                canCheckIn: true,
+                ticket: ticketInfo
+              };
+            }
 
-          actorEmails = emails.map((e) => e.email);
-        } catch (e) {
-          logger(`${LOG_TAG} Failed to verify credential due to error: `, e);
-          setError(e, span);
-          span?.setAttribute("precheck_error", "InvalidSignature");
-          return {
-            success: false,
-            error: { name: "InvalidSignature" }
-          };
-        }
+            // 2) badge action
+            if (this.definition.options.ticketActions?.badges?.enabled) {
+              const badgesGivenToTicketHolder = await this.badgeDB.getBadges(
+                client,
+                this.id,
+                ticketInfo.attendeeEmail
+              );
 
-        let eventConfig: LemonadePipelineEventConfig;
-        const manualTicket = this.getManualTicketById(request.ticketId);
-        const ticketAtom = await this.db.loadById(this.id, request.ticketId);
-        let ticketInfo: TicketInfo;
-        let notCheckedIn;
-
-        if (ticketAtom) {
-          eventConfig = this.lemonadeAtomToEvent(ticketAtom);
-          ticketInfo = {
-            eventName: eventConfig.name,
-            ticketName: this.lemonadeAtomToTicketName(ticketAtom),
-            attendeeEmail: ticketAtom.email,
-            attendeeName: ticketAtom.name
-          };
-          notCheckedIn = await this.notCheckedIn(ticketAtom);
-        } else if (manualTicket) {
-          eventConfig = this.getEventById(manualTicket.eventId);
-          const ticketType = this.getTicketTypeById(
-            eventConfig,
-            manualTicket.productId
-          );
-          ticketInfo = {
-            eventName: eventConfig.name,
-            ticketName: ticketType.name,
-            attendeeEmail: manualTicket.attendeeEmail,
-            attendeeName: manualTicket.attendeeName
-          };
-          notCheckedIn = await this.notCheckedInManual(manualTicket);
-        } else {
-          return {
-            success: false,
-            error: { name: "InvalidTicket" }
-          };
-        }
-
-        // 1) checkin action
-        const canCheckIn = await this.canCheckInForEvent(
-          request.eventId,
-          actorEmails
-        );
-        if (canCheckIn !== true) {
-          result.checkinActionInfo = {
-            permissioned: false,
-            canCheckIn: false,
-            reason: { name: "NotSuperuser" }
-          };
-        } else if (notCheckedIn !== true) {
-          result.checkinActionInfo = {
-            permissioned: true,
-            canCheckIn: false,
-            reason: notCheckedIn,
-            ticket: ticketInfo
-          };
-        } else {
-          result.checkinActionInfo = {
-            permissioned: true,
-            canCheckIn: true,
-            ticket: ticketInfo
-          };
-        }
-
-        // 2) badge action
-        if (this.definition.options.ticketActions?.badges?.enabled) {
-          const badgesGivenToTicketHolder = await this.badgeDB.getBadges(
-            this.id,
-            ticketInfo.attendeeEmail
-          );
-
-          const badgesGiveableByUser = (
-            await Promise.all(
-              actorEmails.map((e) => this.getBadgesGiveableByEmail(e))
-            )
-          ).flat();
-
-          const rateLimitedGiveableByUser = badgesGiveableByUser.filter(
-            (b) => b.maxPerDay !== undefined
-          );
-
-          const notAlreadyGivenBadges = badgesGiveableByUser.filter(
-            (c) => !badgesGivenToTicketHolder.find((b) => b.id === c.id)
-          );
-
-          const intervalMs = 24 * 60 * 60 * 1000;
-          const alreadyGivenRateLimited = (
-            await Promise.all(
-              actorEmails.map((e) =>
-                this.badgeDB.getGivenBadges(
-                  this.id,
-                  e,
-                  rateLimitedGiveableByUser.map((b) => b.id),
-                  intervalMs
+              const badgesGiveableByUser = (
+                await Promise.all(
+                  actorEmails.map((e) => this.getBadgesGiveableByEmail(e))
                 )
-              )
-            )
-          ).flat();
+              ).flat();
 
-          result.giveBadgeActionInfo = {
-            permissioned: badgesGiveableByUser.length > 0,
-            giveableBadges: notAlreadyGivenBadges,
-            rateLimitedBadges: badgesGiveableByUser
-              .filter(isPerDayBadge)
-              .filter(() => {
-                return !actorEmails.includes(ticketInfo.attendeeEmail);
-              })
-              .map((b) => ({
-                alreadyGivenInInterval: alreadyGivenRateLimited.filter(
-                  (g) => g.id === b.id
-                ).length,
-                id: b.id,
-                eventName: b.eventName,
-                productName: b.productName,
-                intervalMs,
-                maxInInterval: b.maxPerDay,
-                timestampsGiven: alreadyGivenRateLimited
-                  .filter((g) => g.id === b.id)
-                  .map((g) => g.timeCreated)
-              })),
-            ticket: ticketInfo
-          };
-        }
+              const rateLimitedGiveableByUser = badgesGiveableByUser.filter(
+                (b) => b.maxPerDay !== undefined
+              );
 
-        // 3) contact action
-        if (this.definition.options.ticketActions?.contacts?.enabled) {
-          if (actorEmails.includes(ticketInfo.attendeeEmail)) {
-            result.getContactActionInfo = {
-              permissioned: false,
-              alreadyReceived: false
-            };
-          } else {
-            const received = (
-              await Promise.all(
-                actorEmails.map((e) => this.contactDB.getContacts(this.id, e))
-              )
-            ).flat();
-            result.getContactActionInfo = {
-              permissioned: true,
-              alreadyReceived: received.includes(ticketInfo.attendeeEmail),
-              ticket: ticketInfo
-            };
+              const notAlreadyGivenBadges = badgesGiveableByUser.filter(
+                (c) => !badgesGivenToTicketHolder.find((b) => b.id === c.id)
+              );
+
+              const intervalMs = 24 * 60 * 60 * 1000;
+              const alreadyGivenRateLimited = (
+                await Promise.all(
+                  actorEmails.map((e) =>
+                    this.badgeDB.getGivenBadges(
+                      client,
+                      this.id,
+                      e,
+                      rateLimitedGiveableByUser.map((b) => b.id),
+                      intervalMs
+                    )
+                  )
+                )
+              ).flat();
+
+              result.giveBadgeActionInfo = {
+                permissioned: badgesGiveableByUser.length > 0,
+                giveableBadges: notAlreadyGivenBadges,
+                rateLimitedBadges: badgesGiveableByUser
+                  .filter(isPerDayBadge)
+                  .filter(() => {
+                    return !actorEmails.includes(ticketInfo.attendeeEmail);
+                  })
+                  .map((b) => ({
+                    alreadyGivenInInterval: alreadyGivenRateLimited.filter(
+                      (g) => g.id === b.id
+                    ).length,
+                    id: b.id,
+                    eventName: b.eventName,
+                    productName: b.productName,
+                    intervalMs,
+                    maxInInterval: b.maxPerDay,
+                    timestampsGiven: alreadyGivenRateLimited
+                      .filter((g) => g.id === b.id)
+                      .map((g) => g.timeCreated)
+                  })),
+                ticket: ticketInfo
+              };
+            }
+
+            // 3) contact action
+            if (this.definition.options.ticketActions?.contacts?.enabled) {
+              if (actorEmails.includes(ticketInfo.attendeeEmail)) {
+                result.getContactActionInfo = {
+                  permissioned: false,
+                  alreadyReceived: false
+                };
+              } else {
+                const received = (
+                  await Promise.all(
+                    actorEmails.map((e) =>
+                      this.contactDB.getContacts(client, this.id, e)
+                    )
+                  )
+                ).flat();
+                result.getContactActionInfo = {
+                  permissioned: true,
+                  alreadyReceived: received.includes(ticketInfo.attendeeEmail),
+                  ticket: ticketInfo
+                };
+              }
+            }
+
+            // 4) screen config
+            result.actionScreenConfig =
+              this.definition.options.ticketActions?.screenConfig;
+
+            return result;
           }
-        }
-
-        // 4) screen config
-        result.actionScreenConfig =
-          this.definition.options.ticketActions?.screenConfig;
-
-        return result;
+        );
       }
     );
   }
@@ -1533,201 +1599,223 @@ export class LemonadePipeline implements BasePipeline {
       LOG_NAME,
       "executeTicketAction",
       async (span): Promise<PodboxTicketActionResponseValue> => {
-        tracePipeline(this.definition);
+        return namedSqlTransaction(
+          this.context.dbPool,
+          "executeTicketAction",
+          async (client) => {
+            tracePipeline(this.definition);
 
-        let emails: string[];
-        try {
-          const verifiedCredential =
-            await this.credentialSubservice.verifyAndExpectZupassEmail(
-              request.credential
-            );
-          if (
-            !verifiedCredential.emails ||
-            verifiedCredential.emails.length === 0
-          ) {
-            throw new Error("missing emails in credential");
-          }
-          emails = verifiedCredential.emails.map((e) => e.email);
-        } catch (e) {
-          logger(`${LOG_TAG} Failed to verify credential due to error: `, e);
-          setError(e, span);
-          span?.setAttribute("checkin_error", "InvalidSignature");
-          return { success: false, error: { name: "InvalidSignature" } };
-        }
-
-        const precheck = await this.precheckTicketAction(request);
-        logger(
-          LOG_TAG,
-          `got request to execute ticket action ${str(
-            request
-          )} - precheck - ${str(precheck)}`
-        );
-
-        if (!precheck.success) {
-          return precheck;
-        }
-
-        if (request.action.getContact) {
-          if (!precheck.getContactActionInfo?.permissioned) {
-            return {
-              success: false,
-              error: { name: "InvalidTicket" }
-            };
-          }
-
-          if (precheck.getContactActionInfo?.alreadyReceived) {
-            return {
-              success: false,
-              error: { name: "AlreadyReceived" }
-            };
-          }
-
-          const ticketId = request.ticketId;
-          const ticket = await this.db.loadById(this.id, ticketId);
-          const manualTicket = this.getManualTicketById(ticketId);
-          const scaneeEmail = ticket?.email ?? manualTicket?.attendeeEmail;
-
-          if (scaneeEmail) {
-            await this.contactDB.saveContact(this.id, emails[0], scaneeEmail);
-
-            return {
-              success: true
-            };
-          } else {
-            return {
-              success: false,
-              error: { name: "InvalidTicket" }
-            };
-          }
-        } else if (request.action.giftBadge) {
-          const ticketId = request.ticketId;
-          const ticket = await this.db.loadById(this.id, ticketId);
-          const manualTicket = this.getManualTicketById(ticketId);
-          const recipientEmail = ticket?.email ?? manualTicket?.attendeeEmail;
-
-          const matchingBadges: BadgeConfig[] =
-            request.action.giftBadge.badgeIds
-              .map((id) =>
-                (
-                  this.definition.options?.ticketActions?.badges?.choices ?? []
-                ).find((badge) => badge.id === id)
-              )
-              .filter((badge) => !!badge) as BadgeConfig[];
-
-          const allowedBadges = matchingBadges.filter((b) => {
-            const matchingRateLimitedBadge =
-              precheck.giveBadgeActionInfo?.rateLimitedBadges?.find(
-                (r) => r.id === b.id
-              );
-
-            // prevent too many rate limited badges from being given
-            if (matchingRateLimitedBadge) {
+            let emails: string[];
+            try {
+              const verifiedCredential =
+                await this.credentialSubservice.verifyAndExpectZupassEmail(
+                  request.credential
+                );
               if (
-                matchingRateLimitedBadge.alreadyGivenInInterval >=
-                matchingRateLimitedBadge.maxInInterval
+                !verifiedCredential.emails ||
+                verifiedCredential.emails.length === 0
               ) {
-                return false;
+                throw new Error("missing emails in credential");
               }
-            }
-
-            // prevent wrong ppl from issuing wrong badges
-            if (
-              !b.givers?.includes("*") &&
-              !b.givers?.find((e) => emails.includes(e))
-            ) {
-              return false;
-            }
-
-            return true;
-          });
-
-          if (recipientEmail) {
-            await this.badgeDB.giveBadges(
-              this.id,
-              emails[0],
-              recipientEmail,
-              allowedBadges
-            );
-
-            return {
-              success: true
-            };
-          } else {
-            return {
-              success: false,
-              error: { name: "InvalidTicket" }
-            };
-          }
-        } else if (request.action?.checkin) {
-          if (precheck.checkinActionInfo?.reason) {
-            return {
-              success: false,
-              error: precheck.checkinActionInfo?.reason
-            };
-          }
-
-          const autoGrantBadges: BadgeConfig[] = (
-            this.definition.options?.ticketActions?.badges?.choices ?? []
-          ).filter((badge) => badge.grantOnCheckin);
-
-          // First see if we have an atom which matches the ticket ID
-          const ticketAtom = await this.db.loadById(this.id, request.ticketId);
-          if (
-            ticketAtom &&
-            // Ensure that the checker-provided event ID matches the ticket
-            this.lemonadeAtomToZupassEventId(ticketAtom) === request.eventId
-          ) {
-            if (ticketAtom.email) {
-              await this.badgeDB.giveBadges(
-                this.id,
-                emails[0],
-                ticketAtom.email,
-                autoGrantBadges
-              );
-            }
-
-            return this.podboxLocalCheckIn(
-              {
-                id: ticketAtom.id,
-                eventId: ticketAtom.genericIssuanceEventId,
-                productId: ticketAtom.genericIssuanceProductId,
-                attendeeName: ticketAtom.name,
-                attendeeEmail: ticketAtom.email
-              },
-              emails[0]
-            );
-          } else {
-            // No valid Lemonade atom found, try looking for a manual ticket
-            const manualTicket = this.getManualTicketById(request.ticketId);
-            if (manualTicket && manualTicket.eventId === request.eventId) {
-              await this.badgeDB.giveBadges(
-                this.id,
-                emails[0],
-                manualTicket.attendeeEmail,
-                autoGrantBadges
-              );
-
-              // Manual ticket found, check in with the DB
-              return this.podboxLocalCheckIn(manualTicket, emails[0]);
-            } else {
-              // Didn't find any matching ticket
+              emails = verifiedCredential.emails.map((e) => e.email);
+            } catch (e) {
               logger(
-                `${LOG_TAG} Could not find ticket ${request.ticketId} ` +
-                  `for event ${
-                    request.eventId
-                  } for checkin requested by ${JSON.stringify(emails)} ` +
-                  `on pipeline ${this.id}`
+                `${LOG_TAG} Failed to verify credential due to error: `,
+                e
               );
-              span?.setAttribute("checkin_error", "InvalidTicket");
-              return { success: false, error: { name: "InvalidTicket" } };
+              setError(e, span);
+              span?.setAttribute("checkin_error", "InvalidSignature");
+              return { success: false, error: { name: "InvalidSignature" } };
+            }
+
+            const precheck = await this.precheckTicketAction(request);
+            logger(
+              LOG_TAG,
+              `got request to execute ticket action ${str(
+                request
+              )} - precheck - ${str(precheck)}`
+            );
+
+            if (!precheck.success) {
+              return precheck;
+            }
+
+            if (request.action.getContact) {
+              if (!precheck.getContactActionInfo?.permissioned) {
+                return {
+                  success: false,
+                  error: { name: "InvalidTicket" }
+                };
+              }
+
+              if (precheck.getContactActionInfo?.alreadyReceived) {
+                return {
+                  success: false,
+                  error: { name: "AlreadyReceived" }
+                };
+              }
+
+              const ticketId = request.ticketId;
+              const ticket = await this.db.loadById(this.id, ticketId);
+              const manualTicket = this.getManualTicketById(ticketId);
+              const scaneeEmail = ticket?.email ?? manualTicket?.attendeeEmail;
+
+              if (scaneeEmail) {
+                await this.contactDB.saveContact(
+                  client,
+                  this.id,
+                  emails[0],
+                  scaneeEmail
+                );
+
+                return {
+                  success: true
+                };
+              } else {
+                return {
+                  success: false,
+                  error: { name: "InvalidTicket" }
+                };
+              }
+            } else if (request.action.giftBadge) {
+              const ticketId = request.ticketId;
+              const ticket = await this.db.loadById(this.id, ticketId);
+              const manualTicket = this.getManualTicketById(ticketId);
+              const recipientEmail =
+                ticket?.email ?? manualTicket?.attendeeEmail;
+
+              const matchingBadges: BadgeConfig[] =
+                request.action.giftBadge.badgeIds
+                  .map((id) =>
+                    (
+                      this.definition.options?.ticketActions?.badges?.choices ??
+                      []
+                    ).find((badge) => badge.id === id)
+                  )
+                  .filter((badge) => !!badge) as BadgeConfig[];
+
+              const allowedBadges = matchingBadges.filter((b) => {
+                const matchingRateLimitedBadge =
+                  precheck.giveBadgeActionInfo?.rateLimitedBadges?.find(
+                    (r) => r.id === b.id
+                  );
+
+                // prevent too many rate limited badges from being given
+                if (matchingRateLimitedBadge) {
+                  if (
+                    matchingRateLimitedBadge.alreadyGivenInInterval >=
+                    matchingRateLimitedBadge.maxInInterval
+                  ) {
+                    return false;
+                  }
+                }
+
+                // prevent wrong ppl from issuing wrong badges
+                if (
+                  !b.givers?.includes("*") &&
+                  !b.givers?.find((e) => emails.includes(e))
+                ) {
+                  return false;
+                }
+
+                return true;
+              });
+
+              if (recipientEmail) {
+                await this.badgeDB.giveBadges(
+                  client,
+                  this.id,
+                  emails[0],
+                  recipientEmail,
+                  allowedBadges
+                );
+
+                return {
+                  success: true
+                };
+              } else {
+                return {
+                  success: false,
+                  error: { name: "InvalidTicket" }
+                };
+              }
+            } else if (request.action?.checkin) {
+              if (precheck.checkinActionInfo?.reason) {
+                return {
+                  success: false,
+                  error: precheck.checkinActionInfo?.reason
+                };
+              }
+
+              const autoGrantBadges: BadgeConfig[] = (
+                this.definition.options?.ticketActions?.badges?.choices ?? []
+              ).filter((badge) => badge.grantOnCheckin);
+
+              // First see if we have an atom which matches the ticket ID
+              const ticketAtom = await this.db.loadById(
+                this.id,
+                request.ticketId
+              );
+              if (
+                ticketAtom &&
+                // Ensure that the checker-provided event ID matches the ticket
+                this.lemonadeAtomToZupassEventId(ticketAtom) === request.eventId
+              ) {
+                if (ticketAtom.email) {
+                  await this.badgeDB.giveBadges(
+                    client,
+                    this.id,
+                    emails[0],
+                    ticketAtom.email,
+                    autoGrantBadges
+                  );
+                }
+
+                return this.podboxLocalCheckIn(
+                  {
+                    id: ticketAtom.id,
+                    eventId: ticketAtom.genericIssuanceEventId,
+                    productId: ticketAtom.genericIssuanceProductId,
+                    attendeeName: ticketAtom.name,
+                    attendeeEmail: ticketAtom.email
+                  },
+                  emails[0]
+                );
+              } else {
+                // No valid Lemonade atom found, try looking for a manual ticket
+                const manualTicket = this.getManualTicketById(request.ticketId);
+                if (manualTicket && manualTicket.eventId === request.eventId) {
+                  await this.badgeDB.giveBadges(
+                    client,
+                    this.id,
+                    emails[0],
+                    manualTicket.attendeeEmail,
+                    autoGrantBadges
+                  );
+
+                  // Manual ticket found, check in with the DB
+                  return this.podboxLocalCheckIn(manualTicket, emails[0]);
+                } else {
+                  // Didn't find any matching ticket
+                  logger(
+                    `${LOG_TAG} Could not find ticket ${request.ticketId} ` +
+                      `for event ${
+                        request.eventId
+                      } for checkin requested by ${JSON.stringify(emails)} ` +
+                      `on pipeline ${this.id}`
+                  );
+                  span?.setAttribute("checkin_error", "InvalidTicket");
+                  return { success: false, error: { name: "InvalidTicket" } };
+                }
+              }
+            } else {
+              return {
+                success: false,
+                error: { name: "ServerError" }
+              };
             }
           }
-        } else {
-          return {
-            success: false,
-            error: { name: "ServerError" }
-          };
-        }
+        );
       }
     );
   }
@@ -1743,63 +1831,71 @@ export class LemonadePipeline implements BasePipeline {
       LOG_NAME,
       "checkInManualTicket",
       async (span): Promise<PodboxTicketActionResponseValue> => {
-        const pendingCheckin = this.pendingCheckIns.get(manualTicket.id);
-        if (pendingCheckin) {
-          span?.setAttribute("checkin_error", "AlreadyCheckedIn");
-          return {
-            success: false,
-            error: {
-              name: "AlreadyCheckedIn",
-              checkinTimestamp: new Date(
-                pendingCheckin.timestamp
-              ).toISOString(),
-              checker: LEMONADE_CHECKER
-            }
-          };
-        }
-
-        try {
-          await this.checkinDB.checkIn(
-            this.id,
-            manualTicket.id,
-            new Date(),
-            checkerEmail
-          );
-          this.pendingCheckIns.set(manualTicket.id, {
-            status: CheckinStatus.Success,
-            timestamp: Date.now()
-          });
-        } catch (e) {
-          logger(
-            `${LOG_TAG} Failed to check in ticket ${manualTicket.id} for event ${manualTicket.eventId} on behalf of checker ${checkerEmail} on pipeline ${this.id}`
-          );
-          setError(e, span);
-          this.pendingCheckIns.delete(manualTicket.id);
-
-          if (e instanceof DatabaseError) {
-            // We may have received a DatabaseError due to an insertion conflict
-            // Detect this conflict by looking for an existing check-in.
-            const existingCheckin = await this.checkinDB.getByTicketId(
-              this.id,
-              manualTicket.id
-            );
-            if (existingCheckin) {
+        return namedSqlTransaction(
+          this.context.dbPool,
+          "checkInManualTicket",
+          async (client) => {
+            const pendingCheckin = this.pendingCheckIns.get(manualTicket.id);
+            if (pendingCheckin) {
               span?.setAttribute("checkin_error", "AlreadyCheckedIn");
               return {
                 success: false,
                 error: {
                   name: "AlreadyCheckedIn",
-                  checkinTimestamp: existingCheckin.timestamp.toISOString(),
+                  checkinTimestamp: new Date(
+                    pendingCheckin.timestamp
+                  ).toISOString(),
                   checker: LEMONADE_CHECKER
                 }
               };
             }
-          }
-          span?.setAttribute("checkin_error", "ServerError");
-          return { success: false, error: { name: "ServerError" } };
-        }
 
-        return { success: true };
+            try {
+              await this.checkinDB.checkIn(
+                client,
+                this.id,
+                manualTicket.id,
+                new Date(),
+                checkerEmail
+              );
+              this.pendingCheckIns.set(manualTicket.id, {
+                status: CheckinStatus.Success,
+                timestamp: Date.now()
+              });
+            } catch (e) {
+              logger(
+                `${LOG_TAG} Failed to check in ticket ${manualTicket.id} for event ${manualTicket.eventId} on behalf of checker ${checkerEmail} on pipeline ${this.id}`
+              );
+              setError(e, span);
+              this.pendingCheckIns.delete(manualTicket.id);
+
+              if (e instanceof DatabaseError) {
+                // We may have received a DatabaseError due to an insertion conflict
+                // Detect this conflict by looking for an existing check-in.
+                const existingCheckin = await this.checkinDB.getByTicketId(
+                  client,
+                  this.id,
+                  manualTicket.id
+                );
+                if (existingCheckin) {
+                  span?.setAttribute("checkin_error", "AlreadyCheckedIn");
+                  return {
+                    success: false,
+                    error: {
+                      name: "AlreadyCheckedIn",
+                      checkinTimestamp: existingCheckin.timestamp.toISOString(),
+                      checker: LEMONADE_CHECKER
+                    }
+                  };
+                }
+              }
+              span?.setAttribute("checkin_error", "ServerError");
+              return { success: false, error: { name: "ServerError" } };
+            }
+
+            return { success: true };
+          }
+        );
       }
     );
   }
@@ -1916,38 +2012,51 @@ export class LemonadePipeline implements BasePipeline {
    */
   private async getManualCheckinSummary(): Promise<PipelineCheckinSummary[]> {
     return traced(LOG_NAME, "getManualCheckinSummary", async (span) => {
-      const results: PipelineCheckinSummary[] = [];
-      const checkIns = await this.checkinDB.getByPipelineId(this.id);
-      const checkInsById = _.keyBy(checkIns, (checkIn) => checkIn.ticketId);
+      return namedSqlTransaction(
+        this.context.dbPool,
+        "getManualCheckinSummary",
+        async (client) => {
+          const results: PipelineCheckinSummary[] = [];
+          const checkIns = await this.checkinDB.getByPipelineId(
+            client,
+            this.id
+          );
+          const checkInsById = _.keyBy(checkIns, (checkIn) => checkIn.ticketId);
 
-      for (const ticketAtom of await this.db.load(this.id)) {
-        const checkIn = checkInsById[ticketAtom.id];
-        results.push({
-          ticketId: ticketAtom.id,
-          ticketName: this.lemonadeAtomToTicketName(ticketAtom),
-          email: ticketAtom.email,
-          timestamp: checkIn ? checkIn.timestamp.toISOString() : "",
-          checkerEmail: checkIn ? checkIn.checkerEmail : undefined,
-          checkedIn: !!checkIn
-        });
-      }
+          for (const ticketAtom of await this.db.load(this.id)) {
+            const checkIn = checkInsById[ticketAtom.id];
+            results.push({
+              ticketId: ticketAtom.id,
+              ticketName: this.lemonadeAtomToTicketName(ticketAtom),
+              email: ticketAtom.email,
+              timestamp: checkIn ? checkIn.timestamp.toISOString() : "",
+              checkerEmail: checkIn ? checkIn.checkerEmail : undefined,
+              checkedIn: !!checkIn
+            });
+          }
 
-      for (const manualTicket of this.definition.options.manualTickets ?? []) {
-        const checkIn = checkInsById[manualTicket.id];
-        const event = this.getEventById(manualTicket.eventId);
-        const product = this.getTicketTypeById(event, manualTicket.productId);
-        results.push({
-          ticketId: manualTicket.id,
-          ticketName: product.name,
-          email: manualTicket.attendeeEmail,
-          timestamp: checkIn ? checkIn.timestamp.toISOString() : "",
-          checkerEmail: checkIn ? checkIn.checkerEmail : undefined,
-          checkedIn: !!checkIn
-        });
-      }
+          for (const manualTicket of this.definition.options.manualTickets ??
+            []) {
+            const checkIn = checkInsById[manualTicket.id];
+            const event = this.getEventById(manualTicket.eventId);
+            const product = this.getTicketTypeById(
+              event,
+              manualTicket.productId
+            );
+            results.push({
+              ticketId: manualTicket.id,
+              ticketName: product.name,
+              email: manualTicket.attendeeEmail,
+              timestamp: checkIn ? checkIn.timestamp.toISOString() : "",
+              checkerEmail: checkIn ? checkIn.checkerEmail : undefined,
+              checkedIn: !!checkIn
+            });
+          }
 
-      span?.setAttribute("result_count", results.length);
-      return results;
+          span?.setAttribute("result_count", results.length);
+          return results;
+        }
+      );
     });
   }
 
@@ -1957,40 +2066,47 @@ export class LemonadePipeline implements BasePipeline {
     checkerEmail: string
   ): Promise<PipelineSetManualCheckInStateResponseValue> {
     return traced(LOG_NAME, "setManualCheckInState", async (span) => {
-      span?.setAttribute("ticket_id", ticketId);
-      span?.setAttribute("checkin_state", checkInState);
-      span?.setAttribute("checker_email", checkerEmail);
-      const atom = await this.db.loadById(this.id, ticketId);
-      if (!atom) {
-        const manualTicket = (this.definition.options.manualTickets ?? []).find(
-          (m) => m.id === ticketId
-        );
-        if (!manualTicket) {
-          throw new PCDHTTPError(
-            404,
-            `Ticket ${ticketId} does not exist on pipeline ${this.id}`
+      return namedSqlTransaction(
+        this.context.dbPool,
+        "getManualCheckinSummary",
+        async (client) => {
+          span?.setAttribute("ticket_id", ticketId);
+          span?.setAttribute("checkin_state", checkInState);
+          span?.setAttribute("checker_email", checkerEmail);
+          const atom = await this.db.loadById(this.id, ticketId);
+          if (!atom) {
+            const manualTicket = (
+              this.definition.options.manualTickets ?? []
+            ).find((m) => m.id === ticketId);
+            if (!manualTicket) {
+              throw new PCDHTTPError(
+                404,
+                `Ticket ${ticketId} does not exist on pipeline ${this.id}`
+              );
+            }
+          }
+
+          logger(
+            `${LOG_TAG} Setting manual check-in state to ${
+              checkInState ? "checked-in" : "checked-out"
+            } for ticket ${ticketId} on pipeline ${this.id}`
           );
+
+          if (checkInState) {
+            await this.checkinDB.checkIn(
+              client,
+              this.id,
+              ticketId,
+              new Date(),
+              checkerEmail
+            );
+          } else {
+            await this.checkinDB.deleteCheckIn(client, this.id, ticketId);
+          }
+
+          return { checkInState };
         }
-      }
-
-      logger(
-        `${LOG_TAG} Setting manual check-in state to ${
-          checkInState ? "checked-in" : "checked-out"
-        } for ticket ${ticketId} on pipeline ${this.id}`
       );
-
-      if (checkInState) {
-        await this.checkinDB.checkIn(
-          this.id,
-          ticketId,
-          new Date(),
-          checkerEmail
-        );
-      } else {
-        await this.checkinDB.deleteCheckIn(this.id, ticketId);
-      }
-
-      return { checkInState };
     });
   }
 
@@ -1999,6 +2115,7 @@ export class LemonadePipeline implements BasePipeline {
   }
 
   public async sendPipelineEmail(
+    client: PoolClient,
     emailType: PipelineEmailType
   ): Promise<GenericIssuanceSendPipelineEmailResponseValue> {
     return traced(LOG_NAME, "sendPipelineEmail", async () => {
@@ -2017,8 +2134,12 @@ export class LemonadePipeline implements BasePipeline {
         }
 
         const allAtoms = await this.db.load(this.id);
-        const manualCheckins = await this.checkinDB.getByPipelineId(this.id);
+        const manualCheckins = await this.checkinDB.getByPipelineId(
+          client,
+          this.id
+        );
         const sentEmails = await this.emailDB.getSentEmails(
+          client,
           this.id,
           PipelineEmailType.EsmeraldaOneClick
         );
@@ -2059,6 +2180,7 @@ export class LemonadePipeline implements BasePipeline {
         for (const toSend of filteredAtoms) {
           try {
             await this.emailDB.recordEmailSent(
+              client,
               this.id,
               PipelineEmailType.EsmeraldaOneClick,
               toSend.email

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -48,6 +48,7 @@ import { normalizeEmail, str } from "@pcd/util";
 import stable_stringify from "fast-json-stable-stringify";
 import PQueue from "p-queue";
 import { DatabaseError } from "pg";
+import { PoolClient } from "postgres-pool";
 import { v5 as uuidv5 } from "uuid";
 import { IGenericPretixAPI } from "../../../apis/pretix/genericPretixAPI";
 import {
@@ -58,6 +59,10 @@ import { IPipelineCheckinDB } from "../../../database/queries/pipelineCheckinDB"
 import { IPipelineConsumerDB } from "../../../database/queries/pipelineConsumerDB";
 import { IPipelineManualTicketDB } from "../../../database/queries/pipelineManualTicketDB";
 import { IPipelineSemaphoreHistoryDB } from "../../../database/queries/pipelineSemaphoreHistoryDB";
+import {
+  namedSqlTransaction,
+  sqlTransaction
+} from "../../../database/sqlQuery";
 import { PCDHTTPError } from "../../../routing/pcdHttpError";
 import { ApplicationContext } from "../../../types";
 import { mostRecentCheckinEvent } from "../../../util/devconnectTicket";
@@ -184,6 +189,7 @@ export class PretixPipeline implements BasePipeline {
     }
     if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
       this.semaphoreGroupProvider = new SemaphoreGroupProvider(
+        this.context,
         this.id,
         this.definition.options.semaphoreGroups ?? [],
         consumerDB,
@@ -223,20 +229,36 @@ export class PretixPipeline implements BasePipeline {
         getSerializedLatestGroup: async (
           groupId: string
         ): Promise<SerializedSemaphoreGroup | undefined> => {
-          return this.semaphoreGroupProvider?.getSerializedLatestGroup(groupId);
+          return sqlTransaction(
+            this.context.dbPool,
+            async (client) =>
+              this.semaphoreGroupProvider?.getSerializedLatestGroup(
+                client,
+                groupId
+              )
+          );
         },
         getLatestGroupRoot: async (
           groupId: string
         ): Promise<string | undefined> => {
-          return this.semaphoreGroupProvider?.getLatestGroupRoot(groupId);
+          return sqlTransaction(
+            this.context.dbPool,
+            async (client) =>
+              this.semaphoreGroupProvider?.getLatestGroupRoot(client, groupId)
+          );
         },
         getSerializedHistoricalGroup: async (
           groupId: string,
           rootHash: string
         ): Promise<SerializedSemaphoreGroup | undefined> => {
-          return this.semaphoreGroupProvider?.getSerializedHistoricalGroup(
-            groupId,
-            rootHash
+          return sqlTransaction(
+            this.context.dbPool,
+            async (client) =>
+              this.semaphoreGroupProvider?.getSerializedHistoricalGroup(
+                client,
+                groupId,
+                rootHash
+              )
           );
         },
         getSupportedGroups: (): PipelineSemaphoreGroupInfo[] => {
@@ -254,7 +276,10 @@ export class PretixPipeline implements BasePipeline {
   public async start(): Promise<void> {
     // On startup, the pipeline definition may have changed, and manual tickets
     // may have been deleted. If so, clean up any check-ins for those tickets.
-    await this.cleanUpManualCheckins();
+    await sqlTransaction(this.context.dbPool, (client) =>
+      this.cleanUpManualCheckins(client)
+    );
+
     // Initialize the Semaphore Group provider by loading groups from the DB,
     // if one exists.
     await this.semaphoreGroupProvider?.start();
@@ -362,78 +387,90 @@ export class PretixPipeline implements BasePipeline {
           `saving ${atomsToSave.length} atoms for pipeline id '${this.id}' of type ${this.type}`
         );
 
-        if (this.autoIssuanceProvider) {
-          const newManualTickets =
-            await this.autoIssuanceProvider.dripNewManualTickets(
-              this.consumerDB,
-              await this.getAllManualTickets(),
-              atomsToSave
+        return namedSqlTransaction(
+          this.context.dbPool,
+          "load",
+          async (client) => {
+            if (this.autoIssuanceProvider) {
+              const newManualTickets =
+                await this.autoIssuanceProvider.dripNewManualTickets(
+                  client,
+                  this.consumerDB,
+                  await this.getAllManualTickets(client),
+                  atomsToSave
+                );
+
+              await Promise.allSettled(
+                newManualTickets.map((t) =>
+                  this.manualTicketDB.save(client, this.id, t)
+                )
+              );
+            }
+
+            await this.db.clear(this.definition.id);
+            await this.db.save(this.definition.id, atomsToSave);
+            await this.db.markAsLoaded(this.id);
+
+            logs.push(makePLogInfo(`saved ${atomsToSave.length} items`));
+
+            const loadEnd = Date.now();
+
+            logger(
+              LOG_TAG,
+              `loaded ${atomsToSave.length} atoms for pipeline id ${
+                this.id
+              } in ${loadEnd - startTime.getTime()}ms`
             );
 
-          await Promise.allSettled(
-            newManualTickets.map((t) => this.manualTicketDB.save(this.id, t))
-          );
-        }
+            span?.setAttribute("atoms_saved", atomsToSave.length);
 
-        await this.db.clear(this.definition.id);
-        await this.db.save(this.definition.id, atomsToSave);
-        await this.db.markAsLoaded(this.id);
+            // Remove any pending check-ins that succeeded before loading started.
+            // Those that succeeded after loading started might not be represented in
+            // the data we fetched, so we can remove them on the next run.
+            // Pending checkins with the "Pending" status should not be removed, as
+            // they are still in-progress.
+            this.pendingCheckIns.forEach((value, key) => {
+              if (
+                value.status === CheckinStatus.Success &&
+                value.timestamp <= startTime.getTime()
+              ) {
+                this.pendingCheckIns.delete(key);
+              }
+            });
 
-        logs.push(makePLogInfo(`saved ${atomsToSave.length} items`));
+            const end = new Date();
+            logs.push(
+              makePLogInfo(
+                `load finished in ${end.getTime() - startTime.getTime()}ms`
+              )
+            );
 
-        const loadEnd = Date.now();
+            if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
+              await this.triggerSemaphoreGroupUpdate(client);
+            }
 
-        logger(
-          LOG_TAG,
-          `loaded ${atomsToSave.length} atoms for pipeline id ${this.id} in ${
-            loadEnd - startTime.getTime()
-          }ms`
-        );
-
-        span?.setAttribute("atoms_saved", atomsToSave.length);
-
-        // Remove any pending check-ins that succeeded before loading started.
-        // Those that succeeded after loading started might not be represented in
-        // the data we fetched, so we can remove them on the next run.
-        // Pending checkins with the "Pending" status should not be removed, as
-        // they are still in-progress.
-        this.pendingCheckIns.forEach((value, key) => {
-          if (
-            value.status === CheckinStatus.Success &&
-            value.timestamp <= startTime.getTime()
-          ) {
-            this.pendingCheckIns.delete(key);
+            return {
+              lastRunEndTimestamp: end.toISOString(),
+              lastRunStartTimestamp: startTime.toISOString(),
+              latestLogs: logs,
+              atomsLoaded: atomsToSave.length,
+              atomsExpected: atomsToSave.length,
+              errorMessage: undefined,
+              semaphoreGroups:
+                this.semaphoreGroupProvider?.getSupportedGroups(),
+              success: true
+            } satisfies PipelineLoadSummary;
           }
-        });
-
-        const end = new Date();
-        logs.push(
-          makePLogInfo(
-            `load finished in ${end.getTime() - startTime.getTime()}ms`
-          )
         );
-
-        if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
-          await this.triggerSemaphoreGroupUpdate();
-        }
-
-        return {
-          lastRunEndTimestamp: end.toISOString(),
-          lastRunStartTimestamp: startTime.toISOString(),
-          latestLogs: logs,
-          atomsLoaded: atomsToSave.length,
-          atomsExpected: atomsToSave.length,
-          errorMessage: undefined,
-          semaphoreGroups: this.semaphoreGroupProvider?.getSupportedGroups(),
-          success: true
-        } satisfies PipelineLoadSummary;
       }
     );
   }
 
-  private async getAllManualTickets(): Promise<ManualTicket[]> {
+  private async getAllManualTickets(
+    client: PoolClient
+  ): Promise<ManualTicket[]> {
     return (this.definition.options.manualTickets ?? []).concat(
-      await this.manualTicketDB.loadAll(this.id)
+      await this.manualTicketDB.loadAll(client, this.id)
     );
   }
 
@@ -443,7 +480,9 @@ export class PretixPipeline implements BasePipeline {
    * SemaphoreGroupProvider will use to look up Semaphore IDs and match them
    * to configured Semaphore groups.
    */
-  private async semaphoreGroupData(): Promise<SemaphoreGroupTicketInfo[]> {
+  private async semaphoreGroupData(
+    client: PoolClient
+  ): Promise<SemaphoreGroupTicketInfo[]> {
     return traced(LOG_NAME, "semaphoreGroupData", async (span) => {
       const data = [];
       for (const atom of await this.db.load(this.id)) {
@@ -454,7 +493,7 @@ export class PretixPipeline implements BasePipeline {
         });
       }
 
-      for (const manualTicket of await this.getAllManualTickets()) {
+      for (const manualTicket of await this.getAllManualTickets(client)) {
         data.push({
           email: manualTicket.attendeeEmail,
           eventId: manualTicket.eventId,
@@ -468,7 +507,7 @@ export class PretixPipeline implements BasePipeline {
     });
   }
 
-  public async triggerSemaphoreGroupUpdate(): Promise<void> {
+  public async triggerSemaphoreGroupUpdate(client: PoolClient): Promise<void> {
     return traced(LOG_NAME, "triggerSemaphoreGroupUpdate", async (_span) => {
       tracePipeline(this.definition);
       // Whenever an update is triggered, we want to make sure that the
@@ -482,8 +521,8 @@ export class PretixPipeline implements BasePipeline {
       // By returning this promise, we allow the caller to await on the update
       // having been processed.
       return this.semaphoreUpdateQueue.add(async () => {
-        const data = await this.semaphoreGroupData();
-        await this.semaphoreGroupProvider?.update(data);
+        const data = await this.semaphoreGroupData(client);
+        await this.semaphoreGroupProvider?.update(client, data);
       });
     });
   }
@@ -492,14 +531,14 @@ export class PretixPipeline implements BasePipeline {
    * If manual tickets are removed after being checked in, they can leave
    * orphaned check-in data behind. This method cleans those up.
    */
-  private async cleanUpManualCheckins(): Promise<void> {
+  private async cleanUpManualCheckins(client: PoolClient): Promise<void> {
     return traced(LOG_NAME, "cleanUpManualCheckins", async (span) => {
       const ticketIds = new Set(
-        (await this.getAllManualTickets()).map(
+        (await this.getAllManualTickets(client)).map(
           (manualTicket) => manualTicket.id
         )
       );
-      const checkIns = await this.checkinDB.getByPipelineId(this.id);
+      const checkIns = await this.checkinDB.getByPipelineId(client, this.id);
       for (const checkIn of checkIns) {
         if (!ticketIds.has(checkIn.ticketId)) {
           logger(
@@ -507,7 +546,7 @@ export class PretixPipeline implements BasePipeline {
           );
           span?.setAttribute("deleted_checkin_ticket_id", checkIn.ticketId);
 
-          await this.checkinDB.deleteCheckIn(this.id, checkIn.ticketId);
+          await this.checkinDB.deleteCheckIn(client, this.id, checkIn.ticketId);
         }
       }
     });
@@ -852,6 +891,7 @@ export class PretixPipeline implements BasePipeline {
   }
 
   private async manualTicketToTicketData(
+    client: PoolClient,
     manualTicket: ManualTicket,
     sempahoreId: string
   ): Promise<ITicketData> {
@@ -859,6 +899,7 @@ export class PretixPipeline implements BasePipeline {
     const product = this.getProductById(event, manualTicket.productId);
 
     const checkIn = await this.checkinDB.getByTicketId(
+      client,
       this.id,
       manualTicket.id
     );
@@ -883,6 +924,7 @@ export class PretixPipeline implements BasePipeline {
   }
 
   private async manualTicketToPODTicketData(
+    client: PoolClient,
     manualTicket: ManualTicket,
     semaphoreV4Id: string
   ): Promise<IPODTicketData> {
@@ -890,6 +932,7 @@ export class PretixPipeline implements BasePipeline {
     const product = this.getProductById(event, manualTicket.productId);
 
     const checkIn = await this.checkinDB.getByTicketId(
+      client,
       this.id,
       manualTicket.id
     );
@@ -915,17 +958,19 @@ export class PretixPipeline implements BasePipeline {
   }
 
   private async getManualTicketsForEmail(
+    client: PoolClient,
     email: string
   ): Promise<ManualTicket[]> {
-    return (await this.getAllManualTickets()).filter((manualTicket) => {
+    return (await this.getAllManualTickets(client)).filter((manualTicket) => {
       return manualTicket.attendeeEmail.toLowerCase() === email.toLowerCase();
     });
   }
 
   private async getManualTicketById(
+    client: PoolClient,
     id: string
   ): Promise<ManualTicket | undefined> {
-    return (await this.getAllManualTickets()).find(
+    return (await this.getAllManualTickets(client)).find(
       (manualTicket) => manualTicket.id === id
     );
   }
@@ -936,6 +981,7 @@ export class PretixPipeline implements BasePipeline {
    * definition.
    */
   private async getEdDSATicketsForEmail(
+    client: PoolClient,
     email: string,
     identityCommitment: string
   ): Promise<EdDSATicketPCD[]> {
@@ -946,13 +992,17 @@ export class PretixPipeline implements BasePipeline {
       this.atomToEdDSATicketData(t, identityCommitment)
     );
     // Load manual tickets from the definition
-    const manualTickets = await this.getManualTicketsForEmail(email);
+    const manualTickets = await this.getManualTicketsForEmail(client, email);
 
     // Convert manual tickets to ticket data and add to array
     ticketDatas.push(
       ...(await Promise.all(
         manualTickets.map((manualTicket) =>
-          this.manualTicketToTicketData(manualTicket, identityCommitment)
+          this.manualTicketToTicketData(
+            client,
+            manualTicket,
+            identityCommitment
+          )
         )
       ))
     );
@@ -971,6 +1021,7 @@ export class PretixPipeline implements BasePipeline {
    * definition.
    */
   private async getPODTicketsForEmail(
+    client: PoolClient,
     email: string,
     semaphoreV4Id: string
   ): Promise<PODTicketPCD[]> {
@@ -981,13 +1032,13 @@ export class PretixPipeline implements BasePipeline {
       this.atomToPODTicketData(t, semaphoreV4Id)
     );
     // Load manual tickets from the definition
-    const manualTickets = await this.getManualTicketsForEmail(email);
+    const manualTickets = await this.getManualTicketsForEmail(client, email);
 
     // Convert manual tickets to ticket data and add to array
     ticketDatas.push(
       ...(await Promise.all(
         manualTickets.map((manualTicket) =>
-          this.manualTicketToPODTicketData(manualTicket, semaphoreV4Id)
+          this.manualTicketToPODTicketData(client, manualTicket, semaphoreV4Id)
         )
       ))
     );
@@ -1026,96 +1077,103 @@ export class PretixPipeline implements BasePipeline {
 
       let didUpdate = false;
 
-      for (const e of emails) {
-        didUpdate =
-          didUpdate ||
-          (await this.consumerDB.save(
-            this.id,
-            e.email,
-            semaphoreId,
-            new Date()
-          ));
-      }
+      return namedSqlTransaction(this.context.dbPool, "", async (client) => {
+        for (const e of emails) {
+          didUpdate =
+            didUpdate ||
+            (await this.consumerDB.save(
+              client,
+              this.id,
+              e.email,
+              semaphoreId,
+              new Date()
+            ));
+        }
 
-      const provider = this.autoIssuanceProvider;
-      if (provider) {
-        const newManualTickets = (
-          await Promise.all(
-            emails.map(async (e) =>
-              provider.maybeIssueForUser(
-                e.email,
-                await this.getAllManualTickets(),
-                await this.db.loadByEmail(this.id, e.email)
+        const provider = this.autoIssuanceProvider;
+        if (provider) {
+          const newManualTickets = (
+            await Promise.all(
+              emails.map(async (e) =>
+                provider.maybeIssueForUser(
+                  e.email,
+                  await this.getAllManualTickets(client),
+                  await this.db.loadByEmail(this.id, e.email)
+                )
               )
+            )
+          ).flat();
+
+          await Promise.allSettled(
+            newManualTickets.map((t) =>
+              this.manualTicketDB.save(client, this.id, t)
+            )
+          );
+        }
+
+        // If the user's Semaphore commitment has changed, `didUpdate` will be
+        // true, and we need to update the Semaphore groups
+        if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
+          if (didUpdate) {
+            span?.setAttribute("semaphore_groups_updated", true);
+            await this.triggerSemaphoreGroupUpdate(client);
+          }
+        }
+
+        const tickets = (
+          await Promise.all(
+            emails.map((e) =>
+              this.getEdDSATicketsForEmail(client, e.email, semaphoreId)
             )
           )
         ).flat();
 
-        await Promise.allSettled(
-          newManualTickets.map((t) => this.manualTicketDB.save(this.id, t))
-        );
-      }
+        span?.setAttribute("pcds_issued", tickets.length);
 
-      // If the user's Semaphore commitment has changed, `didUpdate` will be
-      // true, and we need to update the Semaphore groups
-      if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
-        if (didUpdate) {
-          span?.setAttribute("semaphore_groups_updated", true);
-          await this.triggerSemaphoreGroupUpdate();
+        const actions: PCDAction[] = [];
+
+        if (await this.db.hasLoaded(this.id)) {
+          actions.push({
+            type: PCDActionType.DeleteFolder,
+            folder: this.definition.options.feedOptions.feedFolder,
+            recursive: true
+          });
         }
-      }
 
-      const tickets = (
-        await Promise.all(
-          emails.map((e) => this.getEdDSATicketsForEmail(e.email, semaphoreId))
-        )
-      ).flat();
+        const ticketPCDs = await Promise.all(
+          tickets.map((t) => EdDSATicketPCDPackage.serialize(t))
+        );
 
-      span?.setAttribute("pcds_issued", tickets.length);
-
-      const actions: PCDAction[] = [];
-
-      if (await this.db.hasLoaded(this.id)) {
-        actions.push({
-          type: PCDActionType.DeleteFolder,
-          folder: this.definition.options.feedOptions.feedFolder,
-          recursive: true
-        });
-      }
-
-      const ticketPCDs = await Promise.all(
-        tickets.map((t) => EdDSATicketPCDPackage.serialize(t))
-      );
-
-      if (this.definition.options.enablePODTickets) {
-        const podTickets = (
-          await Promise.all(
-            emails.map((e) =>
-              e.semaphoreV4Id
-                ? this.getPODTicketsForEmail(e.email, e.semaphoreV4Id)
-                : undefined
+        if (this.definition.options.enablePODTickets) {
+          const podTickets = (
+            await Promise.all(
+              emails.map((e) =>
+                e.semaphoreV4Id
+                  ? this.getPODTicketsForEmail(client, e.email, e.semaphoreV4Id)
+                  : undefined
+              )
             )
           )
-        )
-          .flat()
-          .filter((t) => t !== undefined) as PODTicketPCD[];
+            .flat()
+            .filter((t) => t !== undefined) as PODTicketPCD[];
 
-        ticketPCDs.push(
-          ...(await Promise.all(
-            podTickets.map((t) => PODTicketPCDPackage.serialize(t))
-          ))
-        );
-      }
+          ticketPCDs.push(
+            ...(await Promise.all(
+              podTickets.map((t) => PODTicketPCDPackage.serialize(t))
+            ))
+          );
+        }
 
-      actions.push({
-        type: PCDActionType.ReplaceInFolder,
-        folder: this.definition.options.feedOptions.feedFolder,
-        pcds: ticketPCDs
+        actions.push({
+          type: PCDActionType.ReplaceInFolder,
+          folder: this.definition.options.feedOptions.feedFolder,
+          pcds: ticketPCDs
+        });
+
+        const result: PollFeedResponseValue = { actions };
+
+        return result;
       });
-
-      const result: PollFeedResponseValue = { actions };
-
-      return result;
     });
   }
 
@@ -1444,6 +1502,7 @@ export class PretixPipeline implements BasePipeline {
    * error if not.
    */
   private async canCheckInForEvent(
+    client: PoolClient,
     eventId: string,
     productId: string,
     checkerEmails: string[]
@@ -1463,7 +1522,7 @@ export class PretixPipeline implements BasePipeline {
     ).flat();
     const manualCheckerTickets = (
       await Promise.all(
-        checkerEmails.map((e) => this.getManualTicketsForEmail(e))
+        checkerEmails.map((e) => this.getManualTicketsForEmail(client, e))
       )
     ).flat();
 
@@ -1561,11 +1620,13 @@ export class PretixPipeline implements BasePipeline {
    * is a pending check-in.
    */
   private async canCheckInManualTicket(
+    client: PoolClient,
     manualTicket: ManualTicket
   ): Promise<true | PodboxTicketActionError> {
     return traced(LOG_NAME, "canCheckInManualTicket", async (span) => {
       // Is the ticket already checked in?
       const checkIn = await this.checkinDB.getByTicketId(
+        client,
         this.id,
         manualTicket.id
       );
@@ -1608,214 +1669,232 @@ export class PretixPipeline implements BasePipeline {
       LOG_NAME,
       "checkPretixTicketPCDCanBeCheckedIn",
       async (span): Promise<ActionConfigResponseValue> => {
-        tracePipeline(this.definition);
+        return namedSqlTransaction(
+          this.context.dbPool,
+          "checkPretixTicketPCDCanBeCheckedIn",
+          async (client) => {
+            tracePipeline(this.definition);
 
-        let checkerEmails: string[];
-        const { eventId, ticketId } = request;
+            let checkerEmails: string[];
+            const { eventId, ticketId } = request;
 
-        // This method can only be used to pre-check for check-ins.
-        // There is no pre-check for any other kind of action at this time.
-        if (request.action.checkin !== true) {
-          throw new PCDHTTPError(400, "Not supported");
-        }
-
-        try {
-          span?.setAttribute("ticket_id", ticketId);
-
-          const { emails, semaphoreId } =
-            await this.credentialSubservice.verifyAndExpectZupassEmail(
-              request.credential
-            );
-
-          span?.setAttribute(
-            "checker_email",
-            emails?.map((e) => e.email).join(",") ?? ""
-          );
-          span?.setAttribute("checked_semaphore_id", semaphoreId);
-
-          checkerEmails = emails?.map((e) => e.email) ?? [];
-          if (checkerEmails.length === 0) {
-            throw new Error("missing emails in credential");
-          }
-        } catch (e) {
-          logger(`${LOG_TAG} Failed to verify credential due to error: `, e);
-          setError(e, span);
-          span?.setAttribute("precheck_error", "InvalidSignature");
-          return {
-            success: true,
-            checkinActionInfo: {
-              canCheckIn: false,
-              permissioned: false,
-              reason: { name: "InvalidSignature" }
+            // This method can only be used to pre-check for check-ins.
+            // There is no pre-check for any other kind of action at this time.
+            if (request.action.checkin !== true) {
+              throw new PCDHTTPError(400, "Not supported");
             }
-          };
-        }
 
-        const realTicket = await this.db.loadById(this.id, ticketId);
-        const manualTicket = await this.getManualTicketById(ticketId);
-        const checkinInProductId =
-          realTicket?.productId ?? manualTicket?.productId;
-        if (!checkinInProductId) {
-          throw new Error(`ticket with id '${ticketId}' does not exist`);
-        }
+            try {
+              span?.setAttribute("ticket_id", ticketId);
 
-        try {
-          // Verify that checker can check in tickets for the specified event
-          const canCheckInResult = await this.canCheckInForEvent(
-            eventId,
-            checkinInProductId,
-            checkerEmails
-          );
+              const { emails, semaphoreId } =
+                await this.credentialSubservice.verifyAndExpectZupassEmail(
+                  request.credential
+                );
 
-          if (canCheckInResult !== true) {
-            span?.setAttribute("precheck_error", canCheckInResult.name);
-            return {
-              success: true,
-              checkinActionInfo: {
-                permissioned: false,
-                canCheckIn: false,
-                reason: canCheckInResult
+              span?.setAttribute(
+                "checker_email",
+                emails?.map((e) => e.email).join(",") ?? ""
+              );
+              span?.setAttribute("checked_semaphore_id", semaphoreId);
+
+              checkerEmails = emails?.map((e) => e.email) ?? [];
+              if (checkerEmails.length === 0) {
+                throw new Error("missing emails in credential");
               }
-            };
-          }
-
-          // First see if we have an atom which matches the ticket ID
-          const ticketAtom = await this.db.loadById(this.id, ticketId);
-          if (ticketAtom && ticketAtom.eventId === eventId) {
-            const canCheckInTicketResult =
-              await this.canCheckInPretixTicket(ticketAtom);
-            if (canCheckInTicketResult !== true) {
-              if (canCheckInTicketResult.name === "AlreadyCheckedIn") {
-                return {
-                  success: true,
-                  checkinActionInfo: {
-                    permissioned: true,
-                    canCheckIn: false,
-                    reason: canCheckInTicketResult,
-                    ticket: {
-                      eventName: this.atomToEventName(ticketAtom),
-                      ticketName: this.atomToTicketName(ticketAtom),
-                      attendeeEmail: ticketAtom.email as string,
-                      attendeeName: ticketAtom.name
-                    }
-                  }
-                };
-              }
+            } catch (e) {
+              logger(
+                `${LOG_TAG} Failed to verify credential due to error: `,
+                e
+              );
+              setError(e, span);
+              span?.setAttribute("precheck_error", "InvalidSignature");
               return {
                 success: true,
                 checkinActionInfo: {
-                  permissioned: false,
                   canCheckIn: false,
-                  reason: canCheckInTicketResult
-                }
-              };
-            } else {
-              return {
-                success: true,
-                checkinActionInfo: {
-                  permissioned: true,
-                  canCheckIn: true,
-                  ticket: {
-                    eventName: this.atomToEventName(ticketAtom),
-                    ticketName: this.atomToTicketName(ticketAtom),
-                    attendeeEmail: ticketAtom.email as string,
-                    attendeeName: ticketAtom.name
-                  }
+                  permissioned: false,
+                  reason: { name: "InvalidSignature" }
                 }
               };
             }
-          } else {
-            // No Pretix atom found, try looking for a manual ticket
-            const manualTicket = await this.getManualTicketById(ticketId);
-            if (manualTicket && manualTicket.eventId === eventId) {
-              // Manual ticket found
-              const canCheckInTicketResult =
-                await this.canCheckInManualTicket(manualTicket);
-              if (canCheckInTicketResult !== true) {
-                if (canCheckInTicketResult.name === "AlreadyCheckedIn") {
-                  const eventConfig = this.getEventById(manualTicket.eventId);
-                  const ticketType = this.getProductById(
-                    eventConfig,
-                    manualTicket.productId
-                  );
-                  return {
-                    success: true,
-                    checkinActionInfo: {
-                      permissioned: true,
-                      canCheckIn: false,
-                      reason: canCheckInTicketResult,
-                      ticket: {
-                        eventName: eventConfig.name,
-                        ticketName: ticketType.name,
-                        attendeeEmail: manualTicket.attendeeEmail,
-                        attendeeName: manualTicket.attendeeName
-                      }
-                    }
-                  };
-                }
+
+            const realTicket = await this.db.loadById(this.id, ticketId);
+            const manualTicket = await this.getManualTicketById(
+              client,
+              ticketId
+            );
+            const checkinInProductId =
+              realTicket?.productId ?? manualTicket?.productId;
+            if (!checkinInProductId) {
+              throw new Error(`ticket with id '${ticketId}' does not exist`);
+            }
+
+            try {
+              // Verify that checker can check in tickets for the specified event
+              const canCheckInResult = await this.canCheckInForEvent(
+                client,
+                eventId,
+                checkinInProductId,
+                checkerEmails
+              );
+
+              if (canCheckInResult !== true) {
+                span?.setAttribute("precheck_error", canCheckInResult.name);
                 return {
                   success: true,
                   checkinActionInfo: {
                     permissioned: false,
                     canCheckIn: false,
-                    reason: canCheckInTicketResult
-                  }
-                };
-              } else {
-                const eventConfig = this.getEventById(manualTicket.eventId);
-                const ticketType = this.getProductById(
-                  eventConfig,
-                  manualTicket.productId
-                );
-                return {
-                  success: true,
-                  checkinActionInfo: {
-                    permissioned: true,
-                    canCheckIn: true,
-                    ticket: {
-                      eventName: eventConfig.name,
-                      ticketName: ticketType.name,
-                      attendeeEmail: manualTicket.attendeeEmail,
-                      attendeeName: manualTicket.attendeeName
-                    }
+                    reason: canCheckInResult
                   }
                 };
               }
+
+              // First see if we have an atom which matches the ticket ID
+              const ticketAtom = await this.db.loadById(this.id, ticketId);
+              if (ticketAtom && ticketAtom.eventId === eventId) {
+                const canCheckInTicketResult =
+                  await this.canCheckInPretixTicket(ticketAtom);
+                if (canCheckInTicketResult !== true) {
+                  if (canCheckInTicketResult.name === "AlreadyCheckedIn") {
+                    return {
+                      success: true,
+                      checkinActionInfo: {
+                        permissioned: true,
+                        canCheckIn: false,
+                        reason: canCheckInTicketResult,
+                        ticket: {
+                          eventName: this.atomToEventName(ticketAtom),
+                          ticketName: this.atomToTicketName(ticketAtom),
+                          attendeeEmail: ticketAtom.email as string,
+                          attendeeName: ticketAtom.name
+                        }
+                      }
+                    };
+                  }
+                  return {
+                    success: true,
+                    checkinActionInfo: {
+                      permissioned: false,
+                      canCheckIn: false,
+                      reason: canCheckInTicketResult
+                    }
+                  };
+                } else {
+                  return {
+                    success: true,
+                    checkinActionInfo: {
+                      permissioned: true,
+                      canCheckIn: true,
+                      ticket: {
+                        eventName: this.atomToEventName(ticketAtom),
+                        ticketName: this.atomToTicketName(ticketAtom),
+                        attendeeEmail: ticketAtom.email as string,
+                        attendeeName: ticketAtom.name
+                      }
+                    }
+                  };
+                }
+              } else {
+                // No Pretix atom found, try looking for a manual ticket
+                const manualTicket = await this.getManualTicketById(
+                  client,
+                  ticketId
+                );
+                if (manualTicket && manualTicket.eventId === eventId) {
+                  // Manual ticket found
+                  const canCheckInTicketResult =
+                    await this.canCheckInManualTicket(client, manualTicket);
+                  if (canCheckInTicketResult !== true) {
+                    if (canCheckInTicketResult.name === "AlreadyCheckedIn") {
+                      const eventConfig = this.getEventById(
+                        manualTicket.eventId
+                      );
+                      const ticketType = this.getProductById(
+                        eventConfig,
+                        manualTicket.productId
+                      );
+                      return {
+                        success: true,
+                        checkinActionInfo: {
+                          permissioned: true,
+                          canCheckIn: false,
+                          reason: canCheckInTicketResult,
+                          ticket: {
+                            eventName: eventConfig.name,
+                            ticketName: ticketType.name,
+                            attendeeEmail: manualTicket.attendeeEmail,
+                            attendeeName: manualTicket.attendeeName
+                          }
+                        }
+                      };
+                    }
+                    return {
+                      success: true,
+                      checkinActionInfo: {
+                        permissioned: false,
+                        canCheckIn: false,
+                        reason: canCheckInTicketResult
+                      }
+                    };
+                  } else {
+                    const eventConfig = this.getEventById(manualTicket.eventId);
+                    const ticketType = this.getProductById(
+                      eventConfig,
+                      manualTicket.productId
+                    );
+                    return {
+                      success: true,
+                      checkinActionInfo: {
+                        permissioned: true,
+                        canCheckIn: true,
+                        ticket: {
+                          eventName: eventConfig.name,
+                          ticketName: ticketType.name,
+                          attendeeEmail: manualTicket.attendeeEmail,
+                          attendeeName: manualTicket.attendeeName
+                        }
+                      }
+                    };
+                  }
+                }
+              }
+            } catch (e) {
+              logger(
+                `${LOG_TAG} Error when finding ticket ${ticketId} for checkin by ${JSON.stringify(
+                  checkerEmails
+                )} on pipeline ${this.id}`,
+                e
+              );
+              setError(e);
+              span?.setAttribute("checkin_error", "InvalidTicket");
+              return {
+                success: true,
+                checkinActionInfo: {
+                  permissioned: false,
+                  canCheckIn: false,
+                  reason: { name: "InvalidTicket" }
+                }
+              };
             }
+            // Didn't find any matching ticket
+            logger(
+              `${LOG_TAG} Could not find ticket ${ticketId} for event ${eventId} for checkin requested by ${JSON.stringify(
+                checkerEmails
+              )} on pipeline ${this.id}`
+            );
+            span?.setAttribute("checkin_error", "InvalidTicket");
+            return {
+              success: true,
+              checkinActionInfo: {
+                permissioned: false,
+                canCheckIn: false,
+                reason: { name: "InvalidTicket" }
+              }
+            };
           }
-        } catch (e) {
-          logger(
-            `${LOG_TAG} Error when finding ticket ${ticketId} for checkin by ${JSON.stringify(
-              checkerEmails
-            )} on pipeline ${this.id}`,
-            e
-          );
-          setError(e);
-          span?.setAttribute("checkin_error", "InvalidTicket");
-          return {
-            success: true,
-            checkinActionInfo: {
-              permissioned: false,
-              canCheckIn: false,
-              reason: { name: "InvalidTicket" }
-            }
-          };
-        }
-        // Didn't find any matching ticket
-        logger(
-          `${LOG_TAG} Could not find ticket ${ticketId} for event ${eventId} for checkin requested by ${JSON.stringify(
-            checkerEmails
-          )} on pipeline ${this.id}`
         );
-        span?.setAttribute("checkin_error", "InvalidTicket");
-        return {
-          success: true,
-          checkinActionInfo: {
-            permissioned: false,
-            canCheckIn: false,
-            reason: { name: "InvalidTicket" }
-          }
-        };
       }
     );
   }
@@ -1830,79 +1909,89 @@ export class PretixPipeline implements BasePipeline {
     request: PodboxTicketActionRequest
   ): Promise<PodboxTicketActionResponseValue> {
     return traced(LOG_NAME, "checkinPretixTicketPCDs", async (span) => {
-      tracePipeline(this.definition);
+      return namedSqlTransaction(
+        this.context.dbPool,
+        "checkinPretixTicketPCDs",
+        async (client) => {
+          tracePipeline(this.definition);
 
-      logger(
-        LOG_TAG,
-        `got request to check in tickets with request ${JSON.stringify(
-          request
-        )}`
-      );
-
-      let checkerEmails: string[];
-      const { ticketId, eventId } = request;
-
-      try {
-        span?.setAttribute("ticket_id", ticketId);
-        const { emails, semaphoreId } =
-          await this.credentialSubservice.verifyAndExpectZupassEmail(
-            request.credential
-          );
-
-        span?.setAttribute(
-          "checker_email",
-          emails?.map((e) => e.email).join(",") ?? ""
-        );
-        span?.setAttribute("checked_semaphore_id", semaphoreId);
-        checkerEmails = emails?.map((e) => e.email) ?? [];
-
-        if (checkerEmails.length === 0) {
-          throw new Error("missing emails in credential");
-        }
-      } catch (e) {
-        logger(`${LOG_TAG} Failed to verify credential due to error: `, e);
-        setError(e, span);
-        span?.setAttribute("checkin_error", "InvalidSignature");
-        return { success: false, error: { name: "InvalidSignature" } };
-      }
-
-      const realTicket = await this.db.loadById(this.id, ticketId);
-      const manualTicket = await this.getManualTicketById(ticketId);
-      const checkinInProductId =
-        realTicket?.productId ?? manualTicket?.productId;
-      if (!checkinInProductId) {
-        throw new Error(`ticket with id '${ticketId}' does not exist`);
-      }
-      const canCheckInResult = await this.canCheckInForEvent(
-        eventId,
-        checkinInProductId,
-        checkerEmails
-      );
-
-      if (canCheckInResult !== true) {
-        return { success: false, error: canCheckInResult };
-      }
-
-      // First see if we have an atom which matches the ticket ID
-      const ticketAtom = await this.db.loadById(this.id, ticketId);
-      if (ticketAtom && ticketAtom.eventId === eventId) {
-        return this.checkInPretixTicket(ticketAtom, checkerEmails[0]);
-      } else {
-        const manualTicket = await this.getManualTicketById(ticketId);
-        if (manualTicket && manualTicket.eventId === eventId) {
-          // Manual ticket found, check in with the DB
-          return this.checkInManualTicket(manualTicket, checkerEmails[0]);
-        } else {
-          // Didn't find any matching ticket
           logger(
-            `${LOG_TAG} Could not find ticket ${ticketId} for event ${eventId} for checkin requested by ${JSON.stringify(
-              checkerEmails
-            )} on pipeline ${this.id}`
+            LOG_TAG,
+            `got request to check in tickets with request ${JSON.stringify(
+              request
+            )}`
           );
-          span?.setAttribute("checkin_error", "InvalidTicket");
-          return { success: false, error: { name: "InvalidTicket" } };
+
+          let checkerEmails: string[];
+          const { ticketId, eventId } = request;
+
+          try {
+            span?.setAttribute("ticket_id", ticketId);
+            const { emails, semaphoreId } =
+              await this.credentialSubservice.verifyAndExpectZupassEmail(
+                request.credential
+              );
+
+            span?.setAttribute(
+              "checker_email",
+              emails?.map((e) => e.email).join(",") ?? ""
+            );
+            span?.setAttribute("checked_semaphore_id", semaphoreId);
+            checkerEmails = emails?.map((e) => e.email) ?? [];
+
+            if (checkerEmails.length === 0) {
+              throw new Error("missing emails in credential");
+            }
+          } catch (e) {
+            logger(`${LOG_TAG} Failed to verify credential due to error: `, e);
+            setError(e, span);
+            span?.setAttribute("checkin_error", "InvalidSignature");
+            return { success: false, error: { name: "InvalidSignature" } };
+          }
+
+          const realTicket = await this.db.loadById(this.id, ticketId);
+          const manualTicket = await this.getManualTicketById(client, ticketId);
+          const checkinInProductId =
+            realTicket?.productId ?? manualTicket?.productId;
+          if (!checkinInProductId) {
+            throw new Error(`ticket with id '${ticketId}' does not exist`);
+          }
+          const canCheckInResult = await this.canCheckInForEvent(
+            client,
+            eventId,
+            checkinInProductId,
+            checkerEmails
+          );
+
+          if (canCheckInResult !== true) {
+            return { success: false, error: canCheckInResult };
+          }
+
+          // First see if we have an atom which matches the ticket ID
+          const ticketAtom = await this.db.loadById(this.id, ticketId);
+          if (ticketAtom && ticketAtom.eventId === eventId) {
+            return this.checkInPretixTicket(ticketAtom, checkerEmails[0]);
+          } else {
+            const manualTicket = await this.getManualTicketById(
+              client,
+              ticketId
+            );
+            if (manualTicket && manualTicket.eventId === eventId) {
+              // Manual ticket found, check in with the DB
+              return this.checkInManualTicket(manualTicket, checkerEmails[0]);
+            } else {
+              // Didn't find any matching ticket
+              logger(
+                `${LOG_TAG} Could not find ticket ${ticketId} for event ${eventId} for checkin requested by ${JSON.stringify(
+                  checkerEmails
+                )} on pipeline ${this.id}`
+              );
+              span?.setAttribute("checkin_error", "InvalidTicket");
+              return { success: false, error: { name: "InvalidTicket" } };
+            }
+          }
         }
-      }
+      );
     });
   }
 
@@ -1917,62 +2006,70 @@ export class PretixPipeline implements BasePipeline {
       LOG_NAME,
       "checkInManualTicket",
       async (span): Promise<PodboxTicketActionResponseValue> => {
-        const pendingCheckin = this.pendingCheckIns.get(manualTicket.id);
-        if (pendingCheckin) {
-          span?.setAttribute("checkin_error", "AlreadyCheckedIn");
-          return {
-            success: false,
-            error: {
-              name: "AlreadyCheckedIn",
-              checkinTimestamp: new Date(
-                pendingCheckin.timestamp
-              ).toISOString(),
-              checker: PRETIX_CHECKER
-            }
-          };
-        }
-
-        try {
-          await this.checkinDB.checkIn(
-            this.id,
-            manualTicket.id,
-            new Date(),
-            checkerEmail
-          );
-          this.pendingCheckIns.set(manualTicket.id, {
-            status: CheckinStatus.Success,
-            timestamp: Date.now()
-          });
-        } catch (e) {
-          logger(
-            `${LOG_TAG} Failed to check in ticket ${manualTicket.id} for event ${manualTicket.eventId} on behalf of checker ${checkerEmail} on pipeline ${this.id}`
-          );
-          setError(e, span);
-          this.pendingCheckIns.delete(manualTicket.id);
-
-          if (e instanceof DatabaseError) {
-            // We may have received a DatabaseError due to an insertion conflict
-            // Detect this conflict by looking for an existing check-in.
-            const existingCheckin = await this.checkinDB.getByTicketId(
-              this.id,
-              manualTicket.id
-            );
-            if (existingCheckin) {
+        return namedSqlTransaction(
+          this.context.dbPool,
+          "checkInManualTicket",
+          async (client) => {
+            const pendingCheckin = this.pendingCheckIns.get(manualTicket.id);
+            if (pendingCheckin) {
               span?.setAttribute("checkin_error", "AlreadyCheckedIn");
               return {
                 success: false,
                 error: {
                   name: "AlreadyCheckedIn",
-                  checkinTimestamp: existingCheckin.timestamp.toISOString(),
+                  checkinTimestamp: new Date(
+                    pendingCheckin.timestamp
+                  ).toISOString(),
                   checker: PRETIX_CHECKER
                 }
               };
             }
+
+            try {
+              await this.checkinDB.checkIn(
+                client,
+                this.id,
+                manualTicket.id,
+                new Date(),
+                checkerEmail
+              );
+              this.pendingCheckIns.set(manualTicket.id, {
+                status: CheckinStatus.Success,
+                timestamp: Date.now()
+              });
+            } catch (e) {
+              logger(
+                `${LOG_TAG} Failed to check in ticket ${manualTicket.id} for event ${manualTicket.eventId} on behalf of checker ${checkerEmail} on pipeline ${this.id}`
+              );
+              setError(e, span);
+              this.pendingCheckIns.delete(manualTicket.id);
+
+              if (e instanceof DatabaseError) {
+                // We may have received a DatabaseError due to an insertion conflict
+                // Detect this conflict by looking for an existing check-in.
+                const existingCheckin = await this.checkinDB.getByTicketId(
+                  client,
+                  this.id,
+                  manualTicket.id
+                );
+                if (existingCheckin) {
+                  span?.setAttribute("checkin_error", "AlreadyCheckedIn");
+                  return {
+                    success: false,
+                    error: {
+                      name: "AlreadyCheckedIn",
+                      checkinTimestamp: existingCheckin.timestamp.toISOString(),
+                      checker: PRETIX_CHECKER
+                    }
+                  };
+                }
+              }
+              span?.setAttribute("checkin_error", "ServerError");
+              return { success: false, error: { name: "ServerError" } };
+            }
+            return { success: true };
           }
-          span?.setAttribute("checkin_error", "ServerError");
-          return { success: false, error: { name: "ServerError" } };
-        }
-        return { success: true };
+        );
       }
     );
   }

--- a/apps/passport-server/src/services/generic-issuance/subservices/utils/instantiatePipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/subservices/utils/instantiatePipeline.ts
@@ -63,6 +63,7 @@ export interface InstantiatePipelineArgs {
  * and expose its {@link Capability}s to the external world.
  */
 export function instantiatePipeline(
+  context: ApplicationContext,
   definition: PipelineDefinition,
   args: InstantiatePipelineArgs
 ): Promise<Pipeline> {
@@ -104,6 +105,7 @@ export function instantiatePipeline(
       );
     } else if (isCSVPipelineDefinition(definition)) {
       pipeline = new CSVPipeline(
+        context,
         args.eddsaPrivateKey,
         definition,
         args.pipelineAtomDB,
@@ -113,6 +115,7 @@ export function instantiatePipeline(
       );
     } else if (isPODPipelineDefinition(definition)) {
       pipeline = new PODPipeline(
+        context,
         args.eddsaPrivateKey,
         definition,
         args.pipelineAtomDB,

--- a/apps/passport-server/src/services/persistentCacheService.ts
+++ b/apps/passport-server/src/services/persistentCacheService.ts
@@ -1,11 +1,12 @@
 import { RollbarService } from "@pcd/server-shared";
-import { Pool } from "postgres-pool";
+import { Pool, PoolClient } from "postgres-pool";
 import {
   CacheEntry,
   deleteExpiredCacheEntries,
   getCacheValue,
   setCacheValue
 } from "../database/queries/cache";
+import { namedSqlTransaction } from "../database/sqlQuery";
 import { logger } from "../util/logger";
 import { traced } from "./telemetryService";
 
@@ -25,22 +26,26 @@ export class PersistentCacheService {
    */
   private static readonly CACHE_GARBAGE_COLLECT_INTERVAL_MS = 60_000;
 
-  private expirationInterval: ReturnType<typeof setInterval> | undefined;
-  private db: Pool;
+  private expirationInterval: number | undefined;
+  private pool: Pool;
   private rollbarService: RollbarService | null;
 
-  public constructor(db: Pool, rollbarService: RollbarService | null) {
-    this.db = db;
+  public constructor(pool: Pool, rollbarService: RollbarService | null) {
+    this.pool = pool;
     this.rollbarService = rollbarService;
   }
 
   public start(): void {
     logger("[CACHE] starting expiration loop");
-    this.tryExpireOldEntries();
+
+    namedSqlTransaction(this.pool, "tryExpireOldEntries", (client) =>
+      this.tryExpireOldEntries(client)
+    );
+
     this.expirationInterval = setInterval(
       this.tryExpireOldEntries.bind(this),
       PersistentCacheService.CACHE_GARBAGE_COLLECT_INTERVAL_MS
-    );
+    ) as number;
   }
 
   public stop(): void {
@@ -52,32 +57,36 @@ export class PersistentCacheService {
   public async setValue(key: string, value: string): Promise<void> {
     return traced("Cache", "setValue", async (span) => {
       span?.setAttribute("cache_key", key);
-      await setCacheValue(this.db, key, value);
+      await namedSqlTransaction(this.pool, "setValue", (client) =>
+        setCacheValue(client, key, value)
+      );
     });
   }
 
   public async getValue(key: string): Promise<CacheEntry | undefined> {
     return traced("Cache", "getValue", async (span) => {
       span?.setAttribute("cache_key", key);
-      const value = getCacheValue(this.db, key);
-      span?.setAttribute("hit", !!value);
-      return value;
+      return await namedSqlTransaction(this.pool, "getValue", (client) => {
+        const value = getCacheValue(client, key);
+        span?.setAttribute("hit", !!value);
+        return value;
+      });
     });
   }
 
-  private async tryExpireOldEntries(): Promise<void> {
+  private async tryExpireOldEntries(client: PoolClient): Promise<void> {
     try {
-      this.expireOldEntries();
+      this.expireOldEntries(client);
     } catch (e) {
       logger("failed to expire old cache entries", e);
       this.rollbarService?.reportError(e);
     }
   }
-  private async expireOldEntries(): Promise<void> {
+  private async expireOldEntries(client: PoolClient): Promise<void> {
     return traced("Cache", "expireOldEntries", async (span) => {
       logger("[CACHE] expiring old entries");
       const deleted_count = await deleteExpiredCacheEntries(
-        this.db,
+        client,
         PersistentCacheService.MAX_CACHE_ENTRY_AGE_DAYS,
         PersistentCacheService.MAX_CACHE_ENTRY_COUNT
       );
@@ -87,11 +96,11 @@ export class PersistentCacheService {
 }
 
 export function startPersistentCacheService(
-  db: Pool,
+  pool: Pool,
   rollbarService: RollbarService | null
 ): PersistentCacheService {
   logger("[INIT] starting PersistentCacheService");
-  const cacheService = new PersistentCacheService(db, rollbarService);
+  const cacheService = new PersistentCacheService(pool, rollbarService);
   cacheService.start();
   return cacheService;
 }

--- a/apps/passport-server/src/services/semaphoreService.ts
+++ b/apps/passport-server/src/services/semaphoreService.ts
@@ -1,7 +1,7 @@
 import { ZuzaluUserRole } from "@pcd/passport-interface";
 import { serializeSemaphoreGroup } from "@pcd/semaphore-group-pcd";
 import { Group } from "@semaphore-protocol/group";
-import { Pool } from "postgres-pool";
+import { Pool, PoolClient } from "postgres-pool";
 import { HistoricSemaphoreGroup, LoggedInZuzaluUser } from "../database/models";
 import {
   fetchHistoricGroupByRoot,
@@ -9,7 +9,6 @@ import {
   insertNewHistoricSemaphoreGroup
 } from "../database/queries/historicSemaphore";
 import {
-  fetchAllUsers,
   fetchAllUsersWithDevconnectSuperuserTickets,
   fetchAllUsersWithDevconnectTickets
 } from "../database/queries/users";
@@ -18,6 +17,7 @@ import {
   fetchAllUsersWithZuzaluTickets,
   UserWithZuzaluTickets
 } from "../database/queries/zuzalu_pretix_tickets/fetchZuzaluUser";
+import { sqlTransaction } from "../database/sqlQuery";
 import { PCDHTTPError } from "../routing/pcdHttpError";
 import { ApplicationContext } from "../types";
 import { logger } from "../util/logger";
@@ -134,29 +134,17 @@ export class SemaphoreService {
 
       logger(`[SEMA] Reloading semaphore service...`);
 
-      await this.reloadZuzaluGroups();
-      // turned off for devconnect - lots of users = slow global group.
-      // await this.reloadGenericGroup();
-      await this.reloadDevconnectGroups();
-      await this.saveHistoricSemaphoreGroups();
+      await sqlTransaction(this.dbPool, (client) =>
+        this.reloadZuzaluGroups(client)
+      );
+      await sqlTransaction(this.dbPool, (client) =>
+        this.reloadDevconnectGroups(client)
+      );
+      await sqlTransaction(this.dbPool, (client) =>
+        this.saveHistoricSemaphoreGroups(client)
+      );
 
       logger(`[SEMA] Semaphore service reloaded.`);
-    });
-  }
-
-  private async reloadGenericGroup(): Promise<void> {
-    return traced("Semaphore", "reloadGenericGroup", async (span) => {
-      const allUsers = await fetchAllUsers(this.dbPool);
-      span?.setAttribute("users", allUsers.length);
-      logger(`[SEMA] Rebuilding groups, ${allUsers.length} total users.`);
-
-      const namedGroup = this.getNamedGroup("5");
-      const newGroup = new Group(
-        namedGroup.group.id,
-        namedGroup.group.depth,
-        allUsers.map((c) => c.commitment)
-      );
-      namedGroup.group = newGroup;
     });
   }
 
@@ -191,13 +179,12 @@ export class SemaphoreService {
    * users with any Devconnect ticket, and organizers, which includes all
    * users with any superuser Devconnect ticket.
    */
-  private async reloadDevconnectGroups(): Promise<void> {
+  private async reloadDevconnectGroups(client: PoolClient): Promise<void> {
     return traced("Semaphore", "reloadDevconnectGroups", async (span) => {
-      const devconnectAttendees = await fetchAllUsersWithDevconnectTickets(
-        this.dbPool
-      );
+      const devconnectAttendees =
+        await fetchAllUsersWithDevconnectTickets(client);
       const devconnectOrganizers =
-        await fetchAllUsersWithDevconnectSuperuserTickets(this.dbPool);
+        await fetchAllUsersWithDevconnectSuperuserTickets(client);
 
       span?.setAttribute("attendees", devconnectAttendees.length);
       span?.setAttribute("organizers", devconnectOrganizers.length);
@@ -276,14 +263,14 @@ export class SemaphoreService {
     });
   }
 
-  private async saveHistoricSemaphoreGroups(): Promise<void> {
+  private async saveHistoricSemaphoreGroups(client: PoolClient): Promise<void> {
     if (!this.dbPool) {
       throw new Error("no database connection");
     }
 
     logger(`[SEMA] Semaphore service - diffing historic semaphore groups`);
 
-    const latestGroups = await fetchLatestHistoricSemaphoreGroups(this.dbPool);
+    const latestGroups = await fetchLatestHistoricSemaphoreGroups(client);
 
     for (const localGroup of this.groups.values()) {
       const correspondingLatestGroup = latestGroups.find(
@@ -300,7 +287,7 @@ export class SemaphoreService {
         );
 
         await insertNewHistoricSemaphoreGroup(
-          this.dbPool,
+          client,
           localGroup.group.id.toString(),
           localGroup.group.root.toString(),
           JSON.stringify(
@@ -316,34 +303,34 @@ export class SemaphoreService {
   }
 
   public async getHistoricSemaphoreGroup(
+    client: PoolClient,
     groupId: string,
     rootHash: string
   ): Promise<HistoricSemaphoreGroup | undefined> {
-    return fetchHistoricGroupByRoot(this.dbPool, groupId, rootHash);
+    return fetchHistoricGroupByRoot(client, groupId, rootHash);
   }
 
   public async getHistoricSemaphoreGroupValid(
+    client: PoolClient,
     groupId: string,
     rootHash: string
   ): Promise<boolean> {
-    const group = await fetchHistoricGroupByRoot(
-      this.dbPool,
-      groupId,
-      rootHash
-    );
+    const group = await fetchHistoricGroupByRoot(client, groupId, rootHash);
     return group !== undefined;
   }
 
-  public async getLatestSemaphoreGroups(): Promise<HistoricSemaphoreGroup[]> {
-    return fetchLatestHistoricSemaphoreGroups(this.dbPool);
+  public async getLatestSemaphoreGroups(
+    client: PoolClient
+  ): Promise<HistoricSemaphoreGroup[]> {
+    return fetchLatestHistoricSemaphoreGroups(client);
   }
 
-  private async reloadZuzaluGroups(): Promise<void> {
+  private async reloadZuzaluGroups(client: PoolClient): Promise<void> {
     return traced("Semaphore", "reloadZuzaluGroups", async (span) => {
       const zuzaluUsers: UserWithZuzaluTickets[] =
-        await fetchAllUsersWithZuzaluTickets(this.dbPool);
+        await fetchAllUsersWithZuzaluTickets(client);
 
-      const zuconnectUsers = await fetchAllLoggedInZuconnectUsers(this.dbPool);
+      const zuconnectUsers = await fetchAllLoggedInZuconnectUsers(client);
       // Give Zuconnect users roles equivalent to Zuzalu roles
       const zuconnectUsersWithZuzaluRoles = zuconnectUsers.flatMap((user) => {
         return user.zuconnectTickets.map((t) => ({

--- a/apps/passport-server/src/services/telegramService.ts
+++ b/apps/passport-server/src/services/telegramService.ts
@@ -39,6 +39,7 @@ import {
   UserFromGetMe
 } from "grammy/types";
 import _ from "lodash";
+import { PoolClient } from "postgres-pool";
 import { v1 as uuidV1 } from "uuid";
 import { AnonMessageWithDetails } from "../database/models";
 import {
@@ -71,6 +72,7 @@ import {
   insertTelegramVerification
 } from "../database/queries/telegram/insertTelegramConversation";
 import { insertTelegramReaction } from "../database/queries/telegram/insertTelegramReaction";
+import { namedSqlTransaction, sqlTransaction } from "../database/sqlQuery";
 import { ApplicationContext } from "../types";
 import { handleFrogVerification } from "../util/frogTelegramHelpers";
 import { logger } from "../util/logger";
@@ -179,10 +181,9 @@ export class TelegramService {
             `[TELEGRAM] Got chat join request for ${chatId} from ${userId}`
           );
           // Check if this user is verified for the chat in question
-          const isVerified = await fetchTelegramVerificationStatus(
+          const isVerified = await sqlTransaction(
             this.context.dbPool,
-            userId,
-            chatId
+            (client) => fetchTelegramVerificationStatus(client, userId, chatId)
           );
 
           if (isVerified) {
@@ -241,34 +242,43 @@ export class TelegramService {
     this.authBot.on("chat_member", async (ctx) => {
       return traced("telegram", "chat_member", async (span) => {
         try {
-          const newMember = ctx.update.chat_member.new_chat_member;
-          span?.setAttribute("userId", newMember.user.id.toString());
-          span?.setAttribute("status", newMember.status);
+          namedSqlTransaction(
+            this.context.dbPool,
+            "chat_member",
+            async (client) => {
+              const newMember = ctx.update.chat_member.new_chat_member;
+              span?.setAttribute("userId", newMember.user.id.toString());
+              span?.setAttribute("status", newMember.status);
 
-          if (newMember.status === "left" || newMember.status === "kicked") {
-            logger(
-              `[TELEGRAM] Deleting verification for user leaving ${
-                newMember.user.username || newMember.user.first_name
-              } in chat ${ctx.chat.id}`
-            );
-            await deleteTelegramVerification(
-              this.context.dbPool,
-              newMember.user.id,
-              ctx.chat.id
-            );
-            const chat = await getGroupChat(ctx.api, ctx.chat.id);
-            span?.setAttribute("chatId", chat.id);
-            span?.setAttribute("chatTitle", chat.title);
+              if (
+                newMember.status === "left" ||
+                newMember.status === "kicked"
+              ) {
+                logger(
+                  `[TELEGRAM] Deleting verification for user leaving ${
+                    newMember.user.username || newMember.user.first_name
+                  } in chat ${ctx.chat.id}`
+                );
+                await deleteTelegramVerification(
+                  client,
+                  newMember.user.id,
+                  ctx.chat.id
+                );
+                const chat = await getGroupChat(ctx.api, ctx.chat.id);
+                span?.setAttribute("chatId", chat.id);
+                span?.setAttribute("chatTitle", chat.title);
 
-            const userId = newMember.user.id;
-            if (!newMember.user.is_bot) {
-              await this.authBot.api.sendMessage(
-                userId,
-                `<i>You left ${chat?.title}. To join again, you must re-verify by typing /start.</i>`,
-                { parse_mode: "HTML" }
-              );
+                const userId = newMember.user.id;
+                if (!newMember.user.is_bot) {
+                  await this.authBot.api.sendMessage(
+                    userId,
+                    `<i>You left ${chat?.title}. To join again, you must re-verify by typing /start.</i>`,
+                    { parse_mode: "HTML" }
+                  );
+                }
+              }
             }
-          }
+          );
         } catch (e) {
           logger("[TELEGRAM] chat_member error", e);
           this.rollbarService?.reportError(e);
@@ -291,11 +301,15 @@ export class TelegramService {
             const name = firstName || username;
             ctx.session.directLinkMode = false;
             if (ctx.match && Number.isInteger(Number(ctx.match))) {
-              const [chatWithMembership] = await getChatsWithMembershipStatus(
+              const [chatWithMembership] = await sqlTransaction(
                 ctx.session.dbPool,
-                ctx,
-                userId,
-                Number(ctx.match)
+                (client) =>
+                  getChatsWithMembershipStatus(
+                    client,
+                    ctx,
+                    userId,
+                    Number(ctx.match)
+                  )
               );
               if (chatWithMembership) {
                 ctx.session.chatToJoin = chatWithMembership;
@@ -440,9 +454,8 @@ export class TelegramService {
         userId,
         `Loading tickets and events...`
       );
-      const events = await fetchEventsWithTelegramChats(
-        this.context.dbPool,
-        false
+      const events = await sqlTransaction(ctx.session.dbPool, (client) =>
+        fetchEventsWithTelegramChats(client, false)
       );
       const eventsWithChats = await chatIDsToChats(ctx, events);
 
@@ -486,63 +499,75 @@ export class TelegramService {
 
     this.authBot.on(":forum_topic_created", async (ctx) => {
       return traced("telegram", "forum_topic_created", async (span) => {
-        const topicName = ctx.update?.message?.forum_topic_created.name;
-        const messageThreadId = ctx.update.message?.message_thread_id;
-        const chatId = ctx.chat.id;
-        span?.setAttributes({ topicName, messageThreadId, chatId });
-
-        if (!chatId || !topicName)
-          throw new Error(`Missing chatId or topic name`);
-
-        await insertTelegramChat(this.context.dbPool, chatId);
-        await insertTelegramTopic(
+        await namedSqlTransaction(
           this.context.dbPool,
-          chatId,
-          topicName,
-          messageThreadId,
-          false
-        );
+          "forum_topic_created",
+          async (client) => {
+            const topicName = ctx.update?.message?.forum_topic_created.name;
+            const messageThreadId = ctx.update.message?.message_thread_id;
+            const chatId = ctx.chat.id;
+            span?.setAttributes({ topicName, messageThreadId, chatId });
 
-        logger(`[TELEGRAM CREATED]`, topicName, messageThreadId, chatId);
+            if (!chatId || !topicName)
+              throw new Error(`Missing chatId or topic name`);
+
+            await insertTelegramChat(client, chatId);
+            await insertTelegramTopic(
+              client,
+              chatId,
+              topicName,
+              messageThreadId,
+              false
+            );
+
+            logger(`[TELEGRAM CREATED]`, topicName, messageThreadId, chatId);
+          }
+        );
       });
     });
 
     this.authBot.on(":forum_topic_edited", async (ctx) => {
       return traced("telegram", "forum_topic_edited", async (span) => {
-        const topicName = ctx.update?.message?.forum_topic_edited.name;
-        const chatId = ctx.chat.id;
-        const messageThreadId = ctx.update.message?.message_thread_id;
-        span?.setAttributes({ topicName, messageThreadId, chatId });
-
-        if (!chatId || !topicName)
-          throw new Error(`Missing chatId or topic name`);
-
-        const topic = await fetchTelegramTopic(
+        await namedSqlTransaction(
           this.context.dbPool,
-          chatId,
-          messageThreadId
-        );
+          "forum_topic_edited",
+          async (client) => {
+            const topicName = ctx.update?.message?.forum_topic_edited.name;
+            const chatId = ctx.chat.id;
+            const messageThreadId = ctx.update.message?.message_thread_id;
+            span?.setAttributes({ topicName, messageThreadId, chatId });
 
-        if (!topic) {
-          logger(`[TELEGRAM] adding topic ${topicName} to db`);
-          await insertTelegramChat(this.context.dbPool, chatId);
-          await insertTelegramTopic(
-            this.context.dbPool,
-            chatId,
-            topicName,
-            messageThreadId,
-            false
-          );
-        } else {
-          logger(`[TELEGRAM] updating topic ${topicName} in db`);
-          await insertTelegramTopic(
-            this.context.dbPool,
-            topic.telegramChatID,
-            topicName,
-            topic.topic_id,
-            topic.is_anon_topic
-          );
-        }
+            if (!chatId || !topicName)
+              throw new Error(`Missing chatId or topic name`);
+
+            const topic = await fetchTelegramTopic(
+              client,
+              chatId,
+              messageThreadId
+            );
+
+            if (!topic) {
+              logger(`[TELEGRAM] adding topic ${topicName} to db`);
+              await insertTelegramChat(client, chatId);
+              await insertTelegramTopic(
+                client,
+                chatId,
+                topicName,
+                messageThreadId,
+                false
+              );
+            } else {
+              logger(`[TELEGRAM] updating topic ${topicName} in db`);
+              await insertTelegramTopic(
+                client,
+                topic.telegramChatID,
+                topicName,
+                topic.topic_id,
+                topic.is_anon_topic
+              );
+            }
+          }
+        );
       });
     });
 
@@ -571,80 +596,86 @@ export class TelegramService {
         });
 
       try {
-        const telegramEvents = await fetchTelegramEventsByChatId(
-          this.context.dbPool,
-          ctx.chat.id
-        );
+        await namedSqlTransaction(
+          ctx.session.dbPool,
+          "incognito",
+          async (client) => {
+            const telegramEvents = await fetchTelegramEventsByChatId(
+              client,
+              ctx.chat.id
+            );
 
-        const hasLinked = telegramEvents.length > 0;
-        if (!hasLinked) {
-          await ctx.reply(
-            "This group is not linked to an event. If you're an admin, use /manage to link this group to an event.",
-            { message_thread_id: messageThreadId }
-          );
-          return;
-        }
+            const hasLinked = telegramEvents.length > 0;
+            if (!hasLinked) {
+              await ctx.reply(
+                "This group is not linked to an event. If you're an admin, use /manage to link this group to an event.",
+                { message_thread_id: messageThreadId }
+              );
+              return;
+            }
 
-        const topicToUpdate = await fetchTelegramTopic(
-          this.context.dbPool,
-          ctx.chat.id,
-          messageThreadId
-        );
+            const topicToUpdate = await fetchTelegramTopic(
+              client,
+              ctx.chat.id,
+              messageThreadId
+            );
 
-        if (!topicToUpdate)
-          throw new Error(`Couldn't find this topic in the db.`);
+            if (!topicToUpdate)
+              throw new Error(`Couldn't find this topic in the db.`);
 
-        if (topicToUpdate.is_anon_topic) {
-          await ctx.reply(`This topic is already anonymous.`, {
-            message_thread_id: messageThreadId
-          });
-          return;
-        }
+            if (topicToUpdate.is_anon_topic) {
+              await ctx.reply(`This topic is already anonymous.`, {
+                message_thread_id: messageThreadId
+              });
+              return;
+            }
 
-        const topicName =
-          topicToUpdate?.topic_name ||
-          ctx.message?.reply_to_message?.forum_topic_created?.name;
-        if (!topicName) throw new Error(`No topic name found`);
+            const topicName =
+              topicToUpdate?.topic_name ||
+              ctx.message?.reply_to_message?.forum_topic_created?.name;
+            if (!topicName) throw new Error(`No topic name found`);
 
-        await insertTelegramTopic(
-          this.context.dbPool,
-          ctx.chat.id,
-          topicName,
-          messageThreadId,
-          true
-        );
+            await insertTelegramTopic(
+              client,
+              ctx.chat.id,
+              topicName,
+              messageThreadId,
+              true
+            );
 
-        await ctx.reply(
-          `Linked with topic name <b>${topicName}</b>.\nIf this name is incorrect, edit this topic name to update`,
-          {
-            message_thread_id: messageThreadId,
-            parse_mode: "HTML"
+            await ctx.reply(
+              `Linked with topic name <b>${topicName}</b>.\nIf this name is incorrect, edit this topic name to update`,
+              {
+                message_thread_id: messageThreadId,
+                parse_mode: "HTML"
+              }
+            );
+
+            const directLinkParams: RedirectTopicDataPayload = {
+              type: PayloadType.RedirectTopicData,
+              value: {
+                topicId: messageThreadId,
+                chatId: ctx.chat.id
+              }
+            };
+
+            const encodedPayload = Buffer.from(
+              JSON.stringify(directLinkParams),
+              "utf-8"
+            ).toString("base64");
+
+            const messageToPin = await ctx.reply("Click to post", {
+              message_thread_id: messageThreadId,
+              reply_markup: new InlineKeyboard().url(
+                "Post Anonymously",
+                // NOTE: The order and casing of the direct link params is VERY IMPORTANT. https://github.com/TelegramMessenger/Telegram-iOS/issues/1091
+                `${process.env.TELEGRAM_ANON_BOT_DIRECT_LINK}?startApp=${encodedPayload}&startapp=${encodedPayload}`
+              )
+            });
+            ctx.pinChatMessage(messageToPin.message_id);
+            ctx.api.closeForumTopic(ctx.chat.id, messageThreadId);
           }
         );
-
-        const directLinkParams: RedirectTopicDataPayload = {
-          type: PayloadType.RedirectTopicData,
-          value: {
-            topicId: messageThreadId,
-            chatId: ctx.chat.id
-          }
-        };
-
-        const encodedPayload = Buffer.from(
-          JSON.stringify(directLinkParams),
-          "utf-8"
-        ).toString("base64");
-
-        const messageToPin = await ctx.reply("Click to post", {
-          message_thread_id: messageThreadId,
-          reply_markup: new InlineKeyboard().url(
-            "Post Anonymously",
-            // NOTE: The order and casing of the direct link params is VERY IMPORTANT. https://github.com/TelegramMessenger/Telegram-iOS/issues/1091
-            `${process.env.TELEGRAM_ANON_BOT_DIRECT_LINK}?startApp=${encodedPayload}&startapp=${encodedPayload}`
-          )
-        });
-        ctx.pinChatMessage(messageToPin.message_id);
-        ctx.api.closeForumTopic(ctx.chat.id, messageThreadId);
       } catch (error) {
         logger(`[ERROR] ${error}`);
         await ctx.reply(`Failed to link anonymous chat. ${error} `, {
@@ -677,94 +708,109 @@ export class TelegramService {
 
     if (this.forwardBot) {
       this.forwardBot.command("receive", async (ctx) => {
-        const messageThreadId = ctx.message?.message_thread_id;
-        try {
-          logger(`[TELEGRAM] running receive`);
-          if (isDirectMessage(ctx))
-            return ctx.reply(`/receive can only be run in a group chat`);
+        await namedSqlTransaction(
+          ctx.session.dbPool,
+          "receive",
+          async (client) => {
+            const messageThreadId = ctx.message?.message_thread_id;
+            try {
+              logger(`[TELEGRAM] running receive`);
+              if (isDirectMessage(ctx))
+                return ctx.reply(`/receive can only be run in a group chat`);
 
-          if (!ctx.from?.username)
-            return ctx.reply(`No username found`, {
-              reply_to_message_id: messageThreadId
-            });
+              if (!ctx.from?.username)
+                return ctx.reply(`No username found`, {
+                  reply_to_message_id: messageThreadId
+                });
 
-          if (!ALLOWED_TICKET_MANAGERS.includes(ctx.from.username))
-            return ctx.reply(
-              `Only Zupass team members are allowed to run this command.`,
-              { reply_to_message_id: messageThreadId }
-            );
+              if (!ALLOWED_TICKET_MANAGERS.includes(ctx.from.username))
+                return ctx.reply(
+                  `Only Zupass team members are allowed to run this command.`,
+                  { reply_to_message_id: messageThreadId }
+                );
 
-          // Look up topic.
-          const topic = await fetchTelegramTopic(
-            this.context.dbPool,
-            ctx.chat.id,
-            messageThreadId
-          );
+              // Look up topic.
+              const topic = await fetchTelegramTopic(
+                client,
+                ctx.chat.id,
+                messageThreadId
+              );
 
-          if (!topic)
-            throw new Error(
-              `No topic found. Edit the topic name and try again!`
-            );
+              if (!topic)
+                throw new Error(
+                  `No topic found. Edit the topic name and try again!`
+                );
 
-          await insertTelegramForward(this.context.dbPool, null, topic.id);
-          logger(`[TELEGRAM] ${topic.topic_name} can receive messages`);
-          await ctx.reply(`<b>${topic.topic_name}</b> can receive messages`, {
-            reply_to_message_id: messageThreadId,
-            parse_mode: "HTML"
-          });
-        } catch (error) {
-          ctx.reply(`${error}`, {
-            reply_to_message_id: messageThreadId
-          });
-        }
+              await insertTelegramForward(client, null, topic.id);
+              logger(`[TELEGRAM] ${topic.topic_name} can receive messages`);
+              await ctx.reply(
+                `<b>${topic.topic_name}</b> can receive messages`,
+                {
+                  reply_to_message_id: messageThreadId,
+                  parse_mode: "HTML"
+                }
+              );
+            } catch (error) {
+              ctx.reply(`${error}`, {
+                reply_to_message_id: messageThreadId
+              });
+            }
+          }
+        );
       });
 
       this.forwardBot.command("stopreceive", async (ctx) => {
-        const messageThreadId = ctx.message?.message_thread_id;
-        try {
-          logger(`[TELEGRAM] running receive`);
-          if (isDirectMessage(ctx))
-            return ctx.reply(`/receive can only be run in a group chat`);
+        await namedSqlTransaction(
+          ctx.session.dbPool,
+          "stopreceive",
+          async (client) => {
+            const messageThreadId = ctx.message?.message_thread_id;
+            try {
+              logger(`[TELEGRAM] running receive`);
+              if (isDirectMessage(ctx))
+                return ctx.reply(`/receive can only be run in a group chat`);
 
-          if (!ctx.from?.username)
-            return ctx.reply(`No username found`, {
-              reply_to_message_id: messageThreadId
-            });
+              if (!ctx.from?.username)
+                return ctx.reply(`No username found`, {
+                  reply_to_message_id: messageThreadId
+                });
 
-          if (!ALLOWED_TICKET_MANAGERS.includes(ctx.from.username))
-            return ctx.reply(
-              `Only Zupass team members are allowed to run this command.`,
-              { reply_to_message_id: messageThreadId }
-            );
+              if (!ALLOWED_TICKET_MANAGERS.includes(ctx.from.username))
+                return ctx.reply(
+                  `Only Zupass team members are allowed to run this command.`,
+                  { reply_to_message_id: messageThreadId }
+                );
 
-          // Look up topic.
-          const topic = await fetchTelegramTopic(
-            this.context.dbPool,
-            ctx.chat.id,
-            messageThreadId
-          );
+              // Look up topic.
+              const topic = await fetchTelegramTopic(
+                client,
+                ctx.chat.id,
+                messageThreadId
+              );
 
-          if (!topic)
-            throw new Error(
-              `No topic found. Edit the topic name and try again!`
-            );
+              if (!topic)
+                throw new Error(
+                  `No topic found. Edit the topic name and try again!`
+                );
 
-          await deleteTelegramForward(this.context.dbPool, topic.id, null);
-          logger(
-            `[TELEGRAM] ${topic.topic_name} can no longer receive messages`
-          );
-          await ctx.reply(
-            `<b>${topic.topic_name}</b> can no longer receive messages`,
-            {
-              reply_to_message_id: messageThreadId,
-              parse_mode: "HTML"
+              await deleteTelegramForward(client, topic.id, null);
+              logger(
+                `[TELEGRAM] ${topic.topic_name} can no longer receive messages`
+              );
+              await ctx.reply(
+                `<b>${topic.topic_name}</b> can no longer receive messages`,
+                {
+                  reply_to_message_id: messageThreadId,
+                  parse_mode: "HTML"
+                }
+              );
+            } catch (error) {
+              ctx.reply(`${error}`, {
+                reply_to_message_id: messageThreadId
+              });
             }
-          );
-        } catch (error) {
-          ctx.reply(`${error}`, {
-            reply_to_message_id: messageThreadId
-          });
-        }
+          }
+        );
       });
 
       this.forwardBot.command("forward", async (ctx) => {
@@ -792,82 +838,96 @@ export class TelegramService {
 
       this.forwardBot.on(":forum_topic_edited", async (ctx) => {
         return traced("telegram", "forum_topic_edited", async (span) => {
-          const topicName = ctx.update?.message?.forum_topic_edited.name;
-          const chatId = ctx.chat.id;
-          const messageThreadId = ctx.update.message?.message_thread_id;
-          span?.setAttributes({ topicName, messageThreadId, chatId });
+          await namedSqlTransaction(
+            ctx.session.dbPool,
+            "forum_topic_edited",
+            async (client) => {
+              const topicName = ctx.update?.message?.forum_topic_edited.name;
+              const chatId = ctx.chat.id;
+              const messageThreadId = ctx.update.message?.message_thread_id;
+              span?.setAttributes({ topicName, messageThreadId, chatId });
 
-          if (!chatId || !topicName)
-            throw new Error(`Missing chatId or topic name`);
+              if (!chatId || !topicName)
+                throw new Error(`Missing chatId or topic name`);
 
-          const topic = await fetchTelegramTopic(
-            this.context.dbPool,
-            chatId,
-            messageThreadId
+              const topic = await fetchTelegramTopic(
+                client,
+                chatId,
+                messageThreadId
+              );
+
+              if (!topic) {
+                logger(`[TELEGRAM] adding topic ${topicName} to db`);
+                await insertTelegramChat(client, chatId);
+                await insertTelegramTopic(
+                  client,
+                  chatId,
+                  topicName,
+                  messageThreadId,
+                  false
+                );
+              } else {
+                logger(`[TELEGRAM] updating topic ${topicName} in db`);
+                await insertTelegramTopic(
+                  client,
+                  topic.telegramChatID,
+                  topicName,
+                  topic.topic_id,
+                  topic.is_anon_topic
+                );
+              }
+            }
           );
-
-          if (!topic) {
-            logger(`[TELEGRAM] adding topic ${topicName} to db`);
-            await insertTelegramChat(this.context.dbPool, chatId);
-            await insertTelegramTopic(
-              this.context.dbPool,
-              chatId,
-              topicName,
-              messageThreadId,
-              false
-            );
-          } else {
-            logger(`[TELEGRAM] updating topic ${topicName} in db`);
-            await insertTelegramTopic(
-              this.context.dbPool,
-              topic.telegramChatID,
-              topicName,
-              topic.topic_id,
-              topic.is_anon_topic
-            );
-          }
         });
       });
 
       this.forwardBot.on("message", async (ctx) => {
-        const text = ctx.message.text;
+        await namedSqlTransaction(
+          ctx.session.dbPool,
+          "message",
+          async (client) => {
+            const text = ctx.message.text;
 
-        if (isDirectMessage(ctx)) {
-          return await ctx.reply(`I can only forward messages in a group chat`);
-        } else {
-          const messageThreadId = ctx.message?.message_thread_id;
+            if (isDirectMessage(ctx)) {
+              return await ctx.reply(
+                `I can only forward messages in a group chat`
+              );
+            } else {
+              const messageThreadId = ctx.message?.message_thread_id;
 
-          try {
-            // Check to see if message is from a topic in the forwarding table
-            const forwardResults = await fetchTelegramTopicForwarding(
-              this.context.dbPool,
-              ctx.chat.id,
-              messageThreadId
-            );
-
-            if (forwardResults?.length > 0) {
-              const sentMessages = forwardResults.map((f) => {
-                const destinationTopicID = f.receiverTopicID
-                  ? parseInt(f.receiverTopicID)
-                  : undefined;
-                logger(
-                  `[TElEGRAM] forwarding message ${text} to ${f.receiverTopicName}`
+              try {
+                // Check to see if message is from a topic in the forwarding table
+                const forwardResults = await fetchTelegramTopicForwarding(
+                  client,
+                  ctx.chat.id,
+                  messageThreadId
                 );
-                return ctx.api.forwardMessage(
-                  f.receiverChatID,
-                  f.senderChatID,
-                  ctx.message.message_id,
-                  {
-                    message_thread_id: destinationTopicID
-                  }
-                );
-              });
-              await Promise.allSettled(sentMessages);
+
+                if (forwardResults?.length > 0) {
+                  const sentMessages = forwardResults.map((f) => {
+                    const destinationTopicID = f.receiverTopicID
+                      ? parseInt(f.receiverTopicID)
+                      : undefined;
+                    logger(
+                      `[TElEGRAM] forwarding message ${text} to ${f.receiverTopicName}`
+                    );
+                    return ctx.api.forwardMessage(
+                      f.receiverChatID,
+                      f.senderChatID,
+                      ctx.message.message_id,
+                      {
+                        message_thread_id: destinationTopicID
+                      }
+                    );
+                  });
+                  await Promise.allSettled(sentMessages);
+                }
+              } catch (error) {
+                ctx.reply(`${error}`, { reply_to_message_id: messageThreadId });
+              }
             }
-          } catch (error) {
-            ctx.reply(`${error}`, { reply_to_message_id: messageThreadId });
           }
-        }
+        );
       });
     }
 
@@ -1018,6 +1078,7 @@ export class TelegramService {
   }
 
   private async sendToAnonymousChannel(
+    client: PoolClient,
     chatId: number,
     topicId: number,
     message: string,
@@ -1047,7 +1108,7 @@ export class TelegramService {
             logger(
               `[TELEGRAM] topic has been deleted from Telegram, removing from db...`
             );
-            await deleteTelegramChatTopic(this.context.dbPool, chatId, topicId);
+            await deleteTelegramChatTopic(client, chatId, topicId);
             throw new Error(`Topic has been deleted. Choose a different one!`);
           } else {
             throw new Error(error);
@@ -1094,6 +1155,7 @@ export class TelegramService {
    * This is called from the /telegram/verify route.
    */
   public async handleVerification(
+    client: PoolClient,
     serializedPCD: string,
     telegramUserId: number,
     telegramChatId: string,
@@ -1107,6 +1169,7 @@ export class TelegramService {
       const parsed = JSON.parse(serializedPCD) as SerializedPCD;
       if (parsed.type === ZKEdDSAEventTicketPCDTypeName) {
         await this.handleTicketVerification(
+          client,
           serializedPCD,
           telegramUserId,
           chat.id,
@@ -1114,7 +1177,7 @@ export class TelegramService {
         );
       } else if (parsed.type === ZKEdDSAFrogPCDTypeName) {
         await handleFrogVerification(
-          this.context.dbPool,
+          client,
           serializedPCD,
           telegramUserId,
           chat.id,
@@ -1135,6 +1198,7 @@ export class TelegramService {
    * for later approval when they request to join.
    */
   public async handleTicketVerification(
+    client: PoolClient,
     serializedZKEdDSATicket: string,
     telegramUserId: number,
     telegramChatId: number,
@@ -1182,7 +1246,7 @@ export class TelegramService {
       span?.setAttribute("validEventIds", validEventIds);
 
       const eventsByChat = await fetchTelegramEventsByChatId(
-        this.context.dbPool,
+        client,
         telegramChatId
       );
       if (eventsByChat.length === 0)
@@ -1199,7 +1263,7 @@ export class TelegramService {
       // We've verified that the chat exists, now add the user to our list.
       // This will be important later when the user requests to join.
       await insertTelegramVerification(
-        this.context.dbPool,
+        client,
         telegramUserId,
         telegramChatId,
         attendeeSemaphoreId,
@@ -1209,20 +1273,21 @@ export class TelegramService {
   }
 
   public async handleRequestReactProofLink(
+    client: PoolClient,
     anonPayload: ReactDataPayload
   ): Promise<string> {
     const react = decodeURIComponent(anonPayload.react);
     logger(`[TELEGRAM] got react`, react);
     logger(`[TELEGRAM] payoad id`, anonPayload.anonMessageId);
     const message = await fetchTelegramAnonMessagesById(
-      this.context.dbPool,
+      client,
       anonPayload.anonMessageId
     );
     if (!message) throw new Error(`Message to react to not found`);
 
     // Get valid event Ids
     const events = await fetchTelegramEventsByChatId(
-      this.context.dbPool,
+      client,
       message.telegram_chat_id
     );
     if (events.length === 0)
@@ -1241,6 +1306,7 @@ export class TelegramService {
   }
 
   public async handleReactAnonymousMessage(
+    client: PoolClient,
     serializedZKEdDSATicket: string,
     telegramChatId: string,
     anonMessageId: string,
@@ -1274,7 +1340,7 @@ export class TelegramService {
       span?.setAttribute("externalNullifier", externalNullifier);
 
       const eventsByChat = await fetchTelegramEventsByChatId(
-        this.context.dbPool,
+        client,
         telegramChatId
       );
       if (eventsByChat.length === 0)
@@ -1306,7 +1372,7 @@ export class TelegramService {
       }
 
       const anonMessage = await fetchTelegramAnonMessagesById(
-        this.context.dbPool,
+        client,
         anonMessageId
       );
       if (!anonMessage) {
@@ -1326,7 +1392,7 @@ export class TelegramService {
 
       try {
         await insertTelegramReaction(
-          this.context.dbPool,
+          client,
           serializedZKEdDSATicket,
           anonMessageId,
           reaction,
@@ -1348,7 +1414,7 @@ export class TelegramService {
       }
 
       const reactionsForMessage = await fetchTelegramReactionsForMessage(
-        this.context.dbPool,
+        client,
         anonMessageId
       );
 
@@ -1375,7 +1441,7 @@ export class TelegramService {
       });
 
       const message = await fetchTelegramAnonMessagesById(
-        this.context.dbPool,
+        client,
         anonMessageId
       );
       if (!message) throw new Error(`Message to react to not found`);
@@ -1395,134 +1461,140 @@ export class TelegramService {
     topicId: string
   ): Promise<void> {
     return traced("telegram", "handleSendAnonymousMessage", async (span) => {
-      span?.setAttribute("topicId", topicId);
-      span?.setAttribute("message", rawMessage);
-
-      logger("[TELEGRAM] Verifying anonymous message");
-
-      const pcd = await this.verifyZKEdDSAEventTicketPCD(
-        serializedZKEdDSATicket
-      );
-
-      if (!pcd) {
-        throw new Error("Could not verify PCD for anonymous message");
-      }
-
-      const { watermark, validEventIds, externalNullifier, nullifierHash } =
-        pcd.claim;
-
-      if (!validEventIds) {
-        throw new Error(`User did not submit any valid event ids`);
-      }
-
-      const eventsByChat = await fetchTelegramEventsByChatId(
+      return namedSqlTransaction(
         this.context.dbPool,
-        telegramChatId
-      );
-      if (eventsByChat.length === 0)
-        throw new Error(`No valid events found for given chat`);
-      if (!verifyUserEventIds(eventsByChat, validEventIds)) {
-        throw new Error(`User submitted event Ids are invalid `);
-      }
+        "handleSendAnonymousMessage",
+        async (client) => {
+          span?.setAttribute("topicId", topicId);
+          span?.setAttribute("message", rawMessage);
 
-      span?.setAttribute("chatId", telegramChatId);
+          logger("[TELEGRAM] Verifying anonymous message");
 
-      if (!watermark) {
-        throw new Error("Anonymous message PCD did not contain watermark");
-      }
-
-      if (getMessageWatermark(rawMessage).toString() !== watermark.toString()) {
-        throw new Error(
-          `Anonymous message string ${rawMessage} didn't match watermark. got ${watermark} and expected ${getMessageWatermark(
-            rawMessage
-          ).toString()}`
-        );
-      }
-
-      logger(
-        `[TELEGRAM] Verified PCD for anonynmous message with events ${validEventIds}`
-      );
-
-      const topic = await fetchTelegramTopic(
-        this.context.dbPool,
-        parseInt(telegramChatId),
-        parseInt(topicId)
-      );
-
-      if (!topic || !topic.is_anon_topic || !topic.topic_id) {
-        throw new Error(`this group doesn't have any anon topics`);
-      }
-
-      // The event is linked to a chat. Make sure we can access it.
-      const chat = await getGroupChat(this.anonBot.api, telegramChatId);
-      span?.setAttribute("chatTitle", chat.title);
-
-      if (!nullifierHash) throw new Error(`Nullifier hash not found`);
-
-      const expectedExternalNullifier = getAnonTopicNullifier().toString();
-
-      if (externalNullifier !== expectedExternalNullifier)
-        throw new Error("Nullifier mismatch - try proving again.");
-
-      const nullifierData = await fetchAnonTopicNullifier(
-        this.context.dbPool,
-        nullifierHash,
-        topic.id
-      );
-
-      const currentTime = new Date();
-      const timestamp = currentTime.toISOString();
-
-      if (!nullifierData) {
-        await insertOrUpdateTelegramNullifier(
-          this.context.dbPool,
-          nullifierHash,
-          [timestamp],
-          topic.id
-        );
-      } else {
-        const timestamps = nullifierData.message_timestamps.map((t) =>
-          new Date(t).getTime()
-        );
-        const maxDailyPostsPerTopic = parseInt(
-          process.env.MAX_DAILY_ANON_TOPIC_POSTS_PER_USER ?? "3"
-        );
-        const rlDuration = ONE_HOUR_MS * 24;
-        const { rateLimitExceeded, newTimestamps } =
-          checkSlidingWindowRateLimit(
-            timestamps,
-            maxDailyPostsPerTopic,
-            rlDuration
+          const pcd = await this.verifyZKEdDSAEventTicketPCD(
+            serializedZKEdDSATicket
           );
-        span?.setAttribute("rateLimitExceeded", rateLimitExceeded);
 
-        if (!rateLimitExceeded) {
-          await insertOrUpdateTelegramNullifier(
-            this.context.dbPool,
+          if (!pcd) {
+            throw new Error("Could not verify PCD for anonymous message");
+          }
+
+          const { watermark, validEventIds, externalNullifier, nullifierHash } =
+            pcd.claim;
+
+          if (!validEventIds) {
+            throw new Error(`User did not submit any valid event ids`);
+          }
+
+          const eventsByChat = await fetchTelegramEventsByChatId(
+            client,
+            telegramChatId
+          );
+          if (eventsByChat.length === 0)
+            throw new Error(`No valid events found for given chat`);
+          if (!verifyUserEventIds(eventsByChat, validEventIds)) {
+            throw new Error(`User submitted event Ids are invalid `);
+          }
+
+          span?.setAttribute("chatId", telegramChatId);
+
+          if (!watermark) {
+            throw new Error("Anonymous message PCD did not contain watermark");
+          }
+
+          if (
+            getMessageWatermark(rawMessage).toString() !== watermark.toString()
+          ) {
+            throw new Error(
+              `Anonymous message string ${rawMessage} didn't match watermark. got ${watermark} and expected ${getMessageWatermark(
+                rawMessage
+              ).toString()}`
+            );
+          }
+
+          logger(
+            `[TELEGRAM] Verified PCD for anonynmous message with events ${validEventIds}`
+          );
+
+          const topic = await fetchTelegramTopic(
+            client,
+            parseInt(telegramChatId),
+            parseInt(topicId)
+          );
+
+          if (!topic || !topic.is_anon_topic || !topic.topic_id) {
+            throw new Error(`this group doesn't have any anon topics`);
+          }
+
+          // The event is linked to a chat. Make sure we can access it.
+          const chat = await getGroupChat(this.anonBot.api, telegramChatId);
+          span?.setAttribute("chatTitle", chat.title);
+
+          if (!nullifierHash) throw new Error(`Nullifier hash not found`);
+
+          const expectedExternalNullifier = getAnonTopicNullifier().toString();
+
+          if (externalNullifier !== expectedExternalNullifier)
+            throw new Error("Nullifier mismatch - try proving again.");
+
+          const nullifierData = await fetchAnonTopicNullifier(
+            client,
             nullifierHash,
-            newTimestamps,
             topic.id
           );
-        } else {
-          const rlError = new Error(
-            `You have exceeded the daily limit of ${maxDailyPostsPerTopic} messages for this topic.`
-          );
-          rlError.name = "Rate limit exceeded";
-          throw rlError;
-        }
-      }
 
-      const payloadData: NullifierHashPayload = {
-        type: PayloadType.NullifierHash,
-        value: BigInt(nullifierHash).toString()
-      };
+          const currentTime = new Date();
+          const timestamp = currentTime.toISOString();
 
-      const encodedPayload = Buffer.from(
-        JSON.stringify(payloadData),
-        "utf-8"
-      ).toString("base64");
+          if (!nullifierData) {
+            await insertOrUpdateTelegramNullifier(
+              client,
+              nullifierHash,
+              [timestamp],
+              topic.id
+            );
+          } else {
+            const timestamps = nullifierData.message_timestamps.map((t) =>
+              new Date(t).getTime()
+            );
+            const maxDailyPostsPerTopic = parseInt(
+              process.env.MAX_DAILY_ANON_TOPIC_POSTS_PER_USER ?? "3"
+            );
+            const rlDuration = ONE_HOUR_MS * 24;
+            const { rateLimitExceeded, newTimestamps } =
+              checkSlidingWindowRateLimit(
+                timestamps,
+                maxDailyPostsPerTopic,
+                rlDuration
+              );
+            span?.setAttribute("rateLimitExceeded", rateLimitExceeded);
 
-      const formattedMessage = `
+            if (!rateLimitExceeded) {
+              await insertOrUpdateTelegramNullifier(
+                client,
+                nullifierHash,
+                newTimestamps,
+                topic.id
+              );
+            } else {
+              const rlError = new Error(
+                `You have exceeded the daily limit of ${maxDailyPostsPerTopic} messages for this topic.`
+              );
+              rlError.name = "Rate limit exceeded";
+              throw rlError;
+            }
+          }
+
+          const payloadData: NullifierHashPayload = {
+            type: PayloadType.NullifierHash,
+            value: BigInt(nullifierHash).toString()
+          };
+
+          const encodedPayload = Buffer.from(
+            JSON.stringify(payloadData),
+            "utf-8"
+          ).toString("base64");
+
+          const formattedMessage = `
       <b>${bigIntToPseudonymEmoji(BigInt(nullifierHash))} <u><a href="${
         process.env.TELEGRAM_ANON_BOT_DIRECT_LINK
       }?startApp=${encodedPayload}&startapp=${encodedPayload}">${bigIntToPseudonymName(
@@ -1531,40 +1603,45 @@ export class TelegramService {
         "en-GB"
       )}</i>\n----------------------------------------------------------`;
 
-      const anonMessageId = uuidV1();
+          const anonMessageId = uuidV1();
 
-      const payloads = getDisplayEmojis().map((emoji) => {
-        return {
-          emoji,
-          payload: encodePayload(buildReactPayload(emoji, anonMessageId))
-        };
-      });
-      const link = process.env.TELEGRAM_ANON_BOT_DIRECT_LINK;
-      const buttons: InlineKeyboardButton[] = payloads.map((p) => {
-        return {
-          text: `${p.emoji}`,
-          url: `${link}?startApp=${p.payload}&startapp=${p.payload}`
-        };
-      });
+          const payloads = getDisplayEmojis().map((emoji) => {
+            return {
+              emoji,
+              payload: encodePayload(buildReactPayload(emoji, anonMessageId))
+            };
+          });
+          const link = process.env.TELEGRAM_ANON_BOT_DIRECT_LINK;
+          const buttons: InlineKeyboardButton[] = payloads.map((p) => {
+            return {
+              text: `${p.emoji}`,
+              url: `${link}?startApp=${p.payload}&startapp=${p.payload}`
+            };
+          });
 
-      const replyMarkup: InlineKeyboardMarkup = { inline_keyboard: [buttons] };
-      const message = await this.sendToAnonymousChannel(
-        chat.id,
-        parseInt(topic.topic_id),
-        formattedMessage,
-        replyMarkup
-      );
-      if (!message) throw new Error(`Failed to send telegram message`);
+          const replyMarkup: InlineKeyboardMarkup = {
+            inline_keyboard: [buttons]
+          };
+          const message = await this.sendToAnonymousChannel(
+            client,
+            chat.id,
+            parseInt(topic.topic_id),
+            formattedMessage,
+            replyMarkup
+          );
+          if (!message) throw new Error(`Failed to send telegram message`);
 
-      await insertTelegramAnonMessage(
-        this.context.dbPool,
-        anonMessageId,
-        nullifierHash,
-        topic.id,
-        rawMessage,
-        serializedZKEdDSATicket,
-        timestamp,
-        message.message_id
+          await insertTelegramAnonMessage(
+            client,
+            anonMessageId,
+            nullifierHash,
+            topic.id,
+            rawMessage,
+            serializedZKEdDSATicket,
+            timestamp,
+            message.message_id
+          );
+        }
       );
     });
   }
@@ -1577,51 +1654,60 @@ export class TelegramService {
       "telegram",
       "handleRequestAnonymousMessageLink",
       async (span) => {
-        // Confirm that topicId exists and is anonymous
-        const topic = await fetchTelegramTopic(
+        return namedSqlTransaction(
           this.context.dbPool,
-          telegramChatId,
-          topicId
-        );
+          "handleRequestAnonymousMessageLink",
+          async (client) => {
+            // Confirm that topicId exists and is anonymous
+            const topic = await fetchTelegramTopic(
+              client,
+              telegramChatId,
+              topicId
+            );
 
-        if (!topic || !topic.is_anon_topic || !topic.topic_id)
-          throw new Error(`No anonymous topic found`);
+            if (!topic || !topic.is_anon_topic || !topic.topic_id)
+              throw new Error(`No anonymous topic found`);
 
-        // Get valid eventIds for this chat
-        const telegramEvents = await fetchTelegramEventsByChatId(
-          this.context.dbPool,
-          telegramChatId
-        );
-        if (telegramEvents.length === 0)
-          throw new Error(`No events associated with this group`);
+            // Get valid eventIds for this chat
+            const telegramEvents = await fetchTelegramEventsByChatId(
+              client,
+              telegramChatId
+            );
+            if (telegramEvents.length === 0)
+              throw new Error(`No events associated with this group`);
 
-        const validEventIds = telegramEvents.map((e) => e.ticket_event_id);
+            const validEventIds = telegramEvents.map((e) => e.ticket_event_id);
 
-        const encodedTopicData = encodeTopicData({
-          type: PayloadType.AnonTopicDataPayload,
-          value: {
-            chatId: telegramChatId,
-            topicName: topic.topic_name,
-            topicId: parseInt(topic.topic_id),
-            validEventIds
+            const encodedTopicData = encodeTopicData({
+              type: PayloadType.AnonTopicDataPayload,
+              value: {
+                chatId: telegramChatId,
+                topicName: topic.topic_name,
+                topicId: parseInt(topic.topic_id),
+                validEventIds
+              }
+            });
+
+            const url = `${process.env.TELEGRAM_ANON_WEBSITE}?tgWebAppStartParam=${encodedTopicData}`;
+            span?.setAttribute(`redirect url`, url);
+            logger(
+              `[TELEGRAM] generated redirect url to ${process.env.TELEGRAM_ANON_WEBSITE}`
+            );
+
+            return url;
           }
-        });
-
-        const url = `${process.env.TELEGRAM_ANON_WEBSITE}?tgWebAppStartParam=${encodedTopicData}`;
-        span?.setAttribute(`redirect url`, url);
-        logger(
-          `[TELEGRAM] generated redirect url to ${process.env.TELEGRAM_ANON_WEBSITE}`
         );
-
-        return url;
       }
     );
   }
 
-  public async handleGetAnonTotalKarma(nulliferHash: string): Promise<number> {
+  public async handleGetAnonTotalKarma(
+    client: PoolClient,
+    nulliferHash: string
+  ): Promise<number> {
     return traced("telegram", "handleGetAnonTotalKarma", async () => {
       const totalKarma = await fetchTelegramTotalKarmaForNullifier(
-        this.context.dbPool,
+        client,
         nulliferHash
       );
       return totalKarma;
@@ -1629,11 +1715,12 @@ export class TelegramService {
   }
 
   public async handleGetAnonMessages(
+    client: PoolClient,
     nullifierHash: string
   ): Promise<AnonMessageWithDetails[]> {
     return traced("telegram", "handleGetAnonMessages", async () => {
       const messages = await fetchTelegramAnonMessagesWithTopicByNullifier(
-        this.context.dbPool,
+        client,
         nullifierHash
       );
 

--- a/apps/passport-server/src/services/userService.ts
+++ b/apps/passport-server/src/services/userService.ts
@@ -13,6 +13,7 @@ import {
   UNREDACT_TICKETS_TERMS_VERSION,
   UpgradeUserWithV4CommitmentResult,
   VerifyTokenResponseValue,
+  ZupassUserJson,
   requestPodboxOneClickEmails,
   verifyAddV4CommitmentRequestPCD
 } from "@pcd/passport-interface";
@@ -28,8 +29,8 @@ import {
   validateEmail
 } from "@pcd/util";
 import { randomUUID } from "crypto";
-import { Response } from "express";
 import { sha256 } from "js-sha256";
+import { PoolClient } from "postgres-pool";
 import { z } from "zod";
 import { UserRow } from "../database/models";
 import { agreeTermsAndUnredactTickets } from "../database/queries/devconnect_pretix_tickets/devconnectPretixRedactedTickets";
@@ -66,11 +67,11 @@ const AgreedTermsSchema = z.object({
  */
 export class UserService {
   public readonly bypassEmail: boolean;
+  private context: ApplicationContext;
   /**
    * No particular reason to limit to 6, just needed some limit.
    */
   private static readonly MAX_USER_EMAIL_ADDRESES = 6;
-  private readonly context: ApplicationContext;
   private readonly semaphoreService: SemaphoreService;
   private readonly emailTokenService: EmailTokenService;
   private readonly emailService: EmailService;
@@ -160,8 +161,11 @@ export class UserService {
     });
   }
 
-  public async getSaltByEmail(email: string): Promise<string | null> {
-    const user = await this.getUserByEmail(email);
+  public async getSaltByEmail(
+    client: PoolClient,
+    email: string
+  ): Promise<string | null> {
+    const user = await this.getUserByEmail(client, email);
 
     if (!user) {
       throw new PCDHTTPError(404, `user ${email} does not exist`);
@@ -176,17 +180,18 @@ export class UserService {
    * the user does not have an encryption key stored on the server.
    */
   public async getEncryptionKeyForUser(
+    client: PoolClient,
     email: string
   ): Promise<HexString | null> {
-    const existingUser = await fetchUserByEmail(this.context.dbPool, email);
+    const existingUser = await fetchUserByEmail(client, email);
     return existingUser?.encryption_key ?? null;
   }
 
   public async handleSendTokenEmail(
+    client: PoolClient,
     email: string,
-    force: boolean,
-    res: Response
-  ): Promise<void> {
+    force: boolean
+  ): Promise<ConfirmEmailResponseValue> {
     logger(
       `[USER_SERVICE] send-token-email ${JSON.stringify({
         email,
@@ -200,6 +205,7 @@ export class UserService {
 
     if (
       !(await this.rateLimitService.requestRateLimitedAction(
+        this.context.dbPool,
         "REQUEST_EMAIL_TOKEN",
         email
       ))
@@ -207,22 +213,24 @@ export class UserService {
       throw new PCDHTTPError(401, "Too many attempts. Come back later.");
     }
 
-    const newEmailToken =
-      await this.emailTokenService.saveNewTokenForEmail(email);
-    let existingCommitment = await fetchUserByEmail(this.context.dbPool, email);
+    const newEmailToken = await this.emailTokenService.saveNewTokenForEmail(
+      client,
+      email
+    );
+    let existingCommitment = await fetchUserByEmail(client, email);
     if (
       existingCommitment?.encryption_key &&
       process.env.DELETE_MISSING_USERS === "true"
     ) {
       const blobKey = await getHash(existingCommitment.encryption_key);
-      const storage = await fetchEncryptedStorage(this.context.dbPool, blobKey);
+      const storage = await fetchEncryptedStorage(client, blobKey);
       if (!storage) {
         logger(
           `[USER_SERVICE] Deleting user with no storage: ${JSON.stringify(
             existingCommitment
           )}`
         );
-        await deleteUserByUUID(this.context.dbPool, existingCommitment.uuid);
+        await deleteUserByUUID(client, existingCommitment.uuid);
         existingCommitment = null;
       }
     }
@@ -239,16 +247,15 @@ export class UserService {
 
     if (this.bypassEmail) {
       logger("[DEV] Bypassing email, returning token");
-      res.status(200).json({
+      return {
         devToken: newEmailToken
-      } satisfies ConfirmEmailResponseValue);
-      return;
+      } satisfies ConfirmEmailResponseValue;
     }
 
     logger(`[USER_SERVICE] Sending token=${newEmailToken} to email=${email}`);
     await this.emailService.sendTokenEmail(email, newEmailToken);
 
-    res.sendStatus(200);
+    return undefined;
   }
 
   /**
@@ -258,13 +265,17 @@ export class UserService {
    * a counter and allow the action to proceed. Can only be called on users
    * that have already created an account.
    */
-  private async checkAccountResetRateLimit(user: UserRow): Promise<void> {
+  private async checkAccountResetRateLimit(
+    client: PoolClient,
+    user: UserRow
+  ): Promise<void> {
     if (process.env.ACCOUNT_RESET_RATE_LIMIT_DISABLED === "true") {
       logger("[USER_SERVICE] account rate limit disabled");
       return;
     }
 
     const allowed = await this.rateLimitService.requestRateLimitedAction(
+      this.context.dbPool,
       "ACCOUNT_RESET",
       user.uuid
     );
@@ -279,13 +290,13 @@ export class UserService {
   }
 
   public async handleOneClickLogin(
+    client: PoolClient,
     email: string,
     code: string,
     commitment: string,
     v4PublicKey: string,
-    encryption_key: string,
-    res: Response
-  ): Promise<void> {
+    encryption_key: string
+  ): Promise<OneClickLoginResponseValue> {
     const validDevcon = this.anonymizedDevconEmails[sha256(email)]?.includes(
       sha256(code)
     );
@@ -293,6 +304,7 @@ export class UserService {
     const valid =
       validDevcon ||
       (await this.genericIssuanceService?.validateEmailAndPretixOrderCode(
+        client,
         email,
         code
       ));
@@ -304,33 +316,32 @@ export class UserService {
       );
     }
 
-    let existingUser = await fetchUserByEmail(this.context.dbPool, email);
+    let existingUser = await fetchUserByEmail(client, email);
     if (
       existingUser?.encryption_key &&
       process.env.DELETE_MISSING_USERS === "true"
     ) {
       const blobKey = await getHash(existingUser.encryption_key);
-      const storage = await fetchEncryptedStorage(this.context.dbPool, blobKey);
+      const storage = await fetchEncryptedStorage(client, blobKey);
       if (!storage) {
         logger(
           `[USER_SERVICE] Deleting user with no storage: ${JSON.stringify(
             existingUser
           )}`
         );
-        await deleteUserByUUID(this.context.dbPool, existingUser.uuid);
+        await deleteUserByUUID(client, existingUser.uuid);
         existingUser = null;
       }
     }
 
     if (existingUser) {
-      res.status(200).json({
+      return {
         isNewUser: false,
         encryptionKey: existingUser.encryption_key
-      } satisfies OneClickLoginResponseValue);
-      return;
+      } satisfies OneClickLoginResponseValue;
     }
     // todo: rate limit
-    await upsertUser(this.context.dbPool, {
+    await upsertUser(client, {
       uuid: randomUUID(),
       emails: [email],
       commitment,
@@ -344,7 +355,7 @@ export class UserService {
     // Reload Merkle trees
     this.semaphoreService.scheduleReload();
 
-    const user = await fetchUserByEmail(this.context.dbPool, email);
+    const user = await fetchUserByEmail(client, email);
     if (!user) {
       throw new PCDHTTPError(403, "No user with that email exists");
     }
@@ -357,7 +368,7 @@ export class UserService {
       user.uuid
     );
     await agreeTermsAndUnredactTickets(
-      this.context.dbPool,
+      client,
       user.uuid,
       LATEST_PRIVACY_NOTICE
     );
@@ -365,22 +376,23 @@ export class UserService {
     const userJson = userRowToZupassUserJson(user);
 
     logger(`[USER_SERVICE] logged in a user`, userJson);
-    res.status(200).json({
+
+    return {
       isNewUser: true,
       zupassUser: userJson
-    } satisfies OneClickLoginResponseValue);
+    } satisfies OneClickLoginResponseValue;
   }
 
   public async handleNewUser(
+    client: PoolClient,
     token: string,
     email: string,
     commitment: string,
     v4PublicKey: string,
     salt: string | undefined,
     encryption_key: string | undefined,
-    autoRegister: boolean | undefined,
-    res: Response
-  ): Promise<void> {
+    autoRegister: boolean | undefined
+  ): Promise<NewUserResponseValue> {
     logger(
       `[USER_SERVICE] new-user ${JSON.stringify({
         token,
@@ -397,7 +409,7 @@ export class UserService {
       );
     }
 
-    const existingUser = await fetchUserByEmail(this.context.dbPool, email);
+    const existingUser = await fetchUserByEmail(client, email);
 
     // Prevent accidental account re-creation/reset for one-click links clicked by existing users
     if (existingUser && autoRegister) {
@@ -407,7 +419,9 @@ export class UserService {
       );
     }
 
-    if (!(await this.emailTokenService.checkTokenCorrect(email, token))) {
+    if (
+      !(await this.emailTokenService.checkTokenCorrect(client, email, token))
+    ) {
       throw new PCDHTTPError(
         403,
         autoRegister
@@ -417,13 +431,13 @@ export class UserService {
     }
 
     if (existingUser) {
-      await this.checkAccountResetRateLimit(existingUser);
+      await this.checkAccountResetRateLimit(client, existingUser);
     }
 
-    await this.emailTokenService.saveNewTokenForEmail(email);
+    await this.emailTokenService.saveNewTokenForEmail(client, email);
 
     logger(`[USER_SERVICE] Saving commitment: ${commitment}, ${v4PublicKey}`);
-    await upsertUser(this.context.dbPool, {
+    await upsertUser(client, {
       uuid: existingUser ? existingUser.uuid : randomUUID(),
       emails: existingUser ? existingUser.emails : [email],
       commitment,
@@ -444,7 +458,7 @@ export class UserService {
     // Reload Merkle trees
     this.semaphoreService.scheduleReload();
 
-    const user = await fetchUserByEmail(this.context.dbPool, email);
+    const user = await fetchUserByEmail(client, email);
     if (!user) {
       throw new PCDHTTPError(403, "no user with that email exists");
     }
@@ -454,7 +468,7 @@ export class UserService {
     // a benefit
     logger(`[USER_SERVICE] Unredacting tickets for email`, user.uuid);
     await agreeTermsAndUnredactTickets(
-      this.context.dbPool,
+      client,
       user.uuid,
       LATEST_PRIVACY_NOTICE
     );
@@ -465,7 +479,7 @@ export class UserService {
     };
 
     logger(`[USER_SERVICE] logged in a user`, userJson);
-    res.status(200).json(response);
+    return response;
   }
 
   /**
@@ -473,25 +487,29 @@ export class UserService {
    * If the user does not exist, returns a 404.
    * Otherwise returns the user.
    */
-  public async handleGetUser(uuid: string, res: Response): Promise<void> {
+  public async handleGetUser(
+    client: PoolClient,
+    uuid: string
+  ): Promise<ZupassUserJson> {
     logger(`[USER_SERVICE] Fetching user ${uuid}`);
 
-    const user = await this.getUserByUUID(uuid);
+    const user = await this.getUserByUUID(client, uuid);
 
     if (!user) {
       throw new PCDHTTPError(410, `no user with uuid '${uuid}'`);
     }
 
-    const userJson = userRowToZupassUserJson(user);
-
-    res.status(200).json(userJson);
+    return userRowToZupassUserJson(user);
   }
 
   /**
    * Returns either the user, or null if no user with the given uuid can be found.
    */
-  public async getUserByUUID(uuid: string): Promise<UserRow | null> {
-    const user = await fetchUserByUUID(this.context.dbPool, uuid);
+  public async getUserByUUID(
+    client: PoolClient,
+    uuid: string
+  ): Promise<UserRow | null> {
+    const user = await fetchUserByUUID(client, uuid);
 
     if (!user) {
       logger("[SEMA] no user with that email exists");
@@ -503,8 +521,11 @@ export class UserService {
   /**
    * Gets a user by email address, or null if no user with that email exists.
    */
-  public async getUserByEmail(email: string): Promise<UserRow | null> {
-    const user = await fetchUserByEmail(this.context.dbPool, email);
+  public async getUserByEmail(
+    client: PoolClient,
+    email: string
+  ): Promise<UserRow | null> {
+    const user = await fetchUserByEmail(client, email);
 
     if (!user) {
       logger("[SEMA] no user with that email exists");
@@ -518,9 +539,10 @@ export class UserService {
    * Returns either the user, or null if no user with the given commitment can be found.
    */
   public async getUserByCommitment(
+    client: PoolClient,
     commitment: string
   ): Promise<UserRow | null> {
-    const user = await fetchUserByV3Commitment(this.context.dbPool, commitment);
+    const user = await fetchUserByV3Commitment(client, commitment);
 
     if (!user) {
       logger("[SEMA] no user with that commitment exists");
@@ -531,29 +553,28 @@ export class UserService {
   }
 
   public async handleDeleteAccount(
+    client: PoolClient,
     serializedPCD: SerializedPCD<SemaphoreSignaturePCD>
   ): Promise<void> {
     const verifyResult =
       await this.credentialSubservice.tryVerify(serializedPCD);
 
-    const user = await fetchUserForCredential(
-      this.context.dbPool,
-      verifyResult
-    );
+    const user = await fetchUserForCredential(client, verifyResult);
 
     if (!user) {
       throw new Error("User not found");
     }
 
-    await deleteUserByUUID(this.context.dbPool, user.uuid);
-    await deleteE2EEByV3Commitment(this.context.dbPool, user.commitment);
+    await deleteUserByUUID(client, user.uuid);
+    await deleteE2EEByV3Commitment(client, user.commitment);
   }
 
   public async getUserForUnverifiedCredential(
+    client: PoolClient,
     credential: Credential
   ): Promise<UserRow | null> {
     return fetchUserForCredential(
-      this.context.dbPool,
+      client,
       await this.credentialSubservice.verifyAndExpectZupassEmail(credential)
     );
   }
@@ -562,6 +583,7 @@ export class UserService {
    * @param sig created by {@link makeAddV4CommitmentRequest}
    */
   public async handleAddV4Commitment(
+    client: PoolClient,
     sig: SerializedPCD<SemaphoreSignaturePCD>
   ): Promise<UpgradeUserWithV4CommitmentResult> {
     const v3Sig = await SemaphoreSignaturePCDPackage.deserialize(sig.pcd);
@@ -573,7 +595,7 @@ export class UserService {
     }
 
     const user = await fetchUserByV3Commitment(
-      this.context.dbPool,
+      client,
       verification.v3Commitment
     );
 
@@ -584,7 +606,7 @@ export class UserService {
     if (!user.semaphore_v4_commitment && !user.semaphore_v4_pubkey) {
       user.semaphore_v4_commitment = verification.v4Commitment;
       user.semaphore_v4_pubkey = verification.v4PublicKey;
-      await upsertUser(this.context.dbPool, user);
+      await upsertUser(client, user);
     } else if (
       user.semaphore_v4_commitment !== verification.v4Commitment ||
       user.semaphore_v4_pubkey !== verification.v4PublicKey
@@ -605,6 +627,7 @@ export class UserService {
    * Updates the version of the legal terms the user agrees to
    */
   public async handleAgreeTerms(
+    client: PoolClient,
     serializedPCD: SerializedPCD<SemaphoreSignaturePCD>
   ): Promise<AgreeTermsResult> {
     const pcd = await SemaphoreSignaturePCDPackage.deserialize(
@@ -630,7 +653,7 @@ export class UserService {
 
     const payload = parsedPayload.data;
     const user = await fetchUserByV3Commitment(
-      this.context.dbPool,
+      client,
       pcd.claim.identityCommitment
     );
     if (!user) {
@@ -650,17 +673,13 @@ export class UserService {
         `[USER_SERVICE] Unredacting tickets for email due to accepting version ${payload.version} of legal terms`,
         user.uuid
       );
-      await agreeTermsAndUnredactTickets(
-        this.context.dbPool,
-        user.uuid,
-        payload.version
-      );
+      await agreeTermsAndUnredactTickets(client, user.uuid, payload.version);
     } else {
       logger(
         `[USER_SERVICE] Updating user to version ${payload.version} of legal terms`,
         user.uuid
       );
-      await upsertUser(this.context.dbPool, {
+      await upsertUser(client, {
         ...user,
         terms_agreed: payload.version
       });
@@ -673,11 +692,13 @@ export class UserService {
   }
 
   public async handleVerifyToken(
+    client: PoolClient,
     token: string,
     email: string
   ): Promise<VerifyTokenResponseValue> {
     if (
       !(await this.rateLimitService.requestRateLimitedAction(
+        this.context.dbPool,
         "CHECK_EMAIL_TOKEN",
         email
       ))
@@ -686,6 +707,7 @@ export class UserService {
     }
 
     const tokenCorrect = await this.emailTokenService.checkTokenCorrect(
+      client,
       email,
       token
     );
@@ -697,12 +719,12 @@ export class UserService {
       );
     }
 
-    const user = await this.getUserByEmail(email);
+    const user = await this.getUserByEmail(client, email);
 
     // If we return the user's encryption key, change the token so this request
     // can't be replayed.
     if (user?.encryption_key) {
-      await this.emailTokenService.saveNewTokenForEmail(email);
+      await this.emailTokenService.saveNewTokenForEmail(client, email);
     }
 
     return {
@@ -715,6 +737,7 @@ export class UserService {
    * exits without any updates to the user.
    */
   public async handleAddUserEmail(
+    client: PoolClient,
     emailToAdd: string,
     unverifiedCredential: SerializedPCD<SemaphoreSignaturePCD>,
     confirmationCode?: string
@@ -726,8 +749,10 @@ export class UserService {
       unverifiedCredential
     );
 
-    const requestingUser =
-      await this.getUserForUnverifiedCredential(unverifiedCredential);
+    const requestingUser = await this.getUserForUnverifiedCredential(
+      client,
+      unverifiedCredential
+    );
     if (!requestingUser) {
       throw new PCDHTTPError(400, EmailUpdateError.InvalidCredential);
     }
@@ -736,14 +761,19 @@ export class UserService {
       throw new PCDHTTPError(400, EmailUpdateError.InvalidInput);
     }
 
-    const maybeExistingUserOfNewEmail = await this.getUserByEmail(emailToAdd);
+    const maybeExistingUserOfNewEmail = await this.getUserByEmail(
+      client,
+      emailToAdd
+    );
     if (maybeExistingUserOfNewEmail) {
       throw new PCDHTTPError(400, EmailUpdateError.EmailAlreadyRegistered);
     }
 
     if (confirmationCode === undefined) {
-      const newToken =
-        await this.emailTokenService.saveNewTokenForEmail(emailToAdd);
+      const newToken = await this.emailTokenService.saveNewTokenForEmail(
+        client,
+        emailToAdd
+      );
 
       if (this.bypassEmail) {
         logger("[DEV] Bypassing email, returning token", newToken);
@@ -756,6 +786,7 @@ export class UserService {
     }
 
     const isCodeValid = await this.emailTokenService.checkTokenCorrect(
+      client,
       emailToAdd,
       confirmationCode
     );
@@ -777,7 +808,7 @@ export class UserService {
     try {
       const newEmailList = [...requestingUser.emails, emailToAdd];
 
-      await upsertUser(this.context.dbPool, {
+      await upsertUser(client, {
         ...requestingUser,
         emails: newEmailList
       });
@@ -789,6 +820,7 @@ export class UserService {
   }
 
   public async handleRemoveUserEmail(
+    client: PoolClient,
     emailToRemove: string,
     unverifiedCredential: SerializedPCD<SemaphoreSignaturePCD>
   ): Promise<RemoveUserEmailResponseValue> {
@@ -798,8 +830,10 @@ export class UserService {
       unverifiedCredential
     );
 
-    const requestingUser =
-      await this.getUserForUnverifiedCredential(unverifiedCredential);
+    const requestingUser = await this.getUserForUnverifiedCredential(
+      client,
+      unverifiedCredential
+    );
     if (!requestingUser) {
       throw new PCDHTTPError(400, EmailUpdateError.InvalidCredential);
     }
@@ -820,7 +854,7 @@ export class UserService {
     );
 
     try {
-      await upsertUser(this.context.dbPool, {
+      await upsertUser(client, {
         ...requestingUser,
         emails: newEmailList
       });
@@ -835,6 +869,7 @@ export class UserService {
    * exits without any updates to the user.
    */
   public async handleChangeUserEmail(
+    client: PoolClient,
     oldEmail: string,
     newEmail: string,
     unverifiedCredential: SerializedPCD<SemaphoreSignaturePCD>,
@@ -848,13 +883,18 @@ export class UserService {
       unverifiedCredential
     );
 
-    const requestingUser =
-      await this.getUserForUnverifiedCredential(unverifiedCredential);
+    const requestingUser = await this.getUserForUnverifiedCredential(
+      client,
+      unverifiedCredential
+    );
     if (!requestingUser) {
       throw new PCDHTTPError(400, EmailUpdateError.InvalidCredential);
     }
 
-    const maybeExistingUserOfNewEmail = await this.getUserByEmail(newEmail);
+    const maybeExistingUserOfNewEmail = await this.getUserByEmail(
+      client,
+      newEmail
+    );
     if (maybeExistingUserOfNewEmail) {
       throw new PCDHTTPError(400, EmailUpdateError.EmailAlreadyRegistered);
     }
@@ -878,8 +918,10 @@ export class UserService {
     }
 
     if (confirmationCode === undefined) {
-      const newToken =
-        await this.emailTokenService.saveNewTokenForEmail(newEmail);
+      const newToken = await this.emailTokenService.saveNewTokenForEmail(
+        client,
+        newEmail
+      );
 
       if (this.bypassEmail) {
         logger("[DEV] Bypassing email, returning token", newToken);
@@ -892,6 +934,7 @@ export class UserService {
     }
 
     const isCodeValid = await this.emailTokenService.checkTokenCorrect(
+      client,
       newEmail,
       confirmationCode
     );
@@ -903,7 +946,7 @@ export class UserService {
     try {
       const newEmailList = [newEmail];
 
-      await upsertUser(this.context.dbPool, {
+      await upsertUser(client, {
         ...requestingUser,
         emails: newEmailList
       });

--- a/apps/passport-server/src/util/frogTelegramHelpers.ts
+++ b/apps/passport-server/src/util/frogTelegramHelpers.ts
@@ -8,7 +8,7 @@ import {
   ZKEdDSAFrogPCDArgs,
   ZKEdDSAFrogPCDPackage
 } from "@pcd/zk-eddsa-frog-pcd";
-import { Pool } from "postgres-pool";
+import { PoolClient } from "postgres-pool";
 import { insertTelegramVerification } from "../database/queries/telegram/insertTelegramConversation";
 import { loadRSAPrivateKey } from "../services/issuanceService";
 import { traced } from "../services/telemetryService";
@@ -86,7 +86,7 @@ export const generateFrogProofUrl = async (
  * Verify that a PCD relates to a frog. If so, invite the user to the chat.
  */
 export const handleFrogVerification = async (
-  dbPool: Pool,
+  client: PoolClient,
   serializedZKEdDSAFrogPCD: string,
   telegramUserId: number,
   telegramChatId: number,
@@ -162,7 +162,7 @@ export const handleFrogVerification = async (
     // We've verified that the chat exists, now add the user to our list.
     // This will be important later when the user requests to join.
     await insertTelegramVerification(
-      dbPool,
+      client,
       telegramUserId,
       telegramChatId,
       ownerSemaphoreId,

--- a/apps/passport-server/src/util/frogcrypto.ts
+++ b/apps/passport-server/src/util/frogcrypto.ts
@@ -17,6 +17,7 @@ import { PCDPackage } from "@pcd/pcd-types";
 import _ from "lodash";
 import { Pool } from "postgres-pool";
 import { getFeedData } from "../database/queries/frogcrypto";
+import { namedSqlTransaction } from "../database/sqlQuery";
 import { PCDHTTPError } from "../routing/pcdHttpError";
 
 export class FrogCryptoFeedHost extends FeedHost<FrogCryptoFeed> {
@@ -60,7 +61,11 @@ export class FrogCryptoFeedHost extends FeedHost<FrogCryptoFeed> {
    * Refetch the list of feeds that this server is hosting from the database.
    */
   public async refreshFeeds(): Promise<void> {
-    const feeds = await getFeedData(this.dbPool);
+    const feeds = await namedSqlTransaction(
+      this.dbPool,
+      "refreshFeeds",
+      (client) => getFeedData(client)
+    );
     this.hostedFeed.length = 0;
     this.hostedFeed.push(
       ...feeds.map((feed) => ({

--- a/apps/passport-server/test/generic-issuance/pipelines/auto-issuance/autoIssuanceSpec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/auto-issuance/autoIssuanceSpec.ts
@@ -16,6 +16,7 @@ import { expect } from "chai";
 import "mocha";
 import { step } from "mocha-steps";
 import * as MockDate from "mockdate";
+import { Pool, PoolClient } from "postgres-pool";
 import { stopApplication } from "../../../../src/application";
 import { PipelineCheckinDB } from "../../../../src/database/queries/pipelineCheckinDB";
 import { PipelineConsumerDB } from "../../../../src/database/queries/pipelineConsumerDB";
@@ -58,6 +59,8 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
   let ZUPASS_EDDSA_PRIVATE_KEY: string;
   let giBackend: Zupass;
   let giService: GenericIssuanceService;
+  let client: PoolClient;
+  let pool: Pool;
 
   const {
     adminGIUserId,
@@ -102,7 +105,10 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
 
     giBackend = await startTestingApp({});
 
-    const userDB = new PipelineUserDB(giBackend.context.dbPool);
+    pool = giBackend.context.dbPool;
+    client = await pool.connect();
+
+    const userDB = new PipelineUserDB();
 
     const adminUser: PipelineUser = {
       id: adminGIUserId,
@@ -111,7 +117,7 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
       timeCreated: nowDate,
       timeUpdated: nowDate
     };
-    await userDB.updateUserById(adminUser);
+    await userDB.updateUserById(client, adminUser);
     assertUserMatches(
       {
         id: adminGIUserId,
@@ -120,7 +126,7 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
         timeCreated: nowDate,
         timeUpdated: nowDate
       },
-      await userDB.getUserById(adminUser.id)
+      await userDB.getUserById(client, adminUser.id)
     );
 
     const autoIssuanceGIUser: PipelineUser = {
@@ -130,7 +136,7 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
       timeCreated: nowDate,
       timeUpdated: nowDate
     };
-    await userDB.updateUserById(autoIssuanceGIUser);
+    await userDB.updateUserById(client, autoIssuanceGIUser);
     assertUserMatches(
       {
         id: autoIssuanceGIUserID,
@@ -139,7 +145,7 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
         timeCreated: nowDate,
         timeUpdated: nowDate
       },
-      await userDB.getUserById(autoIssuanceGIUser.id)
+      await userDB.getUserById(client, autoIssuanceGIUser.id)
     );
 
     // The mock server will intercept any requests for URLs that are registered
@@ -150,11 +156,9 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
     giService = giBackend.services
       .genericIssuanceService as GenericIssuanceService;
     await giService.stop();
-    const pipelineDefinitionDB = new PipelineDefinitionDB(
-      giBackend.context.dbPool
-    );
-    await pipelineDefinitionDB.deleteAllDefinitions();
-    await pipelineDefinitionDB.upsertDefinitions(pipelineDefinitions);
+    const pipelineDefinitionDB = new PipelineDefinitionDB();
+    await pipelineDefinitionDB.deleteAllDefinitions(client);
+    await pipelineDefinitionDB.upsertDefinitions(client, pipelineDefinitions);
     await giService.start(false);
   });
 
@@ -172,7 +176,7 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
   });
 
   step("PipelineUserDB", async function () {
-    const userDB = new PipelineUserDB(giBackend.context.dbPool);
+    const userDB = new PipelineUserDB();
 
     const adminUser: PipelineUser = {
       id: adminGIUserId,
@@ -181,7 +185,7 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
       timeCreated: nowDate,
       timeUpdated: nowDate
     };
-    await userDB.updateUserById(adminUser);
+    await userDB.updateUserById(client, adminUser);
     assertUserMatches(
       {
         id: adminGIUserId,
@@ -190,7 +194,7 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
         timeCreated: nowDate,
         timeUpdated: nowDate
       },
-      await userDB.getUserById(adminUser.id)
+      await userDB.getUserById(client, adminUser.id)
     );
 
     // TODO: comprehensive tests of create update read delete
@@ -547,13 +551,17 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
       } satisfies PodboxTicketActionResponseValue);
 
       // Verify that consumers were saved for each user who requested tickets
-      const consumerDB = new PipelineConsumerDB(giBackend.context.dbPool);
-      const consumers = await consumerDB.loadByEmails(autoIssuancePipeline.id, [
-        AutoIssuanceManualAttendeeEmail,
-        AutoIssuanceManualBouncerEmail,
-        pretixBackend.get().autoIssuanceOrganizer.autoIssuanceAttendeeEmail,
-        pretixBackend.get().autoIssuanceOrganizer.autoIssuanceBouncerEmail
-      ]);
+      const consumerDB = new PipelineConsumerDB();
+      const consumers = await consumerDB.loadByEmails(
+        client,
+        autoIssuancePipeline.id,
+        [
+          AutoIssuanceManualAttendeeEmail,
+          AutoIssuanceManualBouncerEmail,
+          pretixBackend.get().autoIssuanceOrganizer.autoIssuanceAttendeeEmail,
+          pretixBackend.get().autoIssuanceOrganizer.autoIssuanceBouncerEmail
+        ]
+      );
       expectLength(consumers, 4);
       expect(consumers).to.deep.include.members([
         {
@@ -664,23 +672,28 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
   step("check-ins for deleted manual tickets are removed", async function () {
     expectToExist(giService);
 
-    const checkinDB = new PipelineCheckinDB(giBackend.context.dbPool);
-    const checkins = await checkinDB.getByPipelineId(autoIssuancePipeline.id);
+    const checkinDB = new PipelineCheckinDB();
+    const checkins = await checkinDB.getByPipelineId(
+      client,
+      autoIssuancePipeline.id
+    );
     // Manual attendee ticket and food voucher was checked in
     expectLength(checkins, 2);
 
-    const userDB = new PipelineUserDB(giBackend.context.dbPool);
-    const adminUser = await userDB.getUserById(adminGIUserId);
+    const userDB = new PipelineUserDB();
+    const adminUser = await userDB.getUserById(client, adminGIUserId);
     expectToExist(adminUser);
 
     // Delete the manual tickets from the definition
     const latestPipeline = (await giService.getPipeline(
+      client,
       autoIssuancePipeline.id
     )) as PretixPipelineDefinition;
     const newPipelineDefinition = structuredClone(latestPipeline);
     newPipelineDefinition.options.manualTickets = [];
     // Update the definition
     const { restartPromise } = await giService.upsertPipelineDefinition(
+      client,
       adminUser,
       newPipelineDefinition
     );
@@ -696,7 +709,10 @@ describe("generic issuance - PretixPipeline w/ auto-issuance enabled", function 
     expect(pipeline.id).to.eq(newPipelineDefinition.id);
     // Verify that there are no checkins in the DB now
     {
-      const checkins = await checkinDB.getByPipelineId(autoIssuancePipeline.id);
+      const checkins = await checkinDB.getByPipelineId(
+        client,
+        autoIssuancePipeline.id
+      );
       // only food voucher checkin is found as the tickets have been deleted
       expectLength(checkins, 1);
     }

--- a/apps/passport-server/test/generic-issuance/pipelines/csv/csvPipeline.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/csv/csvPipeline.spec.ts
@@ -10,6 +10,7 @@ import { randomUUID } from "crypto";
 import "mocha";
 import { step } from "mocha-steps";
 import * as MockDate from "mockdate";
+import { Pool, PoolClient } from "postgres-pool";
 import { stopApplication } from "../../../../src/application";
 import { PipelineDefinitionDB } from "../../../../src/database/queries/pipelineDefinitionDB";
 import { PipelineUserDB } from "../../../../src/database/queries/pipelineUserDB";
@@ -32,6 +33,9 @@ describe("generic issuance - CSVPipeline", function () {
 
   let giBackend: Zupass;
   let giService: GenericIssuanceService;
+
+  let pool: Pool;
+  let client: PoolClient;
 
   const adminGIUserId = randomUUID();
   const adminGIUserEmail = "admin@test.com";
@@ -56,8 +60,10 @@ describe("generic issuance - CSVPipeline", function () {
     });
 
     giBackend = await startTestingApp();
+    pool = giBackend.context.dbPool;
+    client = await pool.connect();
 
-    const userDB = new PipelineUserDB(giBackend.context.dbPool);
+    const userDB = new PipelineUserDB();
 
     const adminUser: PipelineUser = {
       id: adminGIUserId,
@@ -66,7 +72,7 @@ describe("generic issuance - CSVPipeline", function () {
       timeCreated: nowDate,
       timeUpdated: nowDate
     };
-    await userDB.updateUserById(adminUser);
+    await userDB.updateUserById(client, adminUser);
     assertUserMatches(
       {
         id: adminGIUserId,
@@ -75,17 +81,15 @@ describe("generic issuance - CSVPipeline", function () {
         timeCreated: nowDate,
         timeUpdated: nowDate
       },
-      await userDB.getUserById(adminUser.id)
+      await userDB.getUserById(client, adminUser.id)
     );
 
     giService = giBackend.services
       .genericIssuanceService as GenericIssuanceService;
     await giService.stop();
-    const pipelineDefinitionDB = new PipelineDefinitionDB(
-      giBackend.context.dbPool
-    );
-    await pipelineDefinitionDB.deleteAllDefinitions();
-    await pipelineDefinitionDB.upsertDefinitions(pipelineDefinitions);
+    const pipelineDefinitionDB = new PipelineDefinitionDB();
+    await pipelineDefinitionDB.deleteAllDefinitions(client);
+    await pipelineDefinitionDB.upsertDefinitions(client, pipelineDefinitions);
     await giService.start(false);
   });
 
@@ -98,7 +102,7 @@ describe("generic issuance - CSVPipeline", function () {
   });
 
   step("PipelineUserDB", async function () {
-    const userDB = new PipelineUserDB(giBackend.context.dbPool);
+    const userDB = new PipelineUserDB();
 
     const adminUser: PipelineUser = {
       id: adminGIUserId,
@@ -107,7 +111,7 @@ describe("generic issuance - CSVPipeline", function () {
       timeCreated: nowDate,
       timeUpdated: nowDate
     };
-    await userDB.updateUserById(adminUser);
+    await userDB.updateUserById(client, adminUser);
     assertUserMatches(
       {
         id: adminGIUserId,
@@ -116,7 +120,7 @@ describe("generic issuance - CSVPipeline", function () {
         timeCreated: nowDate,
         timeUpdated: nowDate
       },
-      await userDB.getUserById(adminUser.id)
+      await userDB.getUserById(client, adminUser.id)
     );
   });
 

--- a/apps/passport-server/test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts
@@ -26,6 +26,7 @@ import "mocha";
 import { step } from "mocha-steps";
 import * as MockDate from "mockdate";
 import { rest } from "msw";
+import { Pool, PoolClient } from "postgres-pool";
 import urljoin from "url-join";
 import { LemonadeOAuthCredentials } from "../../../../src/apis/lemonade/auth";
 import { LemonadeTicket } from "../../../../src/apis/lemonade/types";
@@ -77,6 +78,9 @@ describe("generic issuance - LemonadePipeline", function () {
   let ZUPASS_EDDSA_PRIVATE_KEY: string;
   let giBackend: Zupass;
   let giService: GenericIssuanceService;
+
+  let client: PoolClient;
+  let pool: Pool;
 
   const adminGIUserId = randomUUID();
   const adminGIUserEmail = "admin@test.com";
@@ -131,7 +135,10 @@ describe("generic issuance - LemonadePipeline", function () {
       lemonadeAPI
     });
 
-    const userDB = new PipelineUserDB(giBackend.context.dbPool);
+    pool = giBackend.context.dbPool;
+    client = await pool.connect();
+
+    const userDB = new PipelineUserDB();
 
     const adminUser: PipelineUser = {
       id: adminGIUserId,
@@ -140,7 +147,7 @@ describe("generic issuance - LemonadePipeline", function () {
       timeCreated: nowDate,
       timeUpdated: nowDate
     };
-    await userDB.updateUserById(adminUser);
+    await userDB.updateUserById(client, adminUser);
     assertUserMatches(
       {
         id: adminGIUserId,
@@ -149,7 +156,7 @@ describe("generic issuance - LemonadePipeline", function () {
         timeCreated: nowDate,
         timeUpdated: nowDate
       },
-      await userDB.getUserById(adminUser.id)
+      await userDB.getUserById(client, adminUser.id)
     );
 
     const edgeCityDenverUser: PipelineUser = {
@@ -159,7 +166,7 @@ describe("generic issuance - LemonadePipeline", function () {
       timeCreated: nowDate,
       timeUpdated: nowDate
     };
-    await userDB.updateUserById(edgeCityDenverUser);
+    await userDB.updateUserById(client, edgeCityDenverUser);
     assertUserMatches(
       {
         id: edgeCityGIUserID,
@@ -168,7 +175,7 @@ describe("generic issuance - LemonadePipeline", function () {
         timeCreated: nowDate,
         timeUpdated: nowDate
       },
-      await userDB.getUserById(edgeCityDenverUser.id)
+      await userDB.getUserById(client, edgeCityDenverUser.id)
     );
 
     // The mock server will intercept any requests for URLs that are registered
@@ -179,11 +186,9 @@ describe("generic issuance - LemonadePipeline", function () {
     giService = giBackend.services
       .genericIssuanceService as GenericIssuanceService;
     await giService.stop();
-    const pipelineDefinitionDB = new PipelineDefinitionDB(
-      giBackend.context.dbPool
-    );
-    await pipelineDefinitionDB.deleteAllDefinitions();
-    await pipelineDefinitionDB.upsertDefinitions(pipelineDefinitions);
+    const pipelineDefinitionDB = new PipelineDefinitionDB();
+    await pipelineDefinitionDB.deleteAllDefinitions(client);
+    await pipelineDefinitionDB.upsertDefinitions(client, pipelineDefinitions);
     await giService.start(false);
   });
 
@@ -201,7 +206,7 @@ describe("generic issuance - LemonadePipeline", function () {
   });
 
   step("PipelineUserDB", async function () {
-    const userDB = new PipelineUserDB(giBackend.context.dbPool);
+    const userDB = new PipelineUserDB();
 
     const adminUser: PipelineUser = {
       id: adminGIUserId,
@@ -210,7 +215,7 @@ describe("generic issuance - LemonadePipeline", function () {
       timeCreated: nowDate,
       timeUpdated: nowDate
     };
-    await userDB.updateUserById(adminUser);
+    await userDB.updateUserById(client, adminUser);
     assertUserMatches(
       {
         id: adminGIUserId,
@@ -219,7 +224,7 @@ describe("generic issuance - LemonadePipeline", function () {
         timeCreated: nowDate,
         timeUpdated: nowDate
       },
-      await userDB.getUserById(adminUser.id)
+      await userDB.getUserById(client, adminUser.id)
     );
 
     // TODO: comprehensive tests of create update read delete
@@ -448,8 +453,9 @@ describe("generic issuance - LemonadePipeline", function () {
       // backend, will be implemented with the pipeline as the check-in backend
 
       // Verify that consumers were saved for each user who requested tickets
-      const consumerDB = new PipelineConsumerDB(giBackend.context.dbPool);
+      const consumerDB = new PipelineConsumerDB();
       const consumers = await consumerDB.loadByEmails(
+        client,
         edgeCityDenverPipeline.id,
         [
           EdgeCityManualAttendeeEmail,
@@ -688,9 +694,11 @@ describe("generic issuance - LemonadePipeline", function () {
 
       expectTrue(await SemaphoreGroupPCDPackage.verify(groupPCD));
 
-      const consumerDB = new PipelineConsumerDB(giBackend.context.dbPool);
+      const consumerDB = new PipelineConsumerDB();
       const consumer = (
-        await consumerDB.loadByEmails(edgeCityPipeline.id, [newUser.email])
+        await consumerDB.loadByEmails(client, edgeCityPipeline.id, [
+          newUser.email
+        ])
       )[0];
       expectToExist(consumer);
       const consumerUpdated = consumer.timeUpdated;
@@ -805,7 +813,7 @@ describe("generic issuance - LemonadePipeline", function () {
       }
 
       const consumerAfterChange = (
-        await consumerDB.loadByEmails(edgeCityDenverPipeline.id, [
+        await consumerDB.loadByEmails(client, edgeCityDenverPipeline.id, [
           newUser.email
         ])
       )[0];

--- a/apps/passport-server/test/generic-issuance/util.ts
+++ b/apps/passport-server/test/generic-issuance/util.ts
@@ -150,6 +150,7 @@ export function getTicketsFromFeedResponse(
   result: PollFeedResult
 ): Promise<(EdDSATicketPCD | PODTicketPCD)[]> {
   expectTrue(result.success);
+
   const secondAction = result.value.actions[1];
   expectIsReplaceInFolderAction(secondAction);
   expect(secondAction.folder).to.eq(expectedFolder);

--- a/apps/passport-server/test/semaphore/checkSemaphore.ts
+++ b/apps/passport-server/test/semaphore/checkSemaphore.ts
@@ -2,6 +2,7 @@ import { deserializeSemaphoreGroup } from "@pcd/semaphore-group-pcd";
 import { BigNumberish, Group } from "@semaphore-protocol/group";
 import { expect } from "chai";
 import { fetchLatestHistoricSemaphoreGroups } from "../../src/database/queries/historicSemaphore";
+import { sqlTransaction } from "../../src/database/sqlQuery";
 import { Zupass } from "../../src/types";
 
 export interface SemaphoreGroups {
@@ -83,8 +84,9 @@ function getCurrentSemaphoreServiceGroups(
 async function getLatestHistoricalSemaphoreGroups(
   application: Zupass
 ): Promise<SemaphoreGroups> {
-  const latestGroups = await fetchLatestHistoricSemaphoreGroups(
-    application.context.dbPool
+  const latestGroups = await sqlTransaction(
+    application.context.dbPool,
+    (client) => fetchLatestHistoricSemaphoreGroups(client)
   );
 
   const parsedLatestGroups = await Promise.all(

--- a/apps/passport-server/test/user/testLogin.ts
+++ b/apps/passport-server/test/user/testLogin.ts
@@ -15,6 +15,7 @@ import { randomUUID } from "@pcd/util";
 import { Identity } from "@semaphore-protocol/identity";
 import { expect } from "chai";
 import { randomBytes } from "crypto";
+import { sqlTransaction } from "../../src/database/sqlQuery";
 import { Zupass } from "../../src/types";
 
 export async function testLogin(
@@ -74,7 +75,10 @@ export async function testLogin(
     }
     token = confirmationEmailResult.value.devToken;
   } else {
-    const serverToken = await emailTokenService.getTokenForEmail(email);
+    const serverToken = await sqlTransaction(
+      application.context.dbPool,
+      (client) => emailTokenService.getTokenForEmail(client, email)
+    );
     if (serverToken === null) {
       throw new Error(
         "expected to be able to get the verification token from the internal server state"

--- a/apps/passport-server/test/util/rateLimit.ts
+++ b/apps/passport-server/test/util/rateLimit.ts
@@ -1,9 +1,11 @@
 import { Pool } from "postgres-pool";
-import { sqlQuery } from "../../src/database/sqlQuery";
+import { sqlQuery, sqlTransaction } from "../../src/database/sqlQuery";
 
 /**
  * Deletes the rate limit buckets, resetting all rate limits.
  */
-export async function resetRateLimitBuckets(db: Pool): Promise<void> {
-  await sqlQuery(db, "DELETE FROM rate_limit_buckets");
+export async function resetRateLimitBuckets(pool: Pool): Promise<void> {
+  await sqlTransaction(pool, (client) =>
+    sqlQuery(client, "DELETE FROM rate_limit_buckets")
+  );
 }


### PR DESCRIPTION
- sql transactions originate from the server in three types of situations:
1. server startup
2. scheduled operation on the server (e.g. reloading a pipeline)
3. user interaction (e.g. zupass client or telegram hitting the backend due to user interaction, or scheduled operation)
- i've carefully surrounded all 'bundles' of queries (a 'bundle' is the set of queries triggered by one of those instances) with sql transactions