### PR TITLE
Add jsdelivr for artifact download, and make it the default

### DIFF
--- a/apps/consumer-client/.env.example
+++ b/apps/consumer-client/.env.example
@@ -21,6 +21,6 @@ GPC_ARTIFACTS_CONFIG_OVERRIDE=
 # git revision (commit hash or tag) you want to use.
 #GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "github", "stability": "test", "version": "@pcd/proto-pod-gpc-artifacts@0.0.2"}
 
-# Use this value to download from NPM using unpkg.  Fill in the "version" field
+# Use this value to download from NPM using jsdelivr.  Fill in the "version" field
 # with the NPM version number.
-#GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "unpkg", "stability": "test", "version": "0.0.2"}
+#GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "jsdelivr", "stability": "test", "version": "0.0.2"}

--- a/apps/consumer-client/src/pages/examples/gpc-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/gpc-proof.tsx
@@ -204,7 +204,7 @@ export default function Page(): JSX.Element {
               code={JSONBig({ useNativeBigInt: true }).stringify(pcd, null, 2)}
             />
             {valid === undefined && <p>❓ Proof verifying</p>}
-            {valid === false && <p>❌ Proof is invalid: ${validationError}</p>}
+            {valid === false && <p>❌ Proof is invalid: {validationError}</p>}
             {valid === true && (
               <>
                 <p>✅ Proof is valid</p>
@@ -433,6 +433,7 @@ async function verifyProof(
     )
   });
   const verified = await verify(pcd);
+  console.error("ART_DBG", verified);
   if (!verified) return { valid: false };
 
   const sameExternalNullifier =

--- a/apps/passport-client/.env.example
+++ b/apps/passport-client/.env.example
@@ -33,9 +33,9 @@ GPC_ARTIFACTS_CONFIG_OVERRIDE=
 # git revision (commit hash or tag) you want to use.
 # GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "github", "stability": "test", "version": "@pcd/proto-pod-gpc-artifacts@0.0.2"}
 
-# Use this value to download from NPM using unpkg.  Fill in the "version" field
+# Use this value to download from NPM using jsdelivr.  Fill in the "version" field
 # with the NPM version number.
-# GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "unpkg", "stability": "test", "version": "0.0.2"}
+# GPC_ARTIFACTS_CONFIG_OVERRIDE={"source": "jsdelivr", "stability": "test", "version": "0.0.2"}
 
 # Use this value to enable one-click login. Set to "true" to enable. Set to "false", or don't set at all to disable.
 # ONE_CLICK_LOGIN_ENABLED=true

--- a/apps/passport-client/src/sharedConstants.ts
+++ b/apps/passport-client/src/sharedConstants.ts
@@ -28,7 +28,7 @@ export const OOM_ERROR_MESSAGE = "Out of memory";
 export const MAX_WIDTH_SCREEN = 420;
 
 // Environment variable configure how we fetch GPC artifacts, however we
-// default to fetching from the Zupass server rather than unpkg.
+// default to fetching from the Zupass server rather than jsdelivr.
 export const GPC_ARTIFACTS_CONFIG =
   process.env.GPC_ARTIFACTS_CONFIG_OVERRIDE !== undefined &&
   process.env.GPC_ARTIFACTS_CONFIG_OVERRIDE !== ""

--- a/examples/pod-gpc-example/src/gpcExample.ts
+++ b/examples/pod-gpc-example/src/gpcExample.ts
@@ -166,7 +166,7 @@ export async function gpcDemo(): Promise<boolean> {
   // If this code were running in a browser, we'd need a URL to download
   // artifacts.  We can get one from the function below, to use in a browser,
   // or to download separately into your own Node environment.
-  const artifactsURL = gpcArtifactDownloadURL("unpkg", "prod", undefined);
+  const artifactsURL = gpcArtifactDownloadURL("jsdelivr", "prod", undefined);
   console.log("In browser we'd download artifacts from", artifactsURL);
 
   //////////////////////////////////////////////////////////////////////////////

--- a/packages/lib/client-shared/src/util.ts
+++ b/packages/lib/client-shared/src/util.ts
@@ -22,7 +22,7 @@ export function parseGPCArtifactsConfig(
   envConfig: string | undefined
 ): GPCArtifactsConfigEnv {
   const defaultConfig = {
-    source: "unpkg",
+    source: "jsdelivr",
     stability: "prod",
     version: undefined // Means to use GPC_ARTIFACTS_NPM_VERSION
   };

--- a/packages/lib/gpc/src/gpc.ts
+++ b/packages/lib/gpc/src/gpc.ts
@@ -7,6 +7,7 @@ import {
   ProtoPODGPCPublicInputs,
   githubDownloadRootURL,
   gpcArtifactPaths,
+  jsdelivrDownloadRootURL,
   unpkgDownloadRootURL
 } from "@pcd/gpcircuits";
 import urljoin from "url-join";
@@ -392,7 +393,7 @@ export const GPC_ARTIFACTS_NPM_VERSION = ProtoPODGPC.ARTIFACTS_NPM_VERSION;
  * Note that the `zupass` source is not currently usable outside of the
  * Zupass app itself.
  */
-export type GPCArtifactSource = "zupass" | "github" | "unpkg";
+export type GPCArtifactSource = "zupass" | "github" | "unpkg" | "jsdelivr";
 
 /**
  * Stability level of GPC artifacts to use.  Test artifacts are for use
@@ -439,6 +440,13 @@ export function gpcArtifactDownloadURL(
         PROTO_POD_GPC_FAMILY_NAME,
         version
       );
+    case "jsdelivr":
+      if (version === undefined || version === "") {
+        version = GPC_ARTIFACTS_NPM_VERSION;
+      }
+      // stability is intentionally ignored.  NPM version can encode
+      // pre-release status.
+      return jsdelivrDownloadRootURL(PROTO_POD_GPC_FAMILY_NAME, version);
     case "unpkg":
       if (version === undefined || version === "") {
         version = GPC_ARTIFACTS_NPM_VERSION;

--- a/packages/lib/gpc/test/gpc.spec.ts
+++ b/packages/lib/gpc/test/gpc.spec.ts
@@ -1966,6 +1966,90 @@ describe("gpcArtifactDownloadURL should work", async function () {
     }
   });
 
+  it("should work for source=jsdelivr", async function () {
+    const TEST_CASES = [
+      {
+        stability: "test",
+        version: undefined,
+        zupassURL: undefined,
+        expected: `https://cdn.jsdelivr.net/npm/@pcd/proto-pod-gpc-artifacts@${GPC_ARTIFACTS_NPM_VERSION}`
+      },
+      {
+        stability: "prod",
+        version: undefined,
+        zupassURL: undefined,
+        expected: `https://cdn.jsdelivr.net/npm/@pcd/proto-pod-gpc-artifacts@${GPC_ARTIFACTS_NPM_VERSION}`
+      },
+      {
+        stability: "test",
+        version: undefined,
+        zupassURL: "https://zupass.org",
+        expected: `https://cdn.jsdelivr.net/npm/@pcd/proto-pod-gpc-artifacts@${GPC_ARTIFACTS_NPM_VERSION}`
+      },
+      {
+        stability: "test",
+        version: "",
+        zupassURL: "https://zupass.org",
+        expected: `https://cdn.jsdelivr.net/npm/@pcd/proto-pod-gpc-artifacts@${GPC_ARTIFACTS_NPM_VERSION}`
+      },
+      {
+        stability: "prod",
+        version: undefined,
+        zupassURL: "https://zupass.org",
+        expected: `https://cdn.jsdelivr.net/npm/@pcd/proto-pod-gpc-artifacts@${GPC_ARTIFACTS_NPM_VERSION}`
+      },
+      {
+        stability: "prod",
+        version: "",
+        zupassURL: "https://zupass.org",
+        expected: `https://cdn.jsdelivr.net/npm/@pcd/proto-pod-gpc-artifacts@${GPC_ARTIFACTS_NPM_VERSION}`
+      },
+      {
+        stability: "test",
+        version: "foo",
+        zupassURL: undefined,
+        expected:
+          "https://cdn.jsdelivr.net/npm/@pcd/proto-pod-gpc-artifacts@foo"
+      },
+      {
+        stability: "prod",
+        version: "foo",
+        zupassURL: undefined,
+        expected:
+          "https://cdn.jsdelivr.net/npm/@pcd/proto-pod-gpc-artifacts@foo"
+      },
+      {
+        stability: "prod",
+        version: "foo/bar",
+        zupassURL: "https://zupass.org",
+        expected:
+          "https://cdn.jsdelivr.net/npm/@pcd/proto-pod-gpc-artifacts@foo/bar"
+      }
+    ];
+
+    for (const testCase of TEST_CASES) {
+      if (testCase.expected !== undefined) {
+        expect(
+          gpcArtifactDownloadURL(
+            "jsdelivr",
+            testCase.stability as GPCArtifactStability,
+            testCase.version as GPCArtifactVersion,
+            testCase.zupassURL
+          )
+        ).to.eq(testCase.expected);
+      } else {
+        expect(() =>
+          gpcArtifactDownloadURL(
+            "jsdelivr",
+            testCase.stability as GPCArtifactStability,
+            testCase.version as GPCArtifactVersion,
+            testCase.zupassURL
+          )
+        ).to.throw(Error);
+      }
+    }
+  });
+
   it("should throw on missing or invalid source", async function () {
     expect(() =>
       gpcArtifactDownloadURL(

--- a/packages/lib/gpcircuits/src/artifacts.ts
+++ b/packages/lib/gpcircuits/src/artifacts.ts
@@ -90,3 +90,20 @@ export function unpkgDownloadRootURL(family: string, version: string): string {
   const packageName = `@pcd/${family}-artifacts`;
   return `https://unpkg.com/${packageName}@${version}`;
 }
+
+/**
+ * Forms a root URL for direct download of artifacts from NPM via jsdelivr.
+ * Pass this root to {@link gpcArtifactPaths} to get paths to individual
+ * artifacts.
+ *
+ * @param family the name of the GPC family
+ * @param version the NPM version identifier
+ * @returns root URL
+ */
+export function jsdelivrDownloadRootURL(
+  family: string,
+  version: string
+): string {
+  const packageName = `@pcd/${family}-artifacts`;
+  return `https://cdn.jsdelivr.net/npm/${packageName}@${version}`;
+}

--- a/packages/lib/gpcircuits/test/artifacts.spec.ts
+++ b/packages/lib/gpcircuits/test/artifacts.spec.ts
@@ -5,6 +5,7 @@ import { chooseCircuitFamilyForTests } from "../scripts/common";
 import {
   githubDownloadRootURL,
   gpcArtifactPaths,
+  jsdelivrDownloadRootURL,
   unpkgDownloadRootURL
 } from "../src";
 
@@ -92,9 +93,15 @@ describe("artifact URL helpers should work", function () {
     );
   });
 
-  it("githubDownloadRootURL should work", async () => {
+  it("unpkgDownloadRootURL should work", async () => {
     expect(unpkgDownloadRootURL("family1", "ver2")).to.eq(
       "https://unpkg.com/@pcd/family1-artifacts@ver2"
+    );
+  });
+
+  it("jsdelivrDownloadRootURL should work", async () => {
+    expect(jsdelivrDownloadRootURL("family1", "ver2")).to.eq(
+      "https://cdn.jsdelivr.net/npm/@pcd/family1-artifacts@ver2"
     );
   });
 });


### PR DESCRIPTION
unpkg has been slow and flaky for a long time.  This PR adds jsdelivr as another download option, and makes it the default
