### PR TITLE
Fix for PCD emails [0XP-1286]

### DIFF
--- a/apps/passport-client/components/shared/PCDCard.tsx
+++ b/apps/passport-client/components/shared/PCDCard.tsx
@@ -22,6 +22,8 @@ import {
   useState
 } from "react";
 import styled, { FlattenSimpleInterpolation, css } from "styled-components";
+import { isEmailPCD } from "../../new-components/shared/Modals/PodsCollectionBottomModal";
+import { getTruncateEmail } from "../../new-components/utils/getTruncateEmail";
 import { usePCDCollection, useUserIdentityPCD } from "../../src/appHooks";
 import { StateContext } from "../../src/dispatch";
 import { pcdRenderers } from "../../src/pcdRenderers";
@@ -332,6 +334,13 @@ export const CardBody = forwardRef<HTMLDivElement, CardBodyProps>(
               idBasedVerifyURL={`${window.location.origin}/#/generic-checkin`}
             />
           </div>
+        );
+      }
+      if (isEmailPCD(pcd)) {
+        return (
+          <TextCenter>
+            {getTruncateEmail(pcd.claim.emailAddress, 40)}
+          </TextCenter>
         );
       }
       const ui = getUI(pcd.type);

--- a/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
@@ -19,6 +19,7 @@ import {
   useDispatch,
   usePCDCollection
 } from "../../../src/appHooks";
+import { getTruncateEmail } from "../../utils/getTruncateEmail";
 import { Avatar } from "../Avatar";
 import { BottomModal } from "../BottomModal";
 import { Button2 } from "../Button";
@@ -43,7 +44,7 @@ const getActivePod = (
   }
 };
 
-const isEmailPCD = (pcd: PCD<unknown, unknown>): pcd is EmailPCD =>
+export const isEmailPCD = (pcd: PCD<unknown, unknown>): pcd is EmailPCD =>
   pcd.type === EmailPCDTypeName;
 
 const getPcdName = (pcd: PCD<unknown, unknown>): string => {
@@ -51,7 +52,7 @@ const getPcdName = (pcd: PCD<unknown, unknown>): string => {
     case isEdDSATicketPCD(pcd) || isPODTicketPCD(pcd):
       return pcd.claim.ticket.eventName + " - " + pcd.claim.ticket.ticketName;
     case isEmailPCD(pcd):
-      return pcd.claim.emailAddress;
+      return getTruncateEmail(pcd.claim.emailAddress, 30);
     case isPODPCD(pcd):
       return getPodDisplayOptions(pcd).header ?? pcd.id;
     case isEdDSAFrogPCD(pcd):


### PR DESCRIPTION
This PR fixes Email PCDs with extremely long addresses by using the `getTruncateEmail` util

<img width="358" alt="Screenshot 2024-10-13 at 21 17 34" src="https://github.com/user-attachments/assets/bcc3ad5e-5272-4b14-82a3-5d83784ace29">
<img width="372" alt="Screenshot 2024-10-13 at 22 05 26" src="https://github.com/user-attachments/assets/24a3eeae-67b4-4d52-968a-eced36786e2f">
