### PR TITLE
Fix quirks of GPC artifact config and build

### DIFF
--- a/apps/passport-client/build.ts
+++ b/apps/passport-client/build.ts
@@ -8,7 +8,10 @@ import Handlebars from "handlebars";
 import https from "https";
 import * as path from "path";
 import { v4 as uuid } from "uuid";
-import { ZUPASS_GPC_ARTIFACT_PATH } from "./src/sharedConstants";
+import {
+  ZUPASS_GPC_ARTIFACT_BASE_PATH,
+  ZUPASS_GPC_ARTIFACT_PATH
+} from "./src/sharedConstants";
 
 dotenv.config();
 
@@ -221,7 +224,7 @@ function compileHtml(): void {
 }
 
 function copyGPCArtifacts(): void {
-  fs.rmSync(path.join("public" + ZUPASS_GPC_ARTIFACT_PATH), {
+  fs.rmSync(path.join("public" + ZUPASS_GPC_ARTIFACT_BASE_PATH), {
     recursive: true,
     force: true
   });

--- a/apps/passport-client/components/screens/EmbeddedScreens/EmbeddedGPCProofScreen.tsx
+++ b/apps/passport-client/components/screens/EmbeddedScreens/EmbeddedGPCProofScreen.tsx
@@ -13,8 +13,8 @@ import { v3tov4Identity } from "@pcd/semaphore-identity-pcd";
 import { Fragment, ReactNode, useMemo, useState } from "react";
 import styled from "styled-components";
 import { useIdentityV3, usePCDCollection } from "../../../src/appHooks";
-import { ZUPASS_GPC_ARTIFACT_PATH } from "../../../src/sharedConstants";
 import { useSyncE2EEStorage } from "../../../src/useSyncE2EEStorage";
+import { getGPCArtifactsURL } from "../../../src/util";
 import { getPODsForCollections } from "../../../src/zapp/collections";
 import { H2 } from "../../core";
 import { AppContainer } from "../../shared/AppContainer";
@@ -126,10 +126,7 @@ export function EmbeddedGPCProofScreen({
                     externalNullifier: proofRequest.externalNullifier
                   }
                 },
-                new URL(
-                  ZUPASS_GPC_ARTIFACT_PATH,
-                  window.location.origin
-                ).toString()
+                getGPCArtifactsURL(window.location.origin)
               )
                 .then((proof) => {
                   callback({

--- a/apps/passport-client/src/pcdPackages.ts
+++ b/apps/passport-client/src/pcdPackages.ts
@@ -1,15 +1,8 @@
-import { parseGPCArtifactsConfig } from "@pcd/client-shared";
 import { EdDSAFrogPCDPackage } from "@pcd/eddsa-frog-pcd";
 import { EdDSAPCDPackage } from "@pcd/eddsa-pcd";
 import { EdDSATicketPCDPackage } from "@pcd/eddsa-ticket-pcd";
 import { EmailPCDPackage } from "@pcd/email-pcd";
 import { EthereumOwnershipPCDPackage } from "@pcd/ethereum-ownership-pcd";
-import {
-  GPCArtifactSource,
-  GPCArtifactStability,
-  GPCArtifactVersion,
-  gpcArtifactDownloadURL
-} from "@pcd/gpc";
 import { GPCPCDPackage } from "@pcd/gpc-pcd";
 import { HaLoNoncePCDPackage } from "@pcd/halo-nonce-pcd";
 import { MessagePCDPackage } from "@pcd/message-pcd";
@@ -31,7 +24,7 @@ import { ZKEdDSAFrogPCDPackage } from "@pcd/zk-eddsa-frog-pcd";
 import { appConfig } from "./appConfig";
 import { loadSelf } from "./localstorage";
 import { makeEncodedVerifyLink } from "./qr";
-import { GPC_ARTIFACTS_CONFIG } from "./sharedConstants";
+import { getGPCArtifactsURL } from "./util";
 
 let pcdPackages: Promise<PCDPackage[]> | undefined;
 
@@ -78,12 +71,8 @@ async function loadPackages(): Promise<PCDPackage[]> {
 
   await PODPCDPackage.init?.({});
 
-  const gpcArtifactsConfig = parseGPCArtifactsConfig(GPC_ARTIFACTS_CONFIG);
   await GPCPCDPackage.init?.({
-    zkArtifactPath: gpcArtifactDownloadURL(
-      gpcArtifactsConfig.source as GPCArtifactSource,
-      gpcArtifactsConfig.stability as GPCArtifactStability,
-      gpcArtifactsConfig.version as GPCArtifactVersion,
+    zkArtifactPath: getGPCArtifactsURL(
       "/" /* zupassURL can use a site-relative URL */
     )
   });

--- a/apps/passport-client/src/sharedConstants.ts
+++ b/apps/passport-client/src/sharedConstants.ts
@@ -39,4 +39,9 @@ export const GPC_ARTIFACTS_CONFIG =
         version: ARTIFACTS_NPM_VERSION
       });
 
-export const ZUPASS_GPC_ARTIFACT_PATH = `/artifacts/proto-pod-gpc/${ARTIFACTS_NPM_VERSION}`;
+// Don't use these paths directly in code, or you'll keep the environment
+// variable override from working.  Prefer to use getGPCArtifactsURL instead,
+// which uses the config above.
+export const ZUPASS_GPC_ARTIFACT_BASE_PATH = `/artifacts/proto-pod-gpc`;
+export const ZUPASS_GPC_ARTIFACT_PATH =
+  ZUPASS_GPC_ARTIFACT_BASE_PATH + `/${ARTIFACTS_NPM_VERSION}`;

--- a/apps/passport-client/src/util.ts
+++ b/apps/passport-client/src/util.ts
@@ -1,3 +1,10 @@
+import { parseGPCArtifactsConfig } from "@pcd/client-shared";
+import {
+  gpcArtifactDownloadURL,
+  GPCArtifactSource,
+  GPCArtifactStability,
+  GPCArtifactVersion
+} from "@pcd/gpc";
 import {
   EdgeCityFolderName,
   FrogCryptoFolderName,
@@ -8,6 +15,7 @@ import { sleep } from "@pcd/util";
 import _ from "lodash";
 import { v4 as uuid } from "uuid";
 import { Dispatcher } from "./dispatch";
+import { GPC_ARTIFACTS_CONFIG } from "./sharedConstants";
 
 export function getHost(returnURL: string): string {
   const url = new URL(returnURL);
@@ -143,3 +151,13 @@ export function stringSizeInBytes(s: string): number {
 }
 
 export const ADD_PCD_SIZE_LIMIT_BYTES = 10000;
+
+export function getGPCArtifactsURL(zupassURL: string): string {
+  const gpcArtifactsConfig = parseGPCArtifactsConfig(GPC_ARTIFACTS_CONFIG);
+  return gpcArtifactDownloadURL(
+    gpcArtifactsConfig.source as GPCArtifactSource,
+    gpcArtifactsConfig.stability as GPCArtifactStability,
+    gpcArtifactsConfig.version as GPCArtifactVersion,
+    zupassURL
+  );
+}

--- a/apps/passport-client/src/zapp/ZappServer.ts
+++ b/apps/passport-client/src/zapp/ZappServer.ts
@@ -31,7 +31,7 @@ import { v4 as uuidv4 } from "uuid";
 import { appConfig } from "../appConfig";
 import { StateContextValue } from "../dispatch";
 import { EmbeddedScreenType } from "../embedded";
-import { ZUPASS_GPC_ARTIFACT_PATH } from "../sharedConstants";
+import { getGPCArtifactsURL } from "../util";
 import { collectionIdToFolderName, getPODsForCollections } from "./collections";
 import { QuerySubscriptionManager } from "./query_subscription_manager";
 import { ListenMode } from "./useZappServer";
@@ -414,7 +414,7 @@ class ZupassGPCRPC extends BaseZappServer implements ParcnetGPCRPC {
       proof,
       boundConfig,
       revealedClaims,
-      new URL(ZUPASS_GPC_ARTIFACT_PATH, window.location.origin).toString()
+      getGPCArtifactsURL(window.location.origin)
     );
   }
 
@@ -431,7 +431,7 @@ class ZupassGPCRPC extends BaseZappServer implements ParcnetGPCRPC {
       proof,
       config as GPCBoundConfig,
       revealedClaims,
-      new URL(ZUPASS_GPC_ARTIFACT_PATH, window.location.origin).toString()
+      getGPCArtifactsURL(window.location.origin)
     );
   }
 

--- a/packages/lib/client-shared/package.json
+++ b/packages/lib/client-shared/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@rollbar/react": "^0.12.0-beta",
+    "@pcd/util": "0.8.0",
     "react": "^18.2.0",
     "rollbar": "^2.26.4"
   },

--- a/packages/lib/client-shared/src/util.ts
+++ b/packages/lib/client-shared/src/util.ts
@@ -1,3 +1,5 @@
+import { emptyStrToUndefined } from "@pcd/util";
+
 /**
  * Settings for calling {@link gpcArtifactDownloadURL} as parsed from an
  * environment variable by {@link parseGPCArtifactsConfig}.
@@ -39,9 +41,10 @@ export function parseGPCArtifactsConfig(
       );
     }
     return {
-      source: config.source ?? defaultConfig.source,
-      stability: config.stability ?? defaultConfig.stability,
-      version: config.version ?? defaultConfig.version
+      source: emptyStrToUndefined(config.source) ?? defaultConfig.source,
+      stability:
+        emptyStrToUndefined(config.stabilit) ?? defaultConfig.stability,
+      version: emptyStrToUndefined(config.version) ?? defaultConfig.version
     };
   } catch (e) {
     console.error(

--- a/packages/lib/client-shared/tsconfig.cjs.json
+++ b/packages/lib/client-shared/tsconfig.cjs.json
@@ -9,5 +9,9 @@
   "include": ["src", "artifacts/*.json"],
   // DO NOT MODIFY MANUALLY BEYOND THIS POINT
   // References are automatically maintained by `yarn fix-references`
-  "references": []
+  "references": [
+    {
+      "path": "../util/tsconfig.cjs.json"
+    }
+  ]
 }

--- a/packages/lib/client-shared/tsconfig.esm.json
+++ b/packages/lib/client-shared/tsconfig.esm.json
@@ -9,5 +9,9 @@
   "include": ["src", "artifacts/*.json"],
   // DO NOT MODIFY MANUALLY BEYOND THIS POINT
   // References are automatically maintained by `yarn fix-references`
-  "references": []
+  "references": [
+    {
+      "path": "../util/tsconfig.esm.json"
+    }
+  ]
 }

--- a/packages/lib/client-shared/tsconfig.json
+++ b/packages/lib/client-shared/tsconfig.json
@@ -1,16 +1,30 @@
 {
   "extends": "@pcd/tsconfig/ts-library.json",
   "compilerOptions": {
-    "lib": ["dom"],
+    "lib": [
+      "dom"
+    ],
     "outDir": "dist",
     "declarationDir": "dist/types",
     // Include all source files, including tests
     "rootDir": "."
   },
   // Some artifact-including packages need to import a JSON file
-  "include": ["src", "test", "artifacts/*.json"],
-  "exclude": ["dist", "build", "node_modules"],
+  "include": [
+    "src",
+    "test",
+    "artifacts/*.json"
+  ],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules"
+  ],
   // DO NOT MODIFY MANUALLY BEYOND THIS POINT
   // References are automatically maintained by `yarn fix-references`
-  "references": []
+  "references": [
+    {
+      "path": "../util"
+    }
+  ]
 }

--- a/packages/lib/gpc/src/gpc.ts
+++ b/packages/lib/gpc/src/gpc.ts
@@ -455,12 +455,13 @@ export function gpcArtifactDownloadURL(
           'Zupass artifact download requires a server URL.  Try "https://zupass.org".'
         );
       }
-      const artifactVersion = version ?? GPC_ARTIFACTS_NPM_VERSION;
+      if (version === undefined || version === "") {
+        version = GPC_ARTIFACTS_NPM_VERSION;
+      }
       return urljoin(
         zupassURL,
         stability === "test" ? "artifacts/test" : "artifacts",
-        PROTO_POD_GPC_FAMILY_NAME +
-          (stability === "test" ? "" : `/${artifactVersion}`)
+        PROTO_POD_GPC_FAMILY_NAME + (stability === "test" ? "" : `/${version}`)
       );
     default:
       throw new Error(`Unknown artifact download source ${source}.`);

--- a/packages/lib/gpc/test/gpc.spec.ts
+++ b/packages/lib/gpc/test/gpc.spec.ts
@@ -1693,8 +1693,20 @@ describe("gpcArtifactDownloadURL should work", async function () {
         expected: "/artifacts/test/proto-pod-gpc"
       },
       {
+        stability: "test",
+        version: "",
+        zupassURL: "/",
+        expected: "/artifacts/test/proto-pod-gpc"
+      },
+      {
         stability: "prod",
         version: undefined,
+        zupassURL: "/",
+        expected: `/artifacts/proto-pod-gpc/${GPC_ARTIFACTS_NPM_VERSION}`
+      },
+      {
+        stability: "prod",
+        version: "",
         zupassURL: "/",
         expected: `/artifacts/proto-pod-gpc/${GPC_ARTIFACTS_NPM_VERSION}`
       },
@@ -1717,8 +1729,20 @@ describe("gpcArtifactDownloadURL should work", async function () {
         expected: "artifacts/test/proto-pod-gpc"
       },
       {
+        stability: "test",
+        version: "",
+        zupassURL: "",
+        expected: "artifacts/test/proto-pod-gpc"
+      },
+      {
         stability: "prod",
         version: undefined,
+        zupassURL: "",
+        expected: `artifacts/proto-pod-gpc/${GPC_ARTIFACTS_NPM_VERSION}`
+      },
+      {
+        stability: "prod",
+        version: "",
         zupassURL: "",
         expected: `artifacts/proto-pod-gpc/${GPC_ARTIFACTS_NPM_VERSION}`
       },
@@ -1810,6 +1834,12 @@ describe("gpcArtifactDownloadURL should work", async function () {
         expected: undefined
       },
       {
+        stability: "prod",
+        version: "",
+        zupassURL: "https://zupass.org",
+        expected: undefined
+      },
+      {
         stability: "test",
         version: "foo",
         zupassURL: undefined,
@@ -1876,8 +1906,20 @@ describe("gpcArtifactDownloadURL should work", async function () {
         expected: `https://unpkg.com/@pcd/proto-pod-gpc-artifacts@${GPC_ARTIFACTS_NPM_VERSION}`
       },
       {
+        stability: "test",
+        version: "",
+        zupassURL: "https://zupass.org",
+        expected: `https://unpkg.com/@pcd/proto-pod-gpc-artifacts@${GPC_ARTIFACTS_NPM_VERSION}`
+      },
+      {
         stability: "prod",
         version: undefined,
+        zupassURL: "https://zupass.org",
+        expected: `https://unpkg.com/@pcd/proto-pod-gpc-artifacts@${GPC_ARTIFACTS_NPM_VERSION}`
+      },
+      {
+        stability: "prod",
+        version: "",
         zupassURL: "https://zupass.org",
         expected: `https://unpkg.com/@pcd/proto-pod-gpc-artifacts@${GPC_ARTIFACTS_NPM_VERSION}`
       },


### PR DESCRIPTION
Several things motivated by tracking down confusing behavior in my local consumer-client build:

- When artifacts moved into a subdir by version, the build script wasn't deleting the old dir, which lead to misconfigured code being able to fetch the old files from the wrong URL.
- Env variable parsing for GPC config was built to assume "" and undefined were equivalent, but not testing that, and not properly enforcing it in some places.
- ZAPI-related prove/verify code wasn't respecting env variable config because it bypassed the GPCPCD package.

I need @robknight to help me figure out how to test the ZAPI part of this to make sure I didn't break it.
