### PR TITLE
Fix missing client parameter for expiry of old cache entries

### DIFF
--- a/apps/passport-server/src/services/persistentCacheService.ts
+++ b/apps/passport-server/src/services/persistentCacheService.ts
@@ -38,6 +38,8 @@ export class PersistentCacheService {
   public start(): void {
     logger("[CACHE] starting expiration loop");
 
+    this.tryExpireOldEntries();
+
     this.expirationInterval = setInterval(
       this.tryExpireOldEntries.bind(this),
       PersistentCacheService.CACHE_GARBAGE_COLLECT_INTERVAL_MS
@@ -71,7 +73,7 @@ export class PersistentCacheService {
   }
 
   private async tryExpireOldEntries(): Promise<void> {
-    namedSqlTransaction(
+    return namedSqlTransaction(
       this.pool,
       "tryExpireOldEntries",
       async (client): Promise<void> => {


### PR DESCRIPTION
When switching to using transactions, we started passing client objects into functions that make SQL queries. `tryExpireOldEntries` is called on a timer, without a parameter, so it doesn't receive a client object, and it fails when calling lower-level DB access functions.

I've switched transaction opening around a bit, so that the transaction is opened inside the function rather than outside of it, and changed the only other place where this function is called to account for that.