### PR TITLE
add search phase1

### DIFF
--- a/apps/passport-client/new-components/screens/Home/NewHomeScreen.tsx
+++ b/apps/passport-client/new-components/screens/Home/NewHomeScreen.tsx
@@ -251,6 +251,7 @@ const ListContainer = styled.div`
   border-radius: 20px;
   border: 2px solid var(--text-white);
   background: rgba(255, 255, 255, 0.8);
+  padding-top: 24px;
 
   box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.05);
   position: relative;
@@ -331,6 +332,9 @@ const NoUpcomingEventsState = ({
   const pods = usePCDCollection();
   const timer = useRef<NodeJS.Timeout>();
   const [showScrollIndicator, setShowScrollIndicator] = useState(false);
+  const [expandedGroupsIds, setExpandedGroupsIds] = useState<
+    Record<string, boolean>
+  >({});
   const [params] = useSearchParams();
   const listContainerRef = useRef<HTMLDivElement>(null);
 
@@ -443,7 +447,9 @@ const NoUpcomingEventsState = ({
                   modal: { modalType: "pods-collection", activePod: pcd }
                 });
               }}
-              style={{ padding: "20px 24px" }}
+              style={{ padding: "0 20px 24px" }}
+              expandedGroupsIds={expandedGroupsIds}
+              setExpandedGroupsIds={setExpandedGroupsIds}
             />
             {showScrollIndicator && <ScrollIndicator />}
           </ListContainer>

--- a/apps/passport-client/new-components/shared/List/ListItem.tsx
+++ b/apps/passport-client/new-components/shared/List/ListItem.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from "react";
-import { FaChevronRight } from "react-icons/fa";
+// import { FaChevronRight } from "react-icons/fa";
 import styled, { FlattenSimpleInterpolation, css } from "styled-components";
 import { Avatar } from "../Avatar";
 import { Typography } from "../Typography";
@@ -108,6 +108,7 @@ export const ListItem = ({
       variant={defaultVariant}
       onClick={onClick}
       isClickable={!!onClick}
+      style={{ paddingLeft: 24 }}
     >
       <IconContainer>{LeftIcon ? LeftIcon : <Avatar />}</IconContainer>
       <ListItemRightContainer showBottomBorder={defaultShowBottomBorder}>
@@ -129,7 +130,7 @@ export const ListItem = ({
             </ElipsisContainer>
           )}
         </Typography>
-        <FaChevronRight color="var(--text-tertiary)" />
+        {/* <FaChevronRight color="var(--text-tertiary)" /> */}
       </ListItemRightContainer>
     </ListItemContainer>
   );

--- a/apps/passport-client/new-components/shared/List/index.tsx
+++ b/apps/passport-client/new-components/shared/List/index.tsx
@@ -1,13 +1,15 @@
+import { ReactElement } from "react";
+import { FaChevronRight } from "react-icons/fa";
 import styled from "styled-components";
 import { Typography } from "../Typography";
 import { ListItem, ListItemType } from "./ListItem";
-import { ReactElement } from "react";
 
 export type GroupType = {
   children: ListItemType[];
   title?: string;
   isLastItemBorder?: boolean;
   id?: string;
+  expanded?: boolean;
 };
 
 type ListChild = GroupType | ListItemType;
@@ -21,29 +23,47 @@ const GroupContainer = styled.div`
 `;
 
 const ListGroup = ({
-  children,
-  title,
-  isLastItemBorder,
-  id
-}: GroupType): ReactElement => {
+  group,
+  onExpanded
+}: {
+  group: GroupType;
+  onExpanded?: (id: string, expanded: boolean) => void;
+}): ReactElement => {
+  const { children, title, expanded, isLastItemBorder, id } = group;
   const len = children.length;
   return (
     <GroupContainer key={id} id={id}>
-      <Typography fontWeight={500} color="var(--text-tertiary)" family="Rubik">
+      <Typography
+        onClick={() => onExpanded && id && onExpanded(id, !expanded)}
+        style={{ cursor: onExpanded ? "pointer" : "default" }}
+        fontWeight={500}
+        color="var(--text-tertiary)"
+        family="Rubik"
+      >
+        <FaChevronRight
+          color="var(--text-tertiary)"
+          style={{
+            transform: expanded ? "rotate(90deg)" : undefined,
+            transition: "transform 0.2s ease-in-out",
+            marginRight: 10,
+            verticalAlign: "text-top"
+          }}
+        />
         {title}
       </Typography>
-      {children.map((child, i) => {
-        if (i === len - 1) {
-          return (
-            <ListItem
-              {...child}
-              showBottomBorder={isLastItemBorder}
-              key={child.key}
-            />
-          );
-        }
-        return <ListItem {...child} key={child.key} />;
-      })}
+      {(!!expanded || !onExpanded) &&
+        children.map((child, i) => {
+          if (i === len - 1) {
+            return (
+              <ListItem
+                {...child}
+                showBottomBorder={isLastItemBorder}
+                key={child.key}
+              />
+            );
+          }
+          return <ListItem {...child} key={child.key} />;
+        })}
     </GroupContainer>
   );
 };
@@ -51,14 +71,15 @@ const ListGroup = ({
 type ListProps = {
   list: ListChild[];
   style?: React.CSSProperties;
+  onExpanded?: (id: string, expanded: boolean) => void;
 };
 
-export const List = ({ list, style }: ListProps): ReactElement => {
+export const List = ({ list, style, onExpanded }: ListProps): ReactElement => {
   return (
     <div style={style}>
       {list.map((child) => {
         return isListGroup(child) ? (
-          <ListGroup {...child} />
+          <ListGroup group={child} onExpanded={onExpanded} />
         ) : (
           <ListItem {...child} />
         );

--- a/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
@@ -161,8 +161,10 @@ export const PodsCollectionList = ({
     <>
       <SearchPodInputContainer>
         <Input2
-          autoFocus
           placeholder="Search for pods"
+          autoCapitalize="off"
+          autoCorrect="off"
+          type="text"
           variant="secondary"
           onChange={({ target: { value } }) => setSearchQuery(value)}
         />

--- a/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
@@ -161,7 +161,8 @@ export const PodsCollectionList = ({
     <>
       <SearchPodInputContainer>
         <Input2
-          placeholder="Search for pods..."
+          autoFocus
+          placeholder="Search for pods"
           variant="secondary"
           onChange={({ target: { value } }) => setSearchQuery(value)}
         />
@@ -182,6 +183,7 @@ export const PodsCollectionList = ({
 
 const SearchPodInputContainer = styled.div`
   padding: 24px;
+  padding-bottom: 0;
 `;
 
 export const PodsCollectionBottomModal = (): JSX.Element | null => {

--- a/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
@@ -14,6 +14,7 @@ import intersectionWith from "lodash/intersectionWith";
 import {
   ReactElement,
   ReactNode,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -77,16 +78,19 @@ const getPCDImage = (pcd: PCD<unknown, unknown>): ReactNode | undefined => {
 type PodsCollectionListProps = {
   onPodClick?: (pcd: PCD<unknown, unknown>) => void;
   style?: CSSProperties;
+  expandedGroupsIds: Record<string, boolean>;
+  setExpandedGroupsIds: React.Dispatch<
+    React.SetStateAction<Record<string, boolean>>
+  >;
 };
 export const PodsCollectionList = ({
   onPodClick,
-  style
+  style,
+  expandedGroupsIds,
+  setExpandedGroupsIds
 }: PodsCollectionListProps): ReactElement => {
   const pcdCollection = usePCDCollection();
   const [searchQuery, setSearchQuery] = useState<string>("");
-  const [expandedGroupsIds, setExpandedGroupsIds] = useState<
-    Record<string, boolean>
-  >({});
 
   const podsCollectionList = useMemo(() => {
     const allPcds = pcdCollection.getAll();
@@ -212,6 +216,10 @@ export const PodsCollectionBottomModal = (): JSX.Element | null => {
       ? activeBottomModal.modalGoBackBehavior
       : "close";
 
+  const [expandedGroupsIds, setExpandedGroupsIds] = useState<
+    Record<string, boolean>
+  >({});
+
   // Check scrollability
   const checkScrollability = (): void => {
     if (listContainerRef.current) {
@@ -252,6 +260,22 @@ export const PodsCollectionBottomModal = (): JSX.Element | null => {
     }
   }, [activePod, scrollPosition, params, setParams, isPodsCollectionModalOpen]);
 
+  const handlePodClick = useCallback(
+    (pcd: PCD<unknown, unknown>) => {
+      listContainerRef.current &&
+        setScrollPosition(listContainerRef.current.scrollTop);
+      dispatch({
+        type: "set-bottom-modal",
+        modal: {
+          modalType: "pods-collection",
+          activePod: pcd,
+          modalGoBackBehavior: "back"
+        }
+      });
+    },
+    [dispatch]
+  );
+
   return (
     <BottomModal
       modalContainerStyle={{ padding: 0, paddingTop: 24 }}
@@ -291,18 +315,9 @@ export const PodsCollectionBottomModal = (): JSX.Element | null => {
             <>
               <PodsCollectionList
                 style={{ padding: "12px 24px", paddingTop: 0 }}
-                onPodClick={(pcd) => {
-                  listContainerRef.current &&
-                    setScrollPosition(listContainerRef.current.scrollTop);
-                  dispatch({
-                    type: "set-bottom-modal",
-                    modal: {
-                      modalType: "pods-collection",
-                      activePod: pcd,
-                      modalGoBackBehavior: "back"
-                    }
-                  });
-                }}
+                onPodClick={handlePodClick}
+                expandedGroupsIds={expandedGroupsIds}
+                setExpandedGroupsIds={setExpandedGroupsIds}
               />
               {showScrollIndicator && <ScrollIndicator />}
             </>

--- a/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
@@ -32,6 +32,7 @@ import { ScrollIndicator } from "../../screens/Home/NewHomeScreen";
 import { Avatar } from "../Avatar";
 import { BottomModal } from "../BottomModal";
 import { Button2 } from "../Button";
+import { Input2 } from "../Input";
 import { GroupType, List } from "../List";
 import { Typography } from "../Typography";
 import { useOrientation } from "../utils";
@@ -82,7 +83,7 @@ export const PodsCollectionList = ({
   style
 }: PodsCollectionListProps): ReactElement => {
   const pcdCollection = usePCDCollection();
-
+  const [searchQuery, setSearchQuery] = useState<string>("");
   const podsCollectionList = useMemo(() => {
     const allPcds = pcdCollection.getAll();
     // If we have the same ticket in both POD and EDSA, we want to show only the POD one
@@ -121,11 +122,46 @@ export const PodsCollectionList = ({
       });
     }
 
-    return Object.values(result).filter((group) => group.children.length > 0);
-  }, [pcdCollection, onPodClick]);
+    return Object.values(result)
+      .map((group) => {
+        if (!searchQuery) {
+          return group;
+        }
 
-  return <List style={style} list={podsCollectionList} />;
+        if (
+          group.title &&
+          group.title.toLowerCase().includes(searchQuery.toLowerCase())
+        ) {
+          return group;
+        }
+
+        return {
+          ...group,
+          children: group.children.filter((pod) =>
+            pod.title.toLowerCase().includes(searchQuery.toLowerCase())
+          )
+        };
+      })
+      .filter((group) => group.children.length > 0);
+  }, [pcdCollection, onPodClick, searchQuery]);
+
+  return (
+    <>
+      <SearchPodInputContainer>
+        <Input2
+          placeholder="Search for pods..."
+          variant="secondary"
+          onChange={({ target: { value } }) => setSearchQuery(value)}
+        />
+      </SearchPodInputContainer>
+      <List style={style} list={podsCollectionList} />
+    </>
+  );
 };
+
+const SearchPodInputContainer = styled.div`
+  padding: 24px;
+`;
 
 export const PodsCollectionBottomModal = (): JSX.Element | null => {
   const activeBottomModal = useBottomModal();

--- a/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
@@ -84,6 +84,10 @@ export const PodsCollectionList = ({
 }: PodsCollectionListProps): ReactElement => {
   const pcdCollection = usePCDCollection();
   const [searchQuery, setSearchQuery] = useState<string>("");
+  const [expandedGroupsIds, setExpandedGroupsIds] = useState<
+    Record<string, boolean>
+  >({});
+
   const podsCollectionList = useMemo(() => {
     const allPcds = pcdCollection.getAll();
     // If we have the same ticket in both POD and EDSA, we want to show only the POD one
@@ -102,10 +106,17 @@ export const PodsCollectionList = ({
     const result: Record<string, GroupType> = {};
     for (const [key, value] of Object.entries(pcdCollection.folders)) {
       if (!result[value]) {
+        const isItTheFirstGroup = !Object.keys(result).length;
+        const shouldExpandedByDefault =
+          isItTheFirstGroup || filteredPcds.length < 20;
         result[value] = {
           title: value.replace(/\//g, " · "),
           id: value, // setting the folder path as a key
-          children: []
+          children: [],
+          expanded:
+            expandedGroupsIds[value] === undefined
+              ? !!shouldExpandedByDefault
+              : !!expandedGroupsIds[value]
         };
       }
 
@@ -137,13 +148,14 @@ export const PodsCollectionList = ({
 
         return {
           ...group,
+          expanded: true, // In case we filter by inside the group we want to auto expend it
           children: group.children.filter((pod) =>
             pod.title.toLowerCase().includes(searchQuery.toLowerCase())
           )
         };
       })
       .filter((group) => group.children.length > 0);
-  }, [pcdCollection, onPodClick, searchQuery]);
+  }, [pcdCollection, onPodClick, searchQuery, expandedGroupsIds]);
 
   return (
     <>
@@ -154,7 +166,16 @@ export const PodsCollectionList = ({
           onChange={({ target: { value } }) => setSearchQuery(value)}
         />
       </SearchPodInputContainer>
-      <List style={style} list={podsCollectionList} />
+      <List
+        onExpanded={(id, newState) => {
+          setExpandedGroupsIds((oldMap) => ({
+            ...oldMap,
+            [id]: newState
+          }));
+        }}
+        style={style}
+        list={podsCollectionList}
+      />
     </>
   );
 };

--- a/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
@@ -188,8 +188,7 @@ export const PodsCollectionList = ({
 };
 
 const SearchPodInputContainer = styled.div`
-  padding: 24px;
-  padding-bottom: 0;
+  padding: 0 24px 24px 24px;
 `;
 
 export const PodsCollectionBottomModal = (): JSX.Element | null => {


### PR DESCRIPTION
This PR is adding search on pods:

<img width="462" alt="image" src="https://github.com/user-attachments/assets/8667c751-fc0b-4fd0-b7d5-bd8b44aea4e5">


The logic will be to filter first on groups if it match show all the group's items then if it doesnt match try to match pods names if it match show the group but only the pods who matched