### PR TITLE
Fix typo in GPCircuits package

### DIFF
--- a/packages/lib/gpcircuits/src/constants.ts
+++ b/packages/lib/gpcircuits/src/constants.ts
@@ -2,7 +2,7 @@
  * Version of the published artifacts on NPM which are compatible with this
  * version of the GPC package.
  */
-export const ARTIFACTS_NPM_VERSION = "1.1.0";
+export const ARTIFACTS_NPM_VERSION = "0.11.0";
 
 /**
  * Name of the package on NPM which contains published artifacts for this


### PR DESCRIPTION
This PR fixes a typo in the `ARTIFACTS_NPM_VERSION` constant in the GPCircuits package.