### PR TITLE
Confirmation Code Errors Fix [0XP-1288][0XP-1289]

### DIFF
--- a/apps/passport-client/new-components/shared/Modals/ManageEmailsModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/ManageEmailsModal.tsx
@@ -409,7 +409,12 @@ export const ManageEmailModal = (): JSX.Element => {
               ? onChangeEmail()
               : sendConfirmationCode();
           }}
-          disabled={errorOrLoading}
+          disabled={
+            errorOrLoading ||
+            (emailManagerState ===
+              EmailManagerState.changeEmailEnterConfirmationCode &&
+              !confirmationCode)
+          }
         >
           {textOrLoader(
             emailManagerState ===

--- a/apps/passport-client/new-components/shared/Modals/ManageEmailsModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/ManageEmailsModal.tsx
@@ -497,7 +497,7 @@ export const ManageEmailModal = (): JSX.Element => {
             verifyCode();
             reset();
           }}
-          disabled={errorOrLoading}
+          disabled={errorOrLoading || !confirmationCode}
         >
           {textOrLoader("Verify")}
         </Button2>

--- a/apps/passport-client/new-components/shared/Modals/ManageEmailsModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/ManageEmailsModal.tsx
@@ -387,13 +387,15 @@ export const ManageEmailModal = (): JSX.Element => {
           setNewEmail(e.target.value);
           setError("");
         }}
-        error={error}
       />
       {emailManagerState ===
         EmailManagerState.changeEmailEnterConfirmationCode && (
         <Input2
           variant="secondary"
-          onChange={(e) => setConfirmationCode(e.target.value)}
+          onChange={(e) => {
+            setConfirmationCode(e.target.value);
+            setError("");
+          }}
           value={confirmationCode}
           error={error}
           placeholder="Enter confirmation code"


### PR DESCRIPTION
in this PR we fix errors in `ManageEmailModal`

1. The “Verify” button in the enterCodeContainer is now disabled when the input field is empty.
2. The error message for an incorrect confirmation code has been removed from the email input field.
3. After receiving an incorrect confirmation code, changing the code input will now reset the error state properly.



https://github.com/user-attachments/assets/9fdc2721-f1cf-4681-8aee-2aeb23a557e2

![Screenshot 2024-10-14 at 16 53 21](https://github.com/user-attachments/assets/12ca2923-deb2-4925-96a1-e8bd35e1878a)
