### PR TITLE
Allow console.log statements to be dropped from builds if env var is set

### DIFF
--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -98,7 +98,8 @@ const appOpts: BuildOptions = {
   metafile: true,
   define,
   splitting: true,
-  format: "esm"
+  format: "esm",
+  drop: process.env.DISABLE_CONSOLE_LOG === "true" ? ["console"] : []
 };
 
 const serviceWorkerOpts: BuildOptions = {

--- a/turbo.json
+++ b/turbo.json
@@ -230,6 +230,7 @@
     "DEVCON_PODBOX_API_KEY",
     "DEVCON_PODBOX_API_URL",
     "DEVCON_PIPELINE_ID",
+    "DISABLE_CONSOLE_LOG",
     "//// add env vars above this line ////"
   ]
 }


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-1340/disable-logging-by-default-for-production-builds

Zupass logs a _lot_ of stuff, and those logs also appear in Zapps which include Zupass via an iframe, which is annoying and confusing to third party developers. We can disable logging in production by stripping `console.log` statements from the build using `esbuild`.

This PR modifies the build script to strip `console.log` statements iff an environment variable, `DISABLE_CONSOLE_LOG`, is set to `"true"`. If we set this in production then logging would be disabled there.