### PR TITLE
Add support for setting the circuit identifier in Z API calls

### DIFF
--- a/apps/passport-client/components/screens/EmbeddedScreens/EmbeddedGPCProofScreen.tsx
+++ b/apps/passport-client/components/screens/EmbeddedScreens/EmbeddedGPCProofScreen.tsx
@@ -1,7 +1,7 @@
 import { ProveResult } from "@parcnet-js/client-rpc";
 import * as p from "@parcnet-js/podspec";
 import { EntriesSchema, PodspecProofRequest } from "@parcnet-js/podspec";
-import { gpcProve } from "@pcd/gpc";
+import { GPCIdentifier, gpcProve } from "@pcd/gpc";
 import { Button, Spacer } from "@pcd/passport-ui";
 import { POD, POD_INT_MAX, POD_INT_MIN } from "@pcd/pod";
 import {
@@ -22,10 +22,12 @@ import { Spinner } from "../../shared/Spinner";
 export function EmbeddedGPCProofScreen({
   proofRequestSchema,
   collectionIds,
+  circuitIdentifier,
   callback
 }: {
   proofRequestSchema: PodspecProofRequest;
   collectionIds: string[];
+  circuitIdentifier?: GPCIdentifier;
   callback: (result: ProveResult) => void;
 }): ReactNode {
   useSyncE2EEStorage();
@@ -53,7 +55,6 @@ export function EmbeddedGPCProofScreen({
     return pods;
   }, [pcds, collectionIds]);
   const candidatePODs = useMemo(() => {
-    // @ts-expect-error not a meaningful type mismatch
     return prs.queryForInputs(allPods);
   }, [allPods, prs]);
   const proofRequest = useMemo(() => {
@@ -92,7 +93,6 @@ export function EmbeddedGPCProofScreen({
               key={name}
               name={name}
               schema={schema}
-              // @ts-expect-error not a meaningful type mismatch
               pods={candidatePODs[name]}
               selectedPOD={selectedPODs[name]}
               onChange={(pod) => {
@@ -112,7 +112,10 @@ export function EmbeddedGPCProofScreen({
               setProving(true);
 
               gpcProve(
-                proofRequest.proofConfig,
+                {
+                  ...proofRequest.proofConfig,
+                  ...(circuitIdentifier ? { circuitIdentifier } : {})
+                },
                 {
                   pods: selectedPODs as Record<string, POD>,
                   membershipLists: proofRequest.membershipLists,

--- a/apps/passport-client/components/screens/EmbeddedScreens/EmbeddedSignPODScreen.tsx
+++ b/apps/passport-client/components/screens/EmbeddedScreens/EmbeddedSignPODScreen.tsx
@@ -64,7 +64,6 @@ export function EmbeddedSignPODScreen({
         </EntriesGrid>
         <Spacer h={4} />
         <div>
-          {/* @ts-expect-error not a meaningful type mismatch */}
           <Button onClick={() => callback(podToPODData(pod))}>Sign</Button>
           <Spacer h={16} />
           <Button onClick={onCancel} style="secondary">

--- a/apps/passport-client/package.json
+++ b/apps/passport-client/package.json
@@ -18,9 +18,9 @@
   "dependencies": {
     "@babel/runtime": "^7.24.0",
     "@heroicons/react": "^2.1.5",
-    "@parcnet-js/client-helpers": "^1.0.2",
-    "@parcnet-js/client-rpc": "^1.1.1",
-    "@parcnet-js/podspec": "^1.1.0",
+    "@parcnet-js/client-helpers": "^1.0.5",
+    "@parcnet-js/client-rpc": "^1.1.4",
+    "@parcnet-js/podspec": "^1.1.2",
     "@pcd/client-shared": "0.3.0",
     "@pcd/eddsa-frog-pcd": "0.6.0",
     "@pcd/eddsa-frog-pcd-ui": "0.5.0",

--- a/apps/passport-client/src/embedded.ts
+++ b/apps/passport-client/src/embedded.ts
@@ -1,5 +1,6 @@
 import { ProveResult } from "@parcnet-js/client-rpc";
 import { PODData, PodspecProofRequest } from "@parcnet-js/podspec";
+import type { GPCIdentifier } from "@pcd/gpc";
 import { PCDGetRequest } from "@pcd/passport-interface";
 import { SerializedPCD } from "@pcd/pcd-types";
 import type { PODEntries } from "@pcd/pod";
@@ -20,6 +21,7 @@ export interface EmbeddedGPCProof {
   type: EmbeddedScreenType.EmbeddedGPCProof;
   proofRequest: PodspecProofRequest;
   collectionIds: string[];
+  circuitIdentifier?: GPCIdentifier;
   callback: (result: ProveResult) => void;
 }
 

--- a/apps/passport-client/src/zapp/ZappServer.ts
+++ b/apps/passport-client/src/zapp/ZappServer.ts
@@ -14,6 +14,7 @@ import {
 import * as p from "@parcnet-js/podspec";
 import {
   GPCBoundConfig,
+  GPCIdentifier,
   GPCProof,
   GPCRevealedClaims,
   gpcVerify
@@ -147,7 +148,6 @@ class ZupassPODRPC extends BaseZappServer implements ParcnetPODRPC {
       collectionId
     ]);
 
-    // @ts-expect-error not a meaningful type mismatch
     const result = p.pod(query).query(pods);
 
     return result.matches.map(p.podToPODData);
@@ -250,7 +250,6 @@ class ZupassPODRPC extends BaseZappServer implements ParcnetPODRPC {
           )
         )
       );
-      // @ts-expect-error not a meaningful type mismatch
       return p.podToPODData(pod);
     }
     return new Promise((resolve, reject) => {
@@ -314,7 +313,6 @@ class ZupassPODRPC extends BaseZappServer implements ParcnetPODRPC {
         )
       )
     );
-    // @ts-expect-error not a meaningful type mismatch
     return p.podToPODData(pod);
   }
 }
@@ -349,10 +347,12 @@ class ZupassGPCRPC extends BaseZappServer implements ParcnetGPCRPC {
 
   public async prove({
     request,
-    collectionIds
+    collectionIds,
+    circuitIdentifier
   }: {
     request: p.PodspecProofRequest;
     collectionIds?: string[];
+    circuitIdentifier?: GPCIdentifier;
   }): Promise<ProveResult> {
     const realCollectionIds =
       collectionIds ?? this.getPermissions().REQUEST_PROOF?.collections ?? [];
@@ -373,7 +373,6 @@ class ZupassGPCRPC extends BaseZappServer implements ParcnetGPCRPC {
 
     pods.push(...ticketPods);
 
-    // @ts-expect-error not a meaningful type mismatch
     const inputPods = prs.queryForInputs(pods);
     if (
       Object.values(inputPods).some((candidates) => candidates.length === 0)
@@ -391,6 +390,7 @@ class ZupassGPCRPC extends BaseZappServer implements ParcnetGPCRPC {
           type: EmbeddedScreenType.EmbeddedGPCProof,
           proofRequest: request,
           collectionIds: realCollectionIds,
+          circuitIdentifier,
           callback: (result: ProveResult) => {
             this.getContext().dispatch({
               type: "hide-embedded-screen"
@@ -446,7 +446,6 @@ class ZupassGPCRPC extends BaseZappServer implements ParcnetGPCRPC {
     const pods = this.getPODsIfPermitted(collectionIds, "gpc.canProve");
     const prs = p.proofRequest(request);
 
-    // @ts-expect-error not a meaningful type mismatch
     const inputPods = prs.queryForInputs(pods);
     return Object.values(inputPods).every(
       (candidates) => candidates.length > 0

--- a/apps/passport-client/src/zapp/query_subscription_manager.ts
+++ b/apps/passport-client/src/zapp/query_subscription_manager.ts
@@ -106,7 +106,6 @@ export class QuerySubscriptionManager {
         }
 
         // Input data has changed, so we need to re-run the query.
-        // @ts-expect-error not a meaningful type mismatch
         const queryResult = subscription.query.query(pods);
         const newOutputSignatures = queryResult.matches.map(
           (pod) => pod.signature
@@ -128,7 +127,6 @@ export class QuerySubscriptionManager {
         this.emitter.emit(
           "subscriptionUpdated",
           subscription.id,
-          // @ts-expect-error not a meaningful type mismatch
           queryResult.matches.map((pod) => p.podToPODData(pod as POD)),
           subscription.serial
         );

--- a/apps/passport-client/src/zapp/useZappServer.ts
+++ b/apps/passport-client/src/zapp/useZappServer.ts
@@ -80,7 +80,6 @@ function isAlreadyAuthorized(
     }
   });
 
-  // @ts-expect-error not a meaningful type mismatch
   const existingPODQuery = appPodSpec.query(zappPODs);
   if (existingPODQuery.matches.length === 1) {
     try {

--- a/examples/test-zapp/package.json
+++ b/examples/test-zapp/package.json
@@ -10,11 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pcd/pod": "0.4.0",
-    "@parcnet-js/podspec": "^1.1.0",
-    "@parcnet-js/ticket-spec": "^1.1.1",
-    "@parcnet-js/client-rpc": "^1.1.1",
-    "@parcnet-js/app-connector": "^1.1.1",
+    "@pcd/pod": "^0.4.0",
+    "@parcnet-js/podspec": "^1.1.2",
+    "@parcnet-js/ticket-spec": "^1.1.4",
+    "@parcnet-js/client-rpc": "^1.1.4",
+    "@parcnet-js/app-connector": "^1.1.5",
     "json-bigint": "^1.0.0",
     "lodash": "^4.17.21",
     "react": "^18.2.0",

--- a/examples/test-zapp/src/apis/GPC.tsx
+++ b/examples/test-zapp/src/apis/GPC.tsx
@@ -132,13 +132,7 @@ const gpcProof = await z.gpc.prove({ request });
           <TryIt
             onClick={async () => {
               try {
-                setProveResult(
-                  await z.gpc.prove({
-                    request,
-                    circuitIdentifier:
-                      "proto-pod-gpc_3o-10e-8md-4nv-2ei-2x20l-2x2t-0ov3-1ov4"
-                  })
-                );
+                setProveResult(await z.gpc.prove({ request }));
               } catch (e) {
                 console.log(e);
               }

--- a/examples/test-zapp/src/apis/GPC.tsx
+++ b/examples/test-zapp/src/apis/GPC.tsx
@@ -132,7 +132,13 @@ const gpcProof = await z.gpc.prove({ request });
           <TryIt
             onClick={async () => {
               try {
-                setProveResult(await z.gpc.prove({ request }));
+                setProveResult(
+                  await z.gpc.prove({
+                    request,
+                    circuitIdentifier:
+                      "proto-pod-gpc_3o-10e-8md-4nv-2ei-2x20l-2x2t-0ov3-1ov4"
+                  })
+                );
               } catch (e) {
                 console.log(e);
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,11 +1373,6 @@
   resolved "https://registry.yarnpkg.com/@bedrock-layout/use-stateful-ref/-/use-stateful-ref-1.4.1.tgz#c543c61d15885e19506f068618a4d6427a5bf817"
   integrity sha512-4eKO2KdQEXcR5LI4QcxqlJykJUDQJWDeWYAukIn6sRQYoabcfI5kDl61PUi6FR6o8VFgQ8IEP7HleKqWlSe8SQ==
 
-"@brenoroosevelt/toast@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@brenoroosevelt/toast/-/toast-2.0.3.tgz#429772acccb8728c8ee7f8583295a30261c71745"
-  integrity sha512-Tivp/tA5EUkQFP9LVmop8Y9EuxVtuom8x+5gYOFjfib/1oATX7QWAc4cKSELd36HoeDIThXD3vDxTy2FVUsRBA==
-
 "@cbor-extract/cbor-extract-darwin-arm64@2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.1.1.tgz#5721f6dd3feae0b96d23122853ce977e0671b7a6"
@@ -5181,77 +5176,51 @@
     browser-or-node "^2.0.0"
     cross-fetch "^3.0.6"
 
-"@parcnet-js/app-connector@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@parcnet-js/app-connector/-/app-connector-1.1.1.tgz#bd35aae8861a5ff023afc8ac74af8803cd6c321b"
-  integrity sha512-kvJ/rIyO23zzqxEIMlgimUc6zF3a08HbJ8NHfiJ6vNbQtoQZZEtf8xFiEFAL+Fe/zIJs5a2DMrUEHNY0fFDKdA==
+"@parcnet-js/app-connector@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@parcnet-js/app-connector/-/app-connector-1.1.5.tgz#6a17a88f50c90b9c355c3fa44d28786a6615a61c"
+  integrity sha512-Us7c/LotkNy4dE/zFn/JQpEqye6znUJblzZZmwoH/UgxTSZ+in18gkGAWQLYKeHAhH0V0KzD8USMtxjOFPrVbA==
   dependencies:
-    "@brenoroosevelt/toast" "^2.0.3"
-    "@parcnet-js/client-rpc" "1.1.1"
-    "@parcnet-js/podspec" "1.1.0"
-    "@pcd/gpc" "^0.2.0"
-    "@pcd/pod" "^0.3.0"
+    "@parcnet-js/client-rpc" "1.1.4"
+    "@parcnet-js/podspec" "1.1.2"
+    "@pcd/gpc" "^0.3.0"
+    "@pcd/pod" "^0.4.0"
     nanoevents "^9.0.0"
     valibot "^0.42.0"
 
-"@parcnet-js/client-helpers@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@parcnet-js/client-helpers/-/client-helpers-1.0.2.tgz#b6ac8c3ff296cdb36bbaa545daa674af51ea9943"
-  integrity sha512-ARDEHliZlvQ3TgVDV+6i8csmfnM32ae3h17r6uAaeWo22VMml3HrReZk4bYqs61QFoumxGct/bNJ39SagDop7w==
+"@parcnet-js/client-helpers@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@parcnet-js/client-helpers/-/client-helpers-1.0.5.tgz#b577d0c5b6672582b64d3e665d0da6fc05951dc4"
+  integrity sha512-Nl9Gl3CGFQ9tRxtyk5ufPpIXTJXKlehLUKsBXhJU+IxaGr/BmjALOgbAzIz5+0N9YoxpSlyF0kQxU8GIpGwxPw==
   dependencies:
-    "@parcnet-js/client-rpc" "1.1.1"
+    "@parcnet-js/client-rpc" "1.1.4"
     valibot "^0.42.0"
 
-"@parcnet-js/client-rpc@1.1.1", "@parcnet-js/client-rpc@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@parcnet-js/client-rpc/-/client-rpc-1.1.1.tgz#e1f6ada0107ab97509d26712c7c1afba2a6f2830"
-  integrity sha512-lIHyy/AQb3NCzNNGRoxmIr22nMpmPOnwxDRzT8BkYWcw/UDh5cZioyv9fHEaFo5GyWBrWG1pLDgAsek006cKRw==
+"@parcnet-js/client-rpc@1.1.4", "@parcnet-js/client-rpc@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@parcnet-js/client-rpc/-/client-rpc-1.1.4.tgz#8e46505426e5590ec309fb785aa91935f4bd3001"
+  integrity sha512-Q2WF1tZIll0cNhq2LsSebH9QFv2ETRdrreJjJQPZBvAbJrUK0mZ0TJ0hnUvF7CyVVl7KNr8BUzB89noIOFzylg==
   dependencies:
-    "@parcnet-js/podspec" "1.1.0"
-    "@pcd/gpc" "^0.2.0"
-    "@pcd/pod" "^0.3.0"
+    "@parcnet-js/podspec" "1.1.2"
+    "@pcd/gpc" "^0.3.0"
+    "@pcd/pod" "^0.4.0"
     valibot "^0.42.0"
 
-"@parcnet-js/podspec@1.1.0", "@parcnet-js/podspec@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@parcnet-js/podspec/-/podspec-1.1.0.tgz#be161ecc10370a179ac34736d348ea9352fade33"
-  integrity sha512-uFnITEppLWRWmRr4LxEr6eWNdJyyTBaDxQ8XGRcPAu46dEabPsYuYb8WRdAKIXUP6rQ0jWM7OMwpyknZ5fit6w==
+"@parcnet-js/podspec@1.1.2", "@parcnet-js/podspec@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@parcnet-js/podspec/-/podspec-1.1.2.tgz#a26c6573d5e4c3ac4c5db54d4410f20041967e75"
+  integrity sha512-XI7WUnAV2EwTWN5SRh52JnNaDqL2m5XQaDRcdyeKdQ0l3BnWWIWIck0LQ/tAvx+pagkl1ksmx7Yu0cB6uVRUZg==
   dependencies:
-    "@pcd/gpc" "0.2.0"
-    "@pcd/pod" "0.3.0"
+    "@pcd/gpc" "^0.3.0"
+    "@pcd/pod" "^0.4.0"
 
-"@parcnet-js/ticket-spec@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@parcnet-js/ticket-spec/-/ticket-spec-1.1.1.tgz#4b51b05da52d65ab9b66031b22f94e6760b0a4bb"
-  integrity sha512-EKXEtKnmL67ZIitDGiUQy4EPydsd/VYKdeqnre5jH5w+TnyfbCgKF3MWm85dfBRy25QH7cVJ9zjP5EdjOTQ77Q==
+"@parcnet-js/ticket-spec@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@parcnet-js/ticket-spec/-/ticket-spec-1.1.4.tgz#9e6e5b4d8a134779a620a04521893f32078dcbf7"
+  integrity sha512-fMapxCan+N6eZFtbivnAJTZ6dQzGIvJ8B++zQtR4equSWBpRktrwEvQeOe7lPWIbI6iItehzrNun9sBo9X3fQw==
   dependencies:
-    "@parcnet-js/client-rpc" "1.1.1"
-    "@parcnet-js/podspec" "1.1.0"
-
-"@pcd/gpc@0.2.0", "@pcd/gpc@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@pcd/gpc/-/gpc-0.2.0.tgz#72a6f286e0376fddc16020383d4d38eeb2d83545"
-  integrity sha512-1PIQdYzU4Dz9nT+F1CyS2Ygaa+tXN3jMiTO1OYUTLppgPYRaYsPjQOd/4lI8yABu2A5l9uhec2DctO7M2Q1vvQ==
-  dependencies:
-    "@pcd/gpcircuits" "0.3.0"
-    "@pcd/pod" "0.3.0"
-    "@pcd/util" "0.7.0"
-    "@semaphore-protocol/identity" "^3.15.2"
-    json-bigint "^1.0.0"
-    lodash "^4.17.21"
-    semaphore-identity-v4 "npm:@semaphore-protocol/identity@^4.0.3"
-    snarkjs "^0.7.4"
-    url-join "^4.0.1"
-
-"@pcd/gpcircuits@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@pcd/gpcircuits/-/gpcircuits-0.3.0.tgz#e1a939974181151985a28559e3e840d35729caa1"
-  integrity sha512-BZn+Cr6fp0lVXfLIJxYcG3PQN1Jio5DrPBRSugSMQNBU/Q8lOPwqGysICL+kIG2k7uZ4qp7wJ8ERGOsgQypp1g==
-  dependencies:
-    "@pcd/pod" "0.3.0"
-    fastfile "0.0.20"
-    snarkjs "^0.7.4"
-    url-join "4.0.1"
+    "@parcnet-js/client-rpc" "1.1.4"
+    "@parcnet-js/podspec" "1.1.2"
 
 "@pcd/libsodium-sumo@^0.7.15":
   version "0.7.15"
@@ -5265,34 +5234,10 @@
   dependencies:
     "@pcd/libsodium-sumo" "^0.7.15"
 
-"@pcd/pod@0.3.0", "@pcd/pod@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@pcd/pod/-/pod-0.3.0.tgz#4b6e041fc867a1d632d309dd3009d6845b26ae5d"
-  integrity sha512-7bWchkdMn1z+cZcNdNMl9t7WhFfhmbT3xVKojZWDxKW/cB60t/ohZ+SIgzf0/6TnY4NqRK+udsI3pn2D2wszmA==
-  dependencies:
-    "@pcd/util" "0.7.0"
-    "@zk-kit/eddsa-poseidon" "1.0.3"
-    "@zk-kit/lean-imt" "2.2.1"
-    "@zk-kit/utils" "1.2.1"
-    js-sha256 "^0.10.1"
-    json-bigint "^1.0.0"
-    poseidon-lite "^0.3.0"
-
 "@pcd/proto-pod-gpc-artifacts@0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pcd/proto-pod-gpc-artifacts/-/proto-pod-gpc-artifacts-0.11.0.tgz#4c7e09b10da1e731932d3916d63d090b5612714c"
   integrity sha512-k/lASCefq1vUyqRirHUAc+yiZAMhSfTJx51qnyImXl6ArW8LtNWRyeoTql2BjY9u3BM/mWN279S5+NtghwnsDw==
-
-"@pcd/util@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@pcd/util/-/util-0.7.0.tgz#7ab1f75edf303f1002ab6812dfa53ac073aae58e"
-  integrity sha512-LVSNKvTppLhqNvjwFyXm1eVPuIh8NglsFx4epy6/LiMtr6GfrFDou6+R7kT33CAfACDsyVf/vw15ugRCnN6h9A==
-  dependencies:
-    buffer "^6.0.3"
-    email-validator "^2.0.4"
-    js-sha256 "^0.10.1"
-    secure-random "^1.1.2"
-    uuid "^9.0.0"
 
 "@peculiar/asn1-android@^2.3.3":
   version "2.3.6"


### PR DESCRIPTION
This adds support for setting a circuit identifier on GPC proofs when invoked via the Z API.

This also bumps all of the Z API-related packages, allowing us to remove the @ts-expect-error comments from passport-client.