### PR TITLE
Expose functions to allow external provers/verifiers

### DIFF
--- a/packages/lib/gpc/src/gpc.ts
+++ b/packages/lib/gpc/src/gpc.ts
@@ -2,6 +2,9 @@ import {
   PROTO_POD_GPC_FAMILY_NAME,
   ProtoPODGPC,
   ProtoPODGPCCircuitDesc,
+  ProtoPODGPCInputs,
+  ProtoPODGPCOutputs,
+  ProtoPODGPCPublicInputs,
   githubDownloadRootURL,
   gpcArtifactPaths,
   unpkgDownloadRootURL
@@ -142,6 +145,91 @@ export function gpcCheckProvable(
 }
 
 /**
+ * Performs only the preparatory steps of {@link gpcProve}, returning all of
+ * the circuit-related info needed to generate a proof using the
+ * {@link @pcd/gpcircuits} package, or another user-supplied proving stack.
+ *
+ * Inputs will be fully validated for structural soundness in the same way as
+ * when generating a proof.  See {@link gpcProve} for more details on inputs
+ * and operation.
+ *
+ * @param proofConfig the configuration specifying the constraints to be proven.
+ * @param proofInputs the input data (PODs and other values) specific to this
+ *  proof.
+ * @param [circuitFamily=DefaultCircuitFamily] the circuit family to pick
+ *   the circuit from. This must be sorted in order of increasing circuit size
+ *   (constraint count).
+ * @returns info necessary to generate a proof with a specific circuit,
+ *   including the bound proof config, circuit description, and its public
+ *   and private input signals
+ * @throws TypeError if any of the arguments is malformed
+ * @throws Error if it is impossible to create a valid proof
+ */
+export function gpcPreProve(
+  proofConfig: GPCProofConfig,
+  proofInputs: GPCProofInputs,
+  circuitFamily: GPCCircuitFamily = DefaultCircuitFamily
+): {
+  boundConfig: GPCBoundConfig;
+  circuitDesc: ProtoPODGPCCircuitDesc;
+  circuitInputs: ProtoPODGPCInputs;
+} {
+  const { boundConfig, circuitDesc } = gpcCheckProvable(
+    proofConfig,
+    proofInputs,
+    circuitFamily
+  );
+
+  const circuitInputs = compileProofConfig(
+    boundConfig,
+    proofInputs,
+    circuitDesc
+  );
+
+  return { boundConfig, circuitDesc, circuitInputs };
+}
+
+/**
+ * Performs only the post-processing steps of {@link gpcProve}, taking in a
+ * proof already genereated using the {@link @pcd/gpcircuits} package, or
+ * another user-supplied proving stack.  The circuit-specific outputs are
+ * processed into the {@link GPCRevealedClaims} to produce the normal output
+ * of {@link gpcProve}.
+ *
+ * The config and inputs are assumed to have already been processed by
+ * {@link gpcPreProve}, so will not be fully validated by this function.
+ * See {@link gpcProve} for more details on inputs, outputs and operation.
+ *
+ * @param proof the Groth16 proof
+ * @param boundConfig the bound configuration specifying the constraints
+ *   proven, and the specific circuit which was used.
+ * @param proofInputs the input data (PODs and other values) specific to this
+ *  proof.
+ * @returns The Groth16 proof, a bound configuration usable for reliable
+ *   verification or future proofs (see {@link GPCBoundConfig}), and the
+ *   revealed claims of this proof (see {@link GPCRevealedClaims}).
+ * @throws TypeError if any of the arguments is malformed
+ * @throws Error if it is impossible to create a valid proof
+ */
+export function gpcPostProve(
+  proof: GPCProof,
+  boundConfig: GPCBoundConfig,
+  proofInputs: GPCProofInputs,
+  circuitOutputs: ProtoPODGPCOutputs
+): {
+  proof: GPCProof;
+  boundConfig: GPCBoundConfig;
+  revealedClaims: GPCRevealedClaims;
+} {
+  const revealedClaims = makeRevealedClaims(
+    boundConfig,
+    proofInputs,
+    circuitOutputs
+  );
+  return { proof, boundConfig, revealedClaims };
+}
+
+/**
  * Generates a GPC proof for the given configuration and inputs.  See the
  * documentation of the input and output types for more details:
  * {@link GPCProofConfig}, {@link GPCProofInputs}, {@link GPCBoundConfig}, and
@@ -178,7 +266,7 @@ export async function gpcProve(
   boundConfig: GPCBoundConfig;
   revealedClaims: GPCRevealedClaims;
 }> {
-  const { boundConfig, circuitDesc } = gpcCheckProvable(
+  const { boundConfig, circuitDesc, circuitInputs } = gpcPreProve(
     proofConfig,
     proofInputs,
     circuitFamily
@@ -186,23 +274,58 @@ export async function gpcProve(
 
   const artifactPaths = gpcArtifactPaths(pathToArtifacts, circuitDesc);
 
-  const circuitInputs = compileProofConfig(
-    boundConfig,
-    proofInputs,
-    circuitDesc
-  );
-
   const { proof, outputs: circuitOutputs } = await ProtoPODGPC.prove(
     circuitInputs,
     artifactPaths.wasmPath,
     artifactPaths.pkeyPath
   );
-  const revealedClaims = makeRevealedClaims(
-    boundConfig,
-    proofInputs,
-    circuitOutputs
+
+  return gpcPostProve(proof, boundConfig, proofInputs, circuitOutputs);
+}
+
+/**
+ * Performs only the preparatory steps of {@link gpcVerify}, returning all of
+ * the circuit-related info needed to verify a proof using the
+ * {@link @pcd/gpcircuits} package, or another user-supplied verification stack.
+ *
+ * Inputs will be fully validated for structural soundness, but not
+ * cryptographically.  See {@link gpcVerify} for more details on inputs and
+ * operation.
+ *
+ * @param boundConfig the bound configuration specifying the constraints
+ *   proven, and the specific circuit which was used.
+ * @param revealedClaims the revealed parts of the proof inputs and outputs.
+ * @param [circuitFamily=DefaultCircuitFamily] the circuit family to pick
+ *   the circuit from. This must be sorted in order of increasing circuit size
+ *   (constraint count).
+ * @returns info necessary to verify a proof with a specific circuit, including
+ *   the circuit description, and its public input and output signals
+ * @throws TypeError if any of the arguments is malformed
+ * @throws Error if the proof cannot be verified
+ */
+export function gpcPreVerify(
+  boundConfig: GPCBoundConfig,
+  revealedClaims: GPCRevealedClaims,
+  circuitFamily: GPCCircuitFamily = DefaultCircuitFamily
+): {
+  circuitDesc: ProtoPODGPCCircuitDesc;
+  circuitPublicInputs: ProtoPODGPCPublicInputs;
+  circuitOutputs: ProtoPODGPCOutputs;
+} {
+  const circuitReq = checkVerifyArgs(boundConfig, revealedClaims);
+  const circuitDesc = checkCircuitRequirements(
+    circuitReq,
+    circuitFamily,
+    boundConfig.circuitIdentifier
   );
-  return { proof, boundConfig, revealedClaims };
+
+  const { circuitPublicInputs, circuitOutputs } = compileVerifyConfig(
+    boundConfig,
+    revealedClaims,
+    circuitDesc
+  );
+
+  return { circuitDesc, circuitPublicInputs, circuitOutputs };
 }
 
 /**
@@ -236,17 +359,10 @@ export async function gpcVerify(
   pathToArtifacts: string,
   circuitFamily: GPCCircuitFamily = DefaultCircuitFamily
 ): Promise<boolean> {
-  const circuitReq = checkVerifyArgs(boundConfig, revealedClaims);
-  const circuitDesc = checkCircuitRequirements(
-    circuitReq,
-    circuitFamily,
-    boundConfig.circuitIdentifier
-  );
-
-  const { circuitPublicInputs, circuitOutputs } = compileVerifyConfig(
+  const { circuitDesc, circuitPublicInputs, circuitOutputs } = gpcPreVerify(
     boundConfig,
     revealedClaims,
-    circuitDesc
+    circuitFamily
   );
 
   return await ProtoPODGPC.verify(

--- a/packages/lib/gpc/src/index.ts
+++ b/packages/lib/gpc/src/index.ts
@@ -3,3 +3,12 @@ export * from "./gpc";
 export * from "./gpcJSON";
 export * from "./gpcSerialize";
 export * from "./gpcTypes";
+
+// TODO(POD-P4): Make these hidden again if they're unneded.  The pre/post
+// prove/verify steps should cover the need, but making these available to
+// devs gives them an alternative.
+export {
+  compileProofConfig,
+  compileVerifyConfig,
+  makeRevealedClaims
+} from "./gpcCompile";

--- a/packages/lib/gpc/test/gpc.spec.ts
+++ b/packages/lib/gpc/test/gpc.spec.ts
@@ -1,4 +1,8 @@
-import { ProtoPODGPCCircuitDesc } from "@pcd/gpcircuits";
+import {
+  ProtoPODGPC,
+  ProtoPODGPCCircuitDesc,
+  gpcArtifactPaths
+} from "@pcd/gpcircuits";
 import {
   POD,
   PODCryptographicValue,
@@ -31,7 +35,10 @@ import {
   gpcCheckProvable as _gpcCheckProvable,
   gpcProve as _gpcProve,
   gpcVerify as _gpcVerify,
-  gpcArtifactDownloadURL
+  gpcArtifactDownloadURL,
+  gpcPostProve,
+  gpcPreProve,
+  gpcPreVerify
 } from "../src";
 import { makeCircuitIdentifier, makeWatermarkSignal } from "../src/gpcUtil";
 import {
@@ -203,6 +210,68 @@ describe(`gpc library (Compiled ${circuitParamType} artifacts) should work`, asy
       proofConfig,
       proofInputs,
       expectedRevealedClaims
+    );
+    expect(isVerified).to.be.true;
+
+    // For this small case, the library should auto-pick the smallest circuit.
+    expect(boundConfig.circuitIdentifier).to.eq(
+      makeCircuitIdentifier(testCircuitFamily[0])
+    );
+  });
+
+  it("should prove and verify with pre/post and separate proving system", async function () {
+    const { proofConfig, proofInputs, expectedRevealedClaims } =
+      makeMinimalArgs();
+
+    const {
+      boundConfig: orgBoundConfig,
+      circuitDesc: pCircuitDesc,
+      circuitInputs
+    } = gpcPreProve(proofConfig, proofInputs, testCircuitFamily);
+
+    const artifactPaths = gpcArtifactPaths(
+      GPC_TEST_ARTIFACTS_PATH,
+      pCircuitDesc
+    );
+
+    const { proof: orgProof, outputs: pCircuitOutputs } =
+      await ProtoPODGPC.prove(
+        circuitInputs,
+        artifactPaths.wasmPath,
+        artifactPaths.pkeyPath
+      );
+
+    const { proof, boundConfig, revealedClaims } = gpcPostProve(
+      orgProof,
+      orgBoundConfig,
+      proofInputs,
+      pCircuitOutputs
+    );
+
+    // There's nothing non-canonical about our input, so boundConfig should
+    // only differ by circuit selection.
+    const manuallyBoundConfig = {
+      ...proofConfig,
+      circuitIdentifier: boundConfig.circuitIdentifier
+    };
+    expect(boundConfig).to.deep.eq(manuallyBoundConfig);
+
+    expect(revealedClaims).to.deep.eq(expectedRevealedClaims);
+
+    const {
+      circuitDesc: vCircuitDesc,
+      circuitPublicInputs,
+      circuitOutputs: vCircuitOutputs
+    } = gpcPreVerify(boundConfig, revealedClaims, testCircuitFamily);
+
+    expect(pCircuitDesc).to.deep.eq(vCircuitDesc);
+    expect(pCircuitOutputs).to.deep.eq(vCircuitOutputs);
+
+    const isVerified = await ProtoPODGPC.verify(
+      gpcArtifactPaths(GPC_TEST_ARTIFACTS_PATH, vCircuitDesc).vkeyPath,
+      proof,
+      circuitPublicInputs,
+      vCircuitOutputs
     );
     expect(isVerified).to.be.true;
 


### PR DESCRIPTION
Splits out parts of gpcProve and gpcVerify into pre/post functions which return circuit inputs/outputs.  This allows the proving/verifying part to be done separately, and thus replaced with another (compatible) system.  The specific use case for this immediately is on-chain verification, for which gpcPreVerify should provide the necessary inputs.  gpcPreProve and gpcPostProve are unneeded for now, but could allow someone to plug in and test a different proof stack if desried.

I also exposed the 3 key compiler functions behind these functions, in case the pre/post functions don't fully meet the need.  There's a TODO to re-hide those if they aren't necessary in future.