### PR TITLE
Add deriveSignerPublicKey helper function

### DIFF
--- a/packages/lib/pod/src/podCrypto.ts
+++ b/packages/lib/pod/src/podCrypto.ts
@@ -194,6 +194,23 @@ export function decodeSignature(encodedSignature: string): Signature<bigint> {
 }
 
 /**
+ * Calculates the corresponding public key for the given private key.  This is
+ * equivalent to the calculation performed in {@link signPODRoot}, and can be
+ * used to pre-publish the expected public key to clients before signing.
+ *
+ * @param privateKey the signer's private key, which is 32 bytes encoded as
+ *   per {@link encodePrivateKey}.
+ * @returns The signer's public key, which is 32 bytes encoded as per
+ *   {@link encodePublicKey}.
+ * @throws TypeError if any of the individual arguments is incorrectly formatted
+ */
+export function deriveSignerPublicKey(privateKey: string): string {
+  const privateKeyBytes = decodePrivateKey(privateKey);
+  const unpackedPublicKey = derivePublicKey(privateKeyBytes);
+  return encodePublicKey(unpackedPublicKey);
+}
+
+/**
  * Signs a POD's root hash.
  *
  * @param root the root hash (content ID) of the POD.

--- a/packages/lib/pod/test/podCrypto.spec.ts
+++ b/packages/lib/pod/test/podCrypto.spec.ts
@@ -20,6 +20,7 @@ import {
   decodePrivateKey,
   decodePublicKey,
   decodeSignature,
+  deriveSignerPublicKey,
   encodePrivateKey,
   encodePublicKey,
   encodeSignature,
@@ -491,6 +492,7 @@ describe("podCrypto signing should work", async function () {
         const { signature, publicKey } = signPODRoot(fakeRoot, testPrivateKey);
         checkSignatureFormat(signature);
         checkPublicKeyFormat(publicKey);
+        expect(publicKey).to.eq(deriveSignerPublicKey(testPrivateKey));
 
         const isValid = verifyPODRootSignature(fakeRoot, signature, publicKey);
         expect(isValid).to.be.true;
@@ -509,6 +511,18 @@ describe("podCrypto signing should work", async function () {
 
     ({ signature, publicKey } = signPODRoot(expectedContentID2, privateKey));
     expect(signature).to.eq(expectedSignature2);
+    expect(publicKey).to.eq(expectedPublicKey);
+  });
+
+  it("derived public keys should match expected values", function () {
+    // This test exists to detect breaking changes in future which could
+    // impact the compatibility of saved PODs.  If sample inputs changed, you
+    // can simply change the expected outputs.  Otherwise think about why
+    // these values changed.
+    let publicKey = deriveSignerPublicKey(privateKey);
+    expect(publicKey).to.eq(expectedPublicKey);
+
+    publicKey = deriveSignerPublicKey(privateKey);
     expect(publicKey).to.eq(expectedPublicKey);
   });
 


### PR DESCRIPTION
This was a request from ZuKyc, which I expect to come up a lot.  Servers need to publish their public key separate from signing anything, and they should be able to do it using the POD library, not by going straight to zk-kit.

Closes https://linear.app/0xparc-pcd/issue/0XP-1074/pod-helper-function-for-private-public-key