### PR TITLE
Add expended on pod lists

### DIFF
--- a/apps/passport-client/new-components/shared/List/index.tsx
+++ b/apps/passport-client/new-components/shared/List/index.tsx
@@ -35,6 +35,7 @@ const ListGroup = ({
     <GroupContainer key={id} id={id}>
       <Typography
         onClick={() => onExpanded && id && onExpanded(id, !expanded)}
+        style={{ cursor: onExpanded ? "pointer" : "default" }}
         fontWeight={500}
         color="var(--text-tertiary)"
         family="Rubik"
@@ -45,8 +46,7 @@ const ListGroup = ({
             transform: expanded ? "rotate(90deg)" : undefined,
             transition: "transform 0.2s ease-in-out",
             marginRight: 10,
-            verticalAlign: "text-top",
-            color: "var(--text-primary)"
+            verticalAlign: "text-top"
           }}
         />
         {title}

--- a/apps/passport-client/new-components/shared/List/index.tsx
+++ b/apps/passport-client/new-components/shared/List/index.tsx
@@ -1,13 +1,15 @@
+import { ReactElement } from "react";
+import { FaChevronRight } from "react-icons/fa";
 import styled from "styled-components";
 import { Typography } from "../Typography";
 import { ListItem, ListItemType } from "./ListItem";
-import { ReactElement } from "react";
 
 export type GroupType = {
   children: ListItemType[];
   title?: string;
   isLastItemBorder?: boolean;
   id?: string;
+  expended?: boolean;
 };
 
 type ListChild = GroupType | ListItemType;
@@ -21,29 +23,47 @@ const GroupContainer = styled.div`
 `;
 
 const ListGroup = ({
-  children,
-  title,
-  isLastItemBorder,
-  id
-}: GroupType): ReactElement => {
+  group,
+  onExpended
+}: {
+  group: GroupType;
+  onExpended?: (id: string, expended: boolean) => void;
+}): ReactElement => {
+  const { children, title, expended, isLastItemBorder, id } = group;
   const len = children.length;
   return (
     <GroupContainer key={id} id={id}>
-      <Typography fontWeight={500} color="var(--text-tertiary)" family="Rubik">
+      <Typography
+        onClick={() => onExpended && id && onExpended(id, !expended)}
+        fontWeight={500}
+        color="var(--text-tertiary)"
+        family="Rubik"
+      >
+        <FaChevronRight
+          color="var(--text-tertiary)"
+          style={{
+            transform: expended ? "rotate(90deg)" : undefined,
+            transition: "transform 0.2s ease-in-out",
+            marginRight: 10,
+            verticalAlign: "text-top",
+            color: "var(--text-primary)"
+          }}
+        />
         {title}
       </Typography>
-      {children.map((child, i) => {
-        if (i === len - 1) {
-          return (
-            <ListItem
-              {...child}
-              showBottomBorder={isLastItemBorder}
-              key={child.key}
-            />
-          );
-        }
-        return <ListItem {...child} key={child.key} />;
-      })}
+      {(!!expended || !onExpended) &&
+        children.map((child, i) => {
+          if (i === len - 1) {
+            return (
+              <ListItem
+                {...child}
+                showBottomBorder={isLastItemBorder}
+                key={child.key}
+              />
+            );
+          }
+          return <ListItem {...child} key={child.key} />;
+        })}
     </GroupContainer>
   );
 };
@@ -51,14 +71,15 @@ const ListGroup = ({
 type ListProps = {
   list: ListChild[];
   style?: React.CSSProperties;
+  onExpended?: (id: string, expended: boolean) => void;
 };
 
-export const List = ({ list, style }: ListProps): ReactElement => {
+export const List = ({ list, style, onExpended }: ListProps): ReactElement => {
   return (
     <div style={style}>
       {list.map((child) => {
         return isListGroup(child) ? (
-          <ListGroup {...child} />
+          <ListGroup group={child} onExpended={onExpended} />
         ) : (
           <ListItem {...child} />
         );

--- a/apps/passport-client/new-components/shared/List/index.tsx
+++ b/apps/passport-client/new-components/shared/List/index.tsx
@@ -9,7 +9,7 @@ export type GroupType = {
   title?: string;
   isLastItemBorder?: boolean;
   id?: string;
-  expended?: boolean;
+  expanded?: boolean;
 };
 
 type ListChild = GroupType | ListItemType;
@@ -24,17 +24,17 @@ const GroupContainer = styled.div`
 
 const ListGroup = ({
   group,
-  onExpended
+  onExpanded
 }: {
   group: GroupType;
-  onExpended?: (id: string, expended: boolean) => void;
+  onExpanded?: (id: string, expanded: boolean) => void;
 }): ReactElement => {
-  const { children, title, expended, isLastItemBorder, id } = group;
+  const { children, title, expanded, isLastItemBorder, id } = group;
   const len = children.length;
   return (
     <GroupContainer key={id} id={id}>
       <Typography
-        onClick={() => onExpended && id && onExpended(id, !expended)}
+        onClick={() => onExpanded && id && onExpanded(id, !expanded)}
         fontWeight={500}
         color="var(--text-tertiary)"
         family="Rubik"
@@ -42,7 +42,7 @@ const ListGroup = ({
         <FaChevronRight
           color="var(--text-tertiary)"
           style={{
-            transform: expended ? "rotate(90deg)" : undefined,
+            transform: expanded ? "rotate(90deg)" : undefined,
             transition: "transform 0.2s ease-in-out",
             marginRight: 10,
             verticalAlign: "text-top",
@@ -51,7 +51,7 @@ const ListGroup = ({
         />
         {title}
       </Typography>
-      {(!!expended || !onExpended) &&
+      {(!!expanded || !onExpanded) &&
         children.map((child, i) => {
           if (i === len - 1) {
             return (
@@ -71,15 +71,15 @@ const ListGroup = ({
 type ListProps = {
   list: ListChild[];
   style?: React.CSSProperties;
-  onExpended?: (id: string, expended: boolean) => void;
+  onExpanded?: (id: string, expanded: boolean) => void;
 };
 
-export const List = ({ list, style, onExpended }: ListProps): ReactElement => {
+export const List = ({ list, style, onExpanded }: ListProps): ReactElement => {
   return (
     <div style={style}>
       {list.map((child) => {
         return isListGroup(child) ? (
-          <ListGroup group={child} onExpended={onExpended} />
+          <ListGroup group={child} onExpanded={onExpanded} />
         ) : (
           <ListItem {...child} />
         );

--- a/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
@@ -84,7 +84,7 @@ export const PodsCollectionList = ({
 }: PodsCollectionListProps): ReactElement => {
   const pcdCollection = usePCDCollection();
   const [searchQuery, setSearchQuery] = useState<string>("");
-  const [expendedGroupsIds, setExpendedGroupsIds] = useState<
+  const [expandedGroupsIds, setExpandedGroupsIds] = useState<
     Record<string, boolean>
   >({});
 
@@ -107,16 +107,16 @@ export const PodsCollectionList = ({
     for (const [key, value] of Object.entries(pcdCollection.folders)) {
       if (!result[value]) {
         const isItTheFirstGroup = !Object.keys(result).length;
-        const shouldExpendedByDefault =
+        const shouldExpandedByDefault =
           isItTheFirstGroup || filteredPcds.length < 20;
         result[value] = {
           title: value.replace(/\//g, " · "),
           id: value, // setting the folder path as a key
           children: [],
-          expended:
-            expendedGroupsIds[value] === undefined
-              ? !!shouldExpendedByDefault
-              : !!expendedGroupsIds[value]
+          expanded:
+            expandedGroupsIds[value] === undefined
+              ? !!shouldExpandedByDefault
+              : !!expandedGroupsIds[value]
         };
       }
 
@@ -148,14 +148,14 @@ export const PodsCollectionList = ({
 
         return {
           ...group,
-          expended: true, // In case we filter by inside the group we want to auto expend it
+          expanded: true, // In case we filter by inside the group we want to auto expend it
           children: group.children.filter((pod) =>
             pod.title.toLowerCase().includes(searchQuery.toLowerCase())
           )
         };
       })
       .filter((group) => group.children.length > 0);
-  }, [pcdCollection, onPodClick, searchQuery, expendedGroupsIds]);
+  }, [pcdCollection, onPodClick, searchQuery, expandedGroupsIds]);
 
   return (
     <>
@@ -167,8 +167,8 @@ export const PodsCollectionList = ({
         />
       </SearchPodInputContainer>
       <List
-        onExpended={(id, newState) => {
-          setExpendedGroupsIds((oldMap) => ({
+        onExpanded={(id, newState) => {
+          setExpandedGroupsIds((oldMap) => ({
             ...oldMap,
             [id]: newState
           }));


### PR DESCRIPTION

https://github.com/user-attachments/assets/29d65772-0690-415d-9091-de7086d543ab

Logic: always show the first group expended, if there is less than 20 pods expended by default all the groups