### PR TITLE
Revert imageUrl to its old logic

### DIFF
--- a/packages/ui/eddsa-ticket-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/eddsa-ticket-pcd-ui/src/CardBody.tsx
@@ -77,18 +77,13 @@ function EdDSATicketPCDCardBody({
     return (
       <NEW_UI__Container>
         <NEW_UI__TicketImageContainer ref={ticketImageRef}>
-          {!ticketData?.qrCodeOverrideImageUrl && (
-            <TicketQR
-              pcd={pcd}
-              identityPCD={identityPCD}
-              verifyURL={verifyURL}
-              idBasedVerifyURL={idBasedVerifyURL}
-              zk={zk}
-            />
-          )}
-          {ticketData?.qrCodeOverrideImageUrl && (
-            <TicketImage pcd={pcd} hidePadding={true} />
-          )}
+          <TicketQR
+            pcd={pcd}
+            identityPCD={identityPCD}
+            verifyURL={verifyURL}
+            idBasedVerifyURL={idBasedVerifyURL}
+            zk={zk}
+          />
           <NEW_UI__InfoContainer>
             <NEW_UI__AttendeeName>
               {ticketData?.attendeeName.toUpperCase() || "Unknown"}
@@ -175,12 +170,11 @@ function TicketImage({
   pcd: EdDSATicketPCD;
   hidePadding?: boolean;
 }): JSX.Element {
-  const { qrCodeOverrideImageUrl, imageAltText } = pcd.claim.ticket;
-  if (hidePadding)
-    return <img src={qrCodeOverrideImageUrl} alt={imageAltText} />;
+  const { imageUrl, imageAltText } = pcd.claim.ticket;
+  if (hidePadding) return <img src={imageUrl} alt={imageAltText} />;
   return (
     <div style={{ padding: "8px" }}>
-      <img src={qrCodeOverrideImageUrl} alt={imageAltText} />
+      <img src={imageUrl} alt={imageAltText} />
     </div>
   );
 }

--- a/packages/ui/pod-ticket-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/pod-ticket-pcd-ui/src/CardBody.tsx
@@ -57,15 +57,10 @@ export function PODTicketCardBodyImpl({
     return (
       <NEW_UI__Container>
         <NEW_UI__TicketImageContainer ref={ticketImageRef}>
-          {!ticketData.qrCodeOverrideImageUrl && (
-            <TicketQR
-              ticketData={ticketData}
-              idBasedVerifyURL={idBasedVerifyURL}
-            />
-          )}
-          {ticketData.qrCodeOverrideImageUrl && (
-            <TicketImage hidePadding={true} ticketData={ticketData} />
-          )}
+          <TicketQR
+            ticketData={ticketData}
+            idBasedVerifyURL={idBasedVerifyURL}
+          />
           <NEW_UI__InfoContainer>
             <NEW_UI__AttendeeName>
               {ticketData?.attendeeName.toUpperCase() || "Unknown"}
@@ -211,11 +206,11 @@ function TicketImage({
   ticketData: IPODTicketData;
   hidePadding?: boolean;
 }): JSX.Element {
-  const { imageAltText, qrCodeOverrideImageUrl } = ticketData;
-  if (hidePadding) return <img src={qrCodeOverrideImageUrl} />;
+  const { imageUrl, imageAltText } = ticketData;
+  if (hidePadding) return <img src={imageUrl} alt={imageAltText} />;
   return (
     <div style={{ padding: "8px" }}>
-      <img src={qrCodeOverrideImageUrl} alt={imageAltText} />
+      <img src={imageUrl} alt={imageAltText} />
     </div>
   );
 }


### PR DESCRIPTION
Reverts a change in #1942 -- we keep `imageUrl` rendering on the CardBody of EdDSATicketPCD and PODTIcketPCD with its previous behavior given that many pipelines (particularly, CSV pipelines) already use this logic.

We would like for the new UI to also use this `imageUrl` logic as well, but won't touch it for now -- may add something to the phase 3 pull request.
