### PR TITLE
Don't return early in service worker

### DIFF
--- a/apps/passport-client/src/worker/service-worker.ts
+++ b/apps/passport-client/src/worker/service-worker.ts
@@ -264,9 +264,6 @@ self.addEventListener("fetch", (event: FetchEvent) => {
       if (zResp) {
         swLog.V(`cache hit fetching ${event.request?.url}`);
         return zResp;
-      } else {
-        const respPromise = startFetch(event);
-        return respPromise;
       }
 
       // Check ephemeral cache next.  We'll only use this if the network


### PR DESCRIPTION
Followup to #1984.  Service worker seems to be always returning early and skipping a lot of its logic.  This likely means at least that the skipped logic (including the timeout and fallback to cache) isn't working right now.

Related to how I found this, Shiv reported some errors when testing Frogbank:
![telegram-cloud-photo-size-5-6118619008862371639-w](https://github.com/user-attachments/assets/59a1ccae-d278-43fa-ac70-4f2725230163)

I don't see those errors, but I do see warnings like this when I fetch the same resource directly from the address bar:
> The service worker navigation preload request was cancelled before 'preloadResponse' settled. If you intend to use 'preloadResponse', use waitUntil() or respondWith() to wait for the promise to settle.Understand this errorAI
telemetry.js:620 

I think my error may be a pre-existing warning which occurs on a cache hit on a navigation-preload, which normally never happens because the user doesn't directly navigate to anything in the stable cache or zcache).

Regarding Shiv's errors, I haven't tested to confirm, but I think the early return may be related.  It's causing the respPromise to be returned without an await or a waitUntil, which affects the timing of things.  I don't know if it's there for a reason, or is vestigial debug code left behind by accident.