### PR TITLE
Check that list names must be PODNames

### DIFF
--- a/packages/lib/gpc/src/gpcChecks.ts
+++ b/packages/lib/gpc/src/gpcChecks.ts
@@ -266,7 +266,7 @@ export function checkProofEntryConfig(
   inequalityChecks: Record<string, PODEntryIdentifier>;
 } {
   requireType(
-    `${nameForErrorMessages}.isValueRevealed`,
+    `${nameForErrorMessages}.isRevealed`,
     entryConfig.isRevealed,
     "boolean"
   );
@@ -486,8 +486,9 @@ export function checkListMembershipInput(
     Object.entries(membershipLists).map((pair) => [pair[0], pair[1].length])
   );
 
-  // All lists of valid values must be non-empty.
+  // All lists should have valid names and be non-empty.
   for (const [listName, listLength] of Object.entries(numListElements)) {
+    checkPODName(listName);
     if (listLength === 0) {
       throw new Error(`Membership list ${listName} is empty.`);
     }

--- a/packages/lib/gpc/src/gpcUtil.ts
+++ b/packages/lib/gpc/src/gpcUtil.ts
@@ -935,11 +935,11 @@ function addIdentifierToListConfig(
   const membershipType: ListMembershipEnum =
     entryConfig.isMemberOf !== undefined ? LIST_MEMBERSHIP : LIST_NONMEMBERSHIP;
 
-  const listIdentifier: PODName = (
+  const listIdentifier: PODName = checkPODName(
     membershipType === LIST_MEMBERSHIP
       ? entryConfig.isMemberOf
       : entryConfig.isNotMemberOf
-  ) as PODName;
+  );
 
   gpcListConfig[identifier] = {
     type: membershipType,


### PR DESCRIPTION
Pointed out by @robknight who apparently had been using names with `$` until the JSON conversion started checking.
These were always declared as PODNames, but weren't being checked in the code.  I tracked down where those checks would go.

This PR doesn't have any unit tests yet, because most of gpcChecks never got utests.  I'll think about that again later.