### PR TITLE
GPC Semaphore V4 enhancements for example

### DIFF
--- a/apps/consumer-client/src/pages/examples/gpc-proof.tsx
+++ b/apps/consumer-client/src/pages/examples/gpc-proof.tsx
@@ -433,7 +433,6 @@ async function verifyProof(
     )
   });
   const verified = await verify(pcd);
-  console.error("ART_DBG", verified);
   if (!verified) return { valid: false };
 
   const sameExternalNullifier =

--- a/apps/passport-client/tsconfig.json
+++ b/apps/passport-client/tsconfig.json
@@ -67,13 +67,13 @@
       "path": "../../packages/lib/gpc"
     },
     {
-      "path": "../../packages/lib/gpcircuits"
-    },
-    {
       "path": "../../packages/pcd/gpc-pcd"
     },
     {
       "path": "../../packages/ui/gpc-pcd-ui"
+    },
+    {
+      "path": "../../packages/lib/gpcircuits"
     },
     {
       "path": "../../packages/pcd/halo-nonce-pcd"

--- a/examples/pod-gpc-example/package.json
+++ b/examples/pod-gpc-example/package.json
@@ -32,7 +32,7 @@
     "@pcd/pod": "0.4.0",
     "@pcd/pod-pcd": "0.4.0",
     "@pcd/semaphore-identity-pcd": "0.14.0",
-    "@semaphore-protocol/identity": "^3.15.2",
+    "@semaphore-protocol/identity": "^4.0.3",
     "lodash": "^4.17.21",
     "snarkjs": "^0.7.4",
     "uuid": "^9.0.0"

--- a/examples/pod-gpc-example/src/podExample.ts
+++ b/examples/pod-gpc-example/src/podExample.ts
@@ -10,12 +10,13 @@
  * transmitted, stored, and displayed in apps like Zupass and Podbox which
  * understand many types of PCDs.
  *
- * All the POD code is an early prototype, and details are subject to change.
- * Feedback is welcome.
+ * The POD format is stable, and the libraries are in beta, but new features are
+ * still in development.  Feedback is welcome.
  */
 
 import { ArgumentTypeName } from "@pcd/pcd-types";
 import {
+  encodePublicKey,
   POD,
   PODContent,
   PODEntries,
@@ -40,19 +41,25 @@ export async function podDemo(): Promise<boolean> {
 
   // Semaphore is the default identity protocol for Zupass.  PODs themselves
   // don't care what you use, but ZK proofs will check POD ownership via
-  // Semaphore V3 by default.  This line creates a new private identity.
+  // Semaphore V4 by default (Semaphore V3 is also available).  This line
+  // creates a new private identity.
   const semaphoreIdentity = new Identity();
 
-  // The public part of a Semaphore identity is called the commitment.  It's
-  // like your Semaphore user ID.
-  console.log("Semaphore commitment", semaphoreIdentity.commitment);
+  // A Semaphore identity is a keypair, so the user can be identified by their
+  // public key.  In Zupass, public keys are encoded in a string which can be
+  // thought of as your user ID.  Some protocols instead use a commitment
+  // which is the hash of the public key.
+  console.log(
+    "Semaphore public key",
+    encodePublicKey(semaphoreIdentity.publicKey)
+  );
 
-  // The semaphore private identity is made up of a "trapdoor" and "nullifier".
+  // The semaphore private identity is the corresponding private key.
   // It can be saved as a string to be restored later.
-  const savedSecrets = semaphoreIdentity.toString();
-  console.log("Private identity", savedSecrets);
-  const sameIdentity = new Identity(savedSecrets);
-  console.log("Restored identity", sameIdentity.commitment);
+  const savedSecrets = semaphoreIdentity.export();
+  console.log("Private key", savedSecrets);
+  const sameIdentity = Identity.import(savedSecrets);
+  console.log("Restored identity", encodePublicKey(sameIdentity.publicKey));
 
   //////////////////////////////////////////////////////////////////////////////
   // The libraries for manipulating PODs are found in the @pcd/pod package.
@@ -65,19 +72,22 @@ export async function podDemo(): Promise<boolean> {
   // by the PODEntries type.
   //////////////////////////////////////////////////////////////////////////////
 
-  // Entry names are strings with a limited character set which make convenient
-  // to use as variable identifiers.
+  // Entry names are strings with a limited character set which make them
+  // convenient to use as variable identifiers.
   //
   // Entry values are represented by a PODValue, which includes a value and type.
   // The type controls how the value is hashed and included in ZK proofs.
   // The type itself is not part of the value, and is not hashed.
-  // Currently supported types are "string", "int", and "cryptographic".
   //
-  // Entries always get sorted when built into a Merkle tree, so the order
-  // of the original input doesn't matter.
+  // Entries always get sorted when they are built into a Merkle tree, so the
+  // order of the original input doesn't matter.
   const sampleEntries: PODEntries = {
     // String values can contain any unicode string, not limited to identifiers.
     my_favorite_dessert: { type: "string", value: "Blueberry Pie" },
+
+    // Raw byte values are also supported, and behave much like strings.
+    // A string is considered equal to a bytes value with its utf8 encoding.
+    blob: { type: "bytes", value: new Uint8Array([1, 2, 3]) },
 
     // int values are bigints with a range limited to 64-bit signed integers.
     // Ints are usable for range checks and ordering (lessThan, etc) in
@@ -85,40 +95,38 @@ export async function podDemo(): Promise<boolean> {
     someNumber: { type: "int", value: -123n },
 
     // "cryptographic" is a bigint type for values like hashes or unique
-    // IDs.  Each is a single field element which fits in a circuit signal,
-    // meaning an integer mod p for a large (254 bit) prime.
-    // In proofs, these values can be compared for equality, but not manipulated
-    // arithmetically (no addition, less-than, etc).
-    mySemaphoreID: {
+    // IDs.  Each can hold up to 254 bits (unsigned) because it is limited to a
+    // single field element in circuits (meaning an integer mod some large
+    // prime).  In proofs, these values can be compared for equality, but not
+    // manipulated arithmetically (no ranges, lessThan, etc).
+    someHash: {
       type: "cryptographic",
-
-      // The commitment is the part of a Semaphore V3 identity to include in a POD
-      // to identify a user.
-      value: semaphoreIdentity.commitment
+      value: 0x1ec239f6c8aef0662b01ce7238c1d73f7fb9e4135a58e726dd86ee59e160f01bn
     },
 
     // "cryptographic" entries can be small numbers too, and they are considered
     // equal to an "int" with the same value.  The type controls the range and
-    // what you can do with the number, not its underlying behavior.
+    // what you can do with the number, not its underlying meaning.
     smallCryptographic: {
       type: "cryptographic",
       value: 42n
     },
 
-    // There are convenience types which act as special types of int values,
-    // with differen valid ranges.
+    // There are convenience types which act like special int values,
+    // with different valid ranges and Typescript typing.
     bool: { type: "boolean", value: true },
     creationDate: { type: "date", value: new Date() },
 
-    // Other non-numeric types exist for special purposes.
-    blob: { type: "bytes", value: new Uint8Array([1, 2, 3]) },
-    userIdentity: {
+    // Ownership of PODs is usually specified using a user's EdDSA public key,
+    // which matches Semaphore V4.  The name of the owner entry is arbitrary,
+    // and can be configured in proofs.
+    ownerPublicKey: {
       type: "eddsa_pubkey",
-      value: "xDP3ppa3qjpSJO+zmTuvDM2eku7O4MKaP2yCCKnoHZ4"
+      value: encodePublicKey(semaphoreIdentity.publicKey)
     },
 
-    // Explicit null values can be used as placeholders, or to ZK prove that an
-    // entry does not have any other value.  A null entry is not the same as a
+    // Null values can be used as placeholders, or to ZK prove that an entry
+    // doesn't have any other value.  A null entry is not the same as a
     // missing entry.
     optionalValue: { type: "null", value: null }
   };
@@ -137,7 +145,7 @@ export async function podDemo(): Promise<boolean> {
 
   // Inside of a POD is the PODContent class, which forms entries into a
   // Merkle tree by hashing them.  Creating a PODContent will also validate
-  // that all of the entries are legal.
+  // that all of the entries are are well-formed and have legal values.
   const podContent = PODContent.fromEntries(sampleEntries);
 
   // The root of the Merkle tree is called the Content ID.
@@ -153,18 +161,18 @@ export async function podDemo(): Promise<boolean> {
   // PODContent can generate Merkle membership proofs which prove that an entry
   // is contained in a given root.  This is the basis of the ZK proofs which
   // can be made using PODs.
-  const entryProof = podContent.generateEntryProof("mySemaphoreID");
+  const entryProof = podContent.generateEntryProof("someHash");
   console.log("Entry proof", entryProof);
 
   // PODs are signed using EdDSA signatures, which are easy to check in a
-  // ZK circuit.  Our private keys can be any 32 bytes encoded as Base64 or hex.
-  const privateKey = "ASNFZ4mrze8BI0VniavN7wEjRWeJq83vASNFZ4mrze8";
+  // ZK circuit.  Private keys can be any 32 bytes encoded as Base64 or hex.
+  const signerPrivateKey = "ASNFZ4mrze8BI0VniavN7wEjRWeJq83vASNFZ4mrze8";
 
   // Signing a POD is usually performed in a single step like this.  No need
   // to go through the PODContent class.
-  const pod = POD.sign(sampleEntries, privateKey);
+  const pod = POD.sign(sampleEntries, signerPrivateKey);
   console.log("POD content ID + signature", pod.contentID, pod.signature);
-  const publicKey = pod.signerPublicKey;
+  const signerPublicKey = pod.signerPublicKey;
   const signature = pod.signature;
 
   // You can get the underlying PODContent from a POD if you need it.
@@ -172,7 +180,7 @@ export async function podDemo(): Promise<boolean> {
 
   // If you already have the signature from a saved POD, you can
   // recreate it without signing again.
-  const loadedPOD = POD.load(sampleEntries, signature, publicKey);
+  const loadedPOD = POD.load(sampleEntries, signature, signerPublicKey);
   console.log("Loaded POD content ID", loadedPOD.contentID);
 
   //////////////////////////////////////////////////////////////////////////////
@@ -188,7 +196,7 @@ export async function podDemo(): Promise<boolean> {
   // automatically.
   //////////////////////////////////////////////////////////////////////////////
 
-  // PODContent serializes as its just its entries, since the Merkle Tree can be
+  // PODContent serializes as just its entries, since the Merkle Tree can be
   // rebuilt on-demand.
   const jsonContent = podContent.toJSON();
   console.log("JSON content", jsonContent);
@@ -227,12 +235,11 @@ export async function podDemo(): Promise<boolean> {
   //////////////////////////////////////////////////////////////////////////////
   // A POD PCD, found in the @pcd/pod-pcd package, wraps a POD and makes
   // it part of the PCD framework.  This means it can be created,
-  // transmitted, stored, and displayed by generic PCD apps like Zupass
-  // and Podbox.
+  // transmitted, stored, and displayed by apps like Zupass and Podbox.
   //////////////////////////////////////////////////////////////////////////////
 
   // In addition to the POD itself, all PCDs have a unique ID, which usually
-  // a UUID (in theory it can be any string).
+  // a UUID (though it can be any string).
   const pcd = new PODPCD(uuid(), pod);
   console.log("PCD ID", pcd.id);
 
@@ -249,16 +256,17 @@ export async function podDemo(): Promise<boolean> {
   // derived from the entries.
   console.log("PCD is valid?", await PODPCDPackage.verify(pcd));
 
-  // PCDs can also be created by the "prove" interface.  This uses a more generic
-  // (and more verbose) argument specification which allows requests to prove
-  // to be transmitted to apps like Zupass.
+  // PCDs can also be created by the "prove" interface.  This uses a more
+  // generic (and more verbose) argument specification which allows requests to
+  // prove to be transmitted to apps like Zupass.  All the arguments must be
+  // JSON-compatible to be transmitted.
   const pcd2 = await PODPCDPackage.prove({
     entries: {
       value: podEntriesToJSON(sampleEntries),
       argumentType: ArgumentTypeName.Object
     },
     privateKey: {
-      value: privateKey,
+      value: signerPrivateKey,
       argumentType: ArgumentTypeName.String
     },
     id: {
@@ -269,8 +277,8 @@ export async function podDemo(): Promise<boolean> {
   console.log("PCD2 is valid?", await PODPCDPackage.verify(pcd2));
 
   // PCDs can also be serialized and deserialized, which is what Zupass uses
-  // for storage and sync.  This layer will (in future) also handle versioning
-  // and backward compatibility.
+  // for storage and sync.  This layer also handles versioning and backward
+  // compatibility.
   const serializedPCD = await PODPCDPackage.serialize(pcd);
   const deserializedPCD = await PODPCDPackage.deserialize(serializedPCD.pcd);
   console.log("Deserialized PCD ID", deserializedPCD.id);

--- a/packages/lib/gpc/src/gpc.ts
+++ b/packages/lib/gpc/src/gpc.ts
@@ -204,6 +204,7 @@ export function gpcPreProve(
  * @param proof the Groth16 proof
  * @param boundConfig the bound configuration specifying the constraints
  *   proven, and the specific circuit which was used.
+ * @param circuitDesc the parameters of the circuit used for the proof.
  * @param proofInputs the input data (PODs and other values) specific to this
  *  proof.
  * @returns The Groth16 proof, a bound configuration usable for reliable
@@ -215,6 +216,7 @@ export function gpcPreProve(
 export function gpcPostProve(
   proof: GPCProof,
   boundConfig: GPCBoundConfig,
+  circuitDesc: ProtoPODGPCCircuitDesc,
   proofInputs: GPCProofInputs,
   circuitOutputs: ProtoPODGPCOutputs
 ): {
@@ -224,6 +226,7 @@ export function gpcPostProve(
 } {
   const revealedClaims = makeRevealedClaims(
     boundConfig,
+    circuitDesc,
     proofInputs,
     circuitOutputs
   );
@@ -281,7 +284,13 @@ export async function gpcProve(
     artifactPaths.pkeyPath
   );
 
-  return gpcPostProve(proof, boundConfig, proofInputs, circuitOutputs);
+  return gpcPostProve(
+    proof,
+    boundConfig,
+    circuitDesc,
+    proofInputs,
+    circuitOutputs
+  );
 }
 
 /**

--- a/packages/lib/gpc/src/gpcChecks.ts
+++ b/packages/lib/gpc/src/gpcChecks.ts
@@ -24,8 +24,6 @@ import {
   printPODValueOrTuple,
   requireType
 } from "@pcd/pod";
-import { Identity as IdentityV3 } from "@pcd/semaphore-identity-v3-wrapper";
-import { Identity as IdentityV4 } from "@semaphore-protocol/identity";
 import isEqual from "lodash/isEqual";
 import uniq from "lodash/uniq";
 import {
@@ -549,21 +547,40 @@ export function checkProofInputs(proofInputs: GPCProofInputs): GPCRequirements {
 
   if (proofInputs.owner !== undefined) {
     if (proofInputs.owner.semaphoreV3 !== undefined) {
+      // instanceof checking is overly strict across separate libraries, so we
+      // directly check the properties of the fields we need to access.
       requireType(`owner.SemaphoreV3`, proofInputs.owner.semaphoreV3, "object");
-      if (!(proofInputs.owner.semaphoreV3 instanceof IdentityV3)) {
-        throw new TypeError(
-          `owner.semaphoreV3 must be a SemaphoreV3 Identity object.`
-        );
-      }
+      requireType(
+        `owner.SemaphoreV3.commitment`,
+        proofInputs.owner.semaphoreV3.commitment,
+        "bigint"
+      );
     }
 
     if (proofInputs.owner.semaphoreV4 !== undefined) {
+      // instanceof checking is overly strict across separate libraries, so we
+      // directly check the properties of the fields we need to access.
       requireType(`owner.SemaphoreV4`, proofInputs.owner.semaphoreV4, "object");
-      if (!(proofInputs.owner.semaphoreV4 instanceof IdentityV4)) {
+      requireType(
+        `owner.SemaphoreV4.publicKey`,
+        proofInputs.owner.semaphoreV4.publicKey,
+        "array"
+      );
+      if (proofInputs.owner.semaphoreV4.publicKey.length !== 2) {
         throw new TypeError(
-          `owner.semaphoreV4 must be a SemaphoreV4 Identity object.`
+          `owner.semaphoreV4.publicKey must be a Point (array of 2 bigints)`
         );
       }
+      requireType(
+        "proofInputs.owner.semaphoreV4.publicKey[0]",
+        proofInputs.owner.semaphoreV4.publicKey[0],
+        "bigint"
+      );
+      requireType(
+        "proofInputs.owner.semaphoreV4.publicKey[1]",
+        proofInputs.owner.semaphoreV4.publicKey[1],
+        "bigint"
+      );
     }
 
     if (proofInputs.owner.externalNullifier !== undefined) {

--- a/packages/lib/gpc/src/gpcCompile.ts
+++ b/packages/lib/gpc/src/gpcCompile.ts
@@ -1528,6 +1528,7 @@ export function compileVerifyOwnerV4(
  */
 export function makeRevealedClaims(
   proofConfig: GPCBoundConfig,
+  circuitDesc: ProtoPODGPCCircuitDesc,
   proofInputs: GPCProofInputs,
   circuitOutputs: ProtoPODGPCOutputs
 ): GPCRevealedClaims {
@@ -1578,14 +1579,16 @@ export function makeRevealedClaims(
       ? {
           owner: {
             externalNullifier: proofInputs.owner.externalNullifier,
-            ...(proofInputs.owner?.semaphoreV3 !== undefined
+            ...(proofInputs.owner?.semaphoreV3 !== undefined &&
+            circuitDesc.includeOwnerV3
               ? {
                   nullifierHashV3: BigInt(
                     circuitOutputs.ownerV3RevealedNullifierHash[0]
                   )
                 }
               : {}),
-            ...(proofInputs.owner?.semaphoreV4 !== undefined
+            ...(proofInputs.owner?.semaphoreV4 !== undefined &&
+            circuitDesc.includeOwnerV4
               ? {
                   nullifierHashV4: BigInt(
                     circuitOutputs.ownerV4RevealedNullifierHash[0]

--- a/packages/lib/gpc/test/gpc.spec.ts
+++ b/packages/lib/gpc/test/gpc.spec.ts
@@ -246,6 +246,7 @@ describe(`gpc library (Compiled ${circuitParamType} artifacts) should work`, asy
     const { proof, boundConfig, revealedClaims } = gpcPostProve(
       orgProof,
       orgBoundConfig,
+      pCircuitDesc,
       proofInputs,
       pCircuitOutputs
     );

--- a/packages/pcd/gpc-pcd/src/GPCPCDPackage.ts
+++ b/packages/pcd/gpc-pcd/src/GPCPCDPackage.ts
@@ -136,6 +136,7 @@ async function checkProofArgs(args: GPCPCDArgs): Promise<{
         ? {
             owner: {
               semaphoreV3: ownerSemaphorePCD?.claim?.identityV3,
+              semaphoreV4: ownerSemaphorePCD?.claim?.identityV4,
               externalNullifier: externalNullifier
             }
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5941,7 +5941,7 @@
     "@ethersproject/strings" "^5.6.1"
     js-sha512 "^0.8.0"
 
-"@semaphore-protocol/identity@^4.5.0":
+"@semaphore-protocol/identity@^4.0.3", "@semaphore-protocol/identity@^4.5.0":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@semaphore-protocol/identity/-/identity-4.5.0.tgz#d5c412eb609df2686b7216825ec88670ef73461b"
   integrity sha512-TIKxF2Lir1LppDQDJU6Z/aJUkocHT03BLpzv5vFEdCo/IT4g/4BhbFp2UQui7HyDE+JgMfUASXfScbFfo/5ULA==


### PR DESCRIPTION
I updated the POD+GPC examples to use Semaphore V4, but in the process ran into some issues with lead to usability enhancments to GPC proving:

- Replaced `instanceof` checks for semaphore identities with more limited checks of the fields we needs.  This avoids issues with differently built classes across multiple libraries.
- Made it safe to pass both V3 and V4 identities, even when one of them isn't used.
- Pass CircuitDescription into gpcPostProve to allow the above.  (Technically a breaking change, but nobody's using htis function, only gpcPreVerify).
- Made GPCPCD pass along both identities so that it can prove V4 ownership.  I tested this end-to-end on localhost