### PR TITLE
Fix back on prove screen

### DIFF
--- a/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveSection.tsx
@@ -244,7 +244,12 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
           <Button2
             style={{ marginTop: "auto" }}
             onClick={() => {
-              window.history.back();
+              if (window.opener && window.opener !== window) {
+                // you are in a popup
+                window.close();
+              } else {
+                window.history.back();
+              }
             }}
             variant="secondary"
           >
@@ -286,7 +291,12 @@ export function GenericProveSection<T extends PCDPackage = PCDPackage>({
 
         <Button2
           onClick={() => {
-            window.history.back();
+            if (window.opener && window.opener !== window) {
+              // you are in a popup
+              window.close();
+            } else {
+              window.history.back();
+            }
           }}
           variant="secondary"
         >

--- a/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
@@ -4,6 +4,9 @@ import { SemaphoreSignatureProveScreen } from "./SemaphoreSignatureProveScreen";
 import { SemaphoreSignaturePCDPackage } from "@pcd/semaphore-signature-pcd";
 import { SemaphoreGroupProveScreen } from "./SemaphoreGroupProveScreen";
 import { SemaphoreGroupPCDPackage } from "@pcd/semaphore-group-pcd";
+import { ProveModal } from "../../../new-components/shared/Modals/ProveModal";
+import { useDispatch } from "../../../src/appHooks";
+import { useSearchParams } from "react-router-dom";
 
 export function getScreen(request: PCDGetRequest): JSX.Element | null {
   if (request.type !== PCDRequestType.Get) {
@@ -20,3 +23,14 @@ export function getScreen(request: PCDGetRequest): JSX.Element | null {
     return <GenericProveScreen req={request} />;
   }
 }
+
+export const ProveScreen = (props: {}) => {
+  const [params] = useSearchParams();
+  const request = JSON.parse(params.get("request") ?? "{}") as PCDGetRequest;
+  const dispatch = useDispatch();
+  dispatch({
+    type: "set-bottom-modal",
+    modal: { request, modalType: "prove" }
+  });
+  return <ProveModal />;
+};

--- a/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/ProveScreen.tsx
@@ -7,6 +7,7 @@ import { SemaphoreGroupPCDPackage } from "@pcd/semaphore-group-pcd";
 import { ProveModal } from "../../../new-components/shared/Modals/ProveModal";
 import { useDispatch } from "../../../src/appHooks";
 import { useSearchParams } from "react-router-dom";
+import { ReactElement } from "react";
 
 export function getScreen(request: PCDGetRequest): JSX.Element | null {
   if (request.type !== PCDRequestType.Get) {
@@ -24,7 +25,7 @@ export function getScreen(request: PCDGetRequest): JSX.Element | null {
   }
 }
 
-export const ProveScreen = (props: {}) => {
+export const ProveScreen = (): ReactElement => {
   const [params] = useSearchParams();
   const request = JSON.parse(params.get("request") ?? "{}") as PCDGetRequest;
   const dispatch = useDispatch();

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreGroupProveScreen.tsx
@@ -198,13 +198,14 @@ export function SemaphoreGroupProveScreen({
           </Button2>
         )}
         <Button2
-          onClick={
-            req.options?.requesterUrl
-              ? (): void => {
-                  window.location.href = req.options?.requesterUrl as string;
-                }
-              : (): void => window.history.back()
-          }
+          onClick={(): void => {
+            if (window.opener && window.opener !== window) {
+              // you are in a popup
+              window.close();
+            } else {
+              window.history.back();
+            }
+          }}
           variant="secondary"
         >
           <Typography fontSize={18} fontWeight={500} family="Rubik">

--- a/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/SemaphoreSignatureProveScreen.tsx
@@ -170,8 +170,13 @@ export function SemaphoreSignatureProveScreen({
         </Button2>
 
         <Button2
-          onClick={() => {
-            window.history.back();
+          onClick={(): void => {
+            if (window.opener && window.opener !== window) {
+              // you are in a popup
+              window.close();
+            } else {
+              window.history.back();
+            }
           }}
           variant="secondary"
         >

--- a/apps/passport-client/new-components/shared/Modals/ProveModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/ProveModal.tsx
@@ -27,6 +27,8 @@ export const ProveModal = (): ReactElement | null => {
     return null;
   }
   return (
-    <BottomModal isOpen={activeModal.modalType === "prove"}>{view}</BottomModal>
+    <BottomModal dismissable={false} isOpen={activeModal.modalType === "prove"}>
+      {view}
+    </BottomModal>
   );
 };

--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -77,6 +77,7 @@ import { loadInitialState } from "../src/loadInitialState";
 import { registerServiceWorker } from "../src/registerServiceWorker";
 import { AppState, StateEmitter } from "../src/state";
 import { ListenMode, useZappServer } from "../src/zapp/useZappServer";
+import { ProveScreen } from "../components/screens/ProveScreen/ProveScreen";
 
 enableLiveReload();
 
@@ -200,7 +201,7 @@ function RouterImpl(): JSX.Element {
           />
           <Route path="halo" element={<HaloScreen />} />
           <Route path="add" element={<AddScreen />} />
-          <Route path="prove" element={<NewHomeScreen />} />
+          <Route path="prove" element={<ProveScreen />} />
           <Route path="subscriptions" element={<SubscriptionsScreen />} />
           <Route path="add-subscription" element={<AddSubscriptionScreen />} />
           <Route path="telegram" element={<HomeScreen />} />


### PR DESCRIPTION
 - [ ] unified way to handle prove and add screens (open a new page in route instead of going through home page)
 - [ ] check if popup and only close if popup, else go back.
 - [ ] 