### PR TITLE
0XP-1528: batched parallelized order fetching from pretix for podbox + improved load scheduling

### DIFF
--- a/apps/generic-issuance-client/package.json
+++ b/apps/generic-issuance-client/package.json
@@ -38,6 +38,7 @@
     "monaco-editor": "^0.47.0",
     "monaco-themes": "^0.4.4",
     "pretty-bytes": "^6.1.1",
+    "pretty-ms": "^9.1.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/generic-issuance-client/src/pages/dashboard/PipelineTable.tsx
+++ b/apps/generic-issuance-client/src/pages/dashboard/PipelineTable.tsx
@@ -14,6 +14,7 @@ import {
   getSortedRowModel,
   useReactTable
 } from "@tanstack/react-table";
+import prettyMilliseconds from "pretty-ms";
 import { ReactNode, useCallback, useMemo, useState } from "react";
 import styled, { FlattenSimpleInterpolation, css } from "styled-components";
 import { PodLink } from "../../components/Core";
@@ -50,7 +51,7 @@ export type PipelineRow = {
   id: string;
   loadTraceLink: string;
   allTraceLink: string;
-  lastLoad?: string;
+  lastLoadDetails?: string;
   name?: string;
   displayName: string;
   pipeline: PipelineDefinition;
@@ -88,7 +89,16 @@ export function PipelineTable({
         id: entry.pipeline.id,
         loadTraceLink: getLoadTraceHoneycombLinkForPipeline(entry.pipeline.id),
         allTraceLink: getAllHoneycombLinkForPipeline(entry.pipeline.id),
-        lastLoad: entry.extraInfo.lastLoad?.lastRunEndTimestamp,
+        lastLoadDetails: entry.extraInfo.lastLoad
+          ? timeAgoStr(entry.extraInfo.lastLoad.lastRunEndTimestamp) +
+            " ago in " +
+            prettyMilliseconds(
+              new Date(entry.extraInfo.lastLoad.lastRunEndTimestamp).getTime() -
+                new Date(
+                  entry.extraInfo.lastLoad.lastRunStartTimestamp
+                ).getTime()
+            )
+          : "n/a",
         name: entry.pipeline.options?.name,
         displayName: pipelineDisplayNameStr(entry.pipeline),
         pipeline: entry.pipeline
@@ -169,9 +179,9 @@ export function PipelineTable({
         )
       }),
 
-      columnHelper.accessor("lastLoad", {
+      columnHelper.accessor("lastLoadDetails", {
         header: "Last Load",
-        cell: (props) => timeAgoStr(props.row.original.lastLoad)
+        cell: (props) => props.row.original.lastLoadDetails
       }),
 
       isAdminView

--- a/apps/passport-server/.env.example
+++ b/apps/passport-server/.env.example
@@ -1,6 +1,6 @@
 # This file is intended to be used as a starting point for local
 # development. You should be able to copy it as-is into a file
-# named `.env` as a sibling of this file, and be able to run 
+# named `.env` as a sibling of this file, and be able to run
 # passport-server
 ##################################################################
 
@@ -16,7 +16,7 @@ PASSPORT_SERVER_URL="http://localhost:3002"
 PASSPORT_CLIENT_URL="http://localhost:3000"
 
 # To enable notifications from the server to be sent to Discord
-# 
+#
 # DISCORD_TOKEN=
 # DISCORD_ALERTS_CHANNEL_ID=
 
@@ -47,11 +47,11 @@ DATABASE_DB_NAME=postgres
 DATABASE_SSL=false
 
 # To enable honeycomb tracing set this API key
-# 
+#
 # HONEYCOMB_API_KEY=
 
 # To enable error reporting, both these environment variables must be set
-# 
+#
 # ROLLBAR_TOKEN=
 # ROLLBAR_ENV_NAME=
 
@@ -122,13 +122,13 @@ WORKER_QUANTITY=1
 ##################################################################
 
 # So that Podbox server knows the url of where its corresponding client lives.
-# 
+#
 GENERIC_ISSUANCE_CLIENT_URL="http://localhost:3005"
 
-# To enable server-issued PCDs using the generic issuance feature, the server needs an an EdDSA 
-# private key. You can generate one using the following command at the root of the project, 
+# To enable server-issued PCDs using the generic issuance feature, the server needs an an EdDSA
+# private key. You can generate one using the following command at the root of the project,
 # after installing dependencies and building the project:
-# 
+#
 # node -e 'console.log(require("@pcd/eddsa-pcd").newEdDSAPrivateKey())' | pbcopy
 GENERIC_ISSUANCE_EDDSA_PRIVATE_KEY="129806f9d68c3cf87450a968748fd31f01ba4e6f2078d80f24ebab23d98df7cf"
 
@@ -143,7 +143,7 @@ GENERIC_ISSUANCE_ZUPASS_PUBLIC_KEY=["00f669040a1c31ff18b8e221b94ac36580da68a05c6
 # in the generic issuance service
 # e.g. you could set the value to be ["ivan@0xparc.org"] to make the server
 # set the user with that email address to be an admin on start-up.
-# 
+#
 GENERIC_ISSUANCE_ADMINS=["ivan@0xparc.org", "admin@podbox.dev"]
 
 # if true, and both `STYTCH_PROJECT_ID` and `STYTCH_SECRET` are
@@ -172,7 +172,7 @@ IS_LOCAL_HTTPS=false
 # TELEGRAM_BOT_DISABLED=
 
 # For anonymous message posting rate limit (per topic)
-# 
+#
 # MAX_DAILY_ANON_TOPIC_POSTS_PER_USER=3
 # url for anon-message-client
 # TELEGRAM_BOT_ANON_WEBSITE=
@@ -187,15 +187,14 @@ IS_LOCAL_HTTPS=false
 # The anonymous message client, like https://dev.local:4000 or https://zk-tg.com
 # TELEGRAM_ANON_WEBSITE=
 
-
 ##################################################################
 ##################################################################
 #   Legacy Integration
 ##################################################################
 ##################################################################
 
-# Zuzalu 2023 
-# 
+# Zuzalu 2023
+#
 # PRETIX_TOKEN=
 # PRETIX_ORG_URL=
 # PRETIX_ZU_EVENT_ID=
@@ -205,7 +204,7 @@ IS_LOCAL_HTTPS=false
 # ZUCONNECT_MOCK_TICKETS='["test@example.com", "another@example.com"]'
 
 # Devconnect 2023
-# 
+#
 # To disable syncing tickets from Pretix for local development
 # PRETIX_SYNC_DISABLED=
 
@@ -230,3 +229,11 @@ IS_LOCAL_HTTPS=false
 # If true, the generic issuance service will not schedule pipeline loads on a loop,
 # but will instead load pipelines on demand.
 # GENERIC_ISSUANCE_TEST_MODE="true"
+
+# The list of Pretix organizer urls to enable batching order requests for. If
+# batching is enabled for an organizer, the server will fetch 30 pages of orders
+# at a time, rather than sequentially one page at a time. Instead of checking
+# whether we've loaded all orders by checking that the last page does not have the
+# `next` field in its response, we instead know that we've loaded all orders when
+# there are 404 errors for pages that are not the first page, and no other errors.
+# PRETIX_BATCH_ENABLED_FOR=[""]

--- a/apps/passport-server/src/services/generic-issuance/GenericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/GenericIssuanceService.ts
@@ -438,10 +438,10 @@ export class GenericIssuanceService {
       );
     }
 
-    const tickets = await pipeline.getAllTickets();
+    const tickets = await pipeline.getAllTicketsForEmail(email);
 
     const matchingTickets = tickets.atoms.filter(
-      (atom) => atom.email === email && atom.orderCode === orderCode
+      (atom) => atom.orderCode === orderCode
     );
 
     const ticketDatas = matchingTickets.map(

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -625,6 +625,7 @@ export class PretixPipeline implements BasePipeline {
         orgUrl,
         token,
         eventId,
+        this.definition.options.batchFetch ?? false,
         this.abort
       );
       const checkinLists = await this.api.fetchEventCheckinLists(

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -2305,6 +2305,18 @@ export class PretixPipeline implements BasePipeline {
     };
   }
 
+  public async getAllTicketsForEmail(email: string): Promise<{
+    atoms: PretixAtom[];
+    manual: ManualTicket[];
+  }> {
+    return {
+      atoms: await this.db.loadByEmail(this.id, email.toLowerCase()),
+      manual: (this.definition.options.manualTickets ?? []).filter(
+        (mt) => mt.attendeeEmail.toLowerCase() === email.toLowerCase()
+      )
+    };
+  }
+
   public static is(p: Pipeline | undefined): p is PretixPipeline {
     return p?.type === PipelineType.Pretix;
   }

--- a/packages/lib/passport-interface/src/genericIssuanceTypes.ts
+++ b/packages/lib/passport-interface/src/genericIssuanceTypes.ts
@@ -460,7 +460,13 @@ const PretixPipelineOptionsSchema = BasePipelineOptionsSchema.extend({
   semaphoreGroups: SemaphoreGroupListSchema,
   enablePODTickets: z.boolean().optional(),
   autoIssuance: z.array(AutoIssuanceOptionsSchema).optional(),
-  userPermissions: z.array(UserPermissionsOptionsSchema).optional()
+  userPermissions: z.array(UserPermissionsOptionsSchema).optional(),
+  /**
+   * The corresponding org url must be in the `PRETIX_BATCH_ENABLED_FOR`
+   * environment variable in order to enable batching for this pipeline,
+   * otherwise this field is a no-op.
+   */
+  batchFetch: z.boolean().optional()
 }).refine((val) => {
   // Validate that the manual tickets have event and product IDs that match the
   // event configuration.

--- a/packages/lib/util/src/Errors.ts
+++ b/packages/lib/util/src/Errors.ts
@@ -11,6 +11,18 @@ export function getErrorMessage(e: unknown | Error): string {
 }
 
 /**
+ * If the value is an `Error`, this returns the value. Otherwise, it creates a
+ * new `Error` with the stringified value as the message.
+ */
+export function toError(e: unknown | Error): Error {
+  if (e instanceof Error) {
+    return e;
+  }
+
+  return new Error(e + "");
+}
+
+/**
  * Check if a parameter is defined. If not, it throws an error.
  * @param parameter Parameter to be checked.
  * @param parameterName Name of the parameter.

--- a/turbo.json
+++ b/turbo.json
@@ -237,6 +237,7 @@
     "LOCAL_FILE_SERVICE_ENABLED",
     "SELF_HOSTED_PODBOX_MODE",
     "GENERIC_ISSUANCE_TEST_MODE",
+    "PRETIX_BATCH_ENABLED_FOR",
     "//// add env vars above this line ////"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17858,6 +17858,11 @@ parse-ms@^3.0.0:
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-3.0.0.tgz#3ea24a934913345fcc3656deda72df921da3a70e"
   integrity sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==
 
+parse-ms@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-4.0.0.tgz#c0c058edd47c2a590151a718990533fd62803df4"
+  integrity sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -18511,6 +18516,13 @@ pretty-ms@^8.0.0:
   integrity sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==
   dependencies:
     parse-ms "^3.0.0"
+
+pretty-ms@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-9.1.0.tgz#0ad44de6086454f48a168e5abb3c26f8db1b3253"
+  integrity sha512-o1piW0n3tgKIKCwk2vpM/vOV13zjJzvP37Ioze54YlTHE06m4tjEbzg9WsKkvTuyYln2DHjo5pY4qrZGI0otpw==
+  dependencies:
+    parse-ms "^4.0.0"
 
 prisma@^4.12.0:
   version "4.16.2"


### PR DESCRIPTION
### summary

- add [`PRETIX_BATCH_ENABLED_FOR`](https://github.com/proofcarryingdata/zupass/blob/ivan/parallel-fetch/apps/passport-server/.env.example#L239) env var to `passport-server`, which is an optional JSON array of pretix `orgUrl`s for which to enable the batch order fetching capability. 
  - this does *not* by default turn on batch fetching for pipelines connected to pretix via those org urls. to enable batch fetching for a pipeline, beyond including its `orgUrl` in the aforementioned env var, you must *also* enable the following option in the pipeline's configuration:
- [`batchFetch`](https://github.com/proofcarryingdata/zupass/blob/ivan/parallel-fetch/packages/lib/passport-interface/src/genericIssuanceTypes.ts#L469) - an optional boolean on `PretixPipelineOptions`. If a pipeline's `orgUrl` is present in the `PRETIX_BATCH_ENABLED_FOR` array, and its `batchFetch` option is `true`, then the pipeline fetches orders from pretix in batches. otherwise, orders are loaded as before: sequentially, one page at a time.
- slightly change [`PipelineExecutorSubservice#startPipelineLoadLoop`](https://github.com/proofcarryingdata/zupass/blob/ivan/parallel-fetch/apps/passport-server/src/services/generic-issuance/subservices/PipelineExecutorSubservice.ts#L524), such that after all pipelines load (or fail to load), instead of scheduling all of the pipelines to load `60s` after all of them *completed*, it schedules them to load again `60s` after all of them *started* loading. 
  - The reason this delay is there in the first place is to avoid hitting the Pretix API rate limit. The rate limit measures the 'rate' in increments of one minute. If there were no delay, in the case there was a single Pretix pipeline with a single order, we would hit the rate limit defined in `OrganizerRequestQueue`.
  - Scheduling in this new way increases the frequency at which pipelines load, without causing excessive API throughput.
- improve performance of `handleGetTicketPreview` (which is used by the one-click flow) by querying tickets by email from the indexed data structure rather than by filtering the full list of atoms by email, i.e. its complexity is now `O(1)` rather than `O(1)`

The batched order loading works as follows:
- load `30` consecutive pages of orders (each page can have at most 50 orders) concurrently from Pretix at a time.
- if the first page returns a `404`, or if any other page returns a non-`404` response, then the loading is considered to have had an error
- if no other errors occur, and if any other page than the first page in a batch of loaded pages returned a `404`, we consider that to mean that we've reached the end of the list of pages, and that we've successfully loaded all the orders, and we do not schedule another batch of loads.
- otherwise, if there were no errors, `404` or not `404`, we schedule the next batch of `30` orders to load from Pretix.
- repeat this process until some of the results of a batched load are `404`s

### impact
- this speeds up the load of the Devcon pipeline from `~6m` to `~1m`.
- tangentially, this will speed up ALL other pipeline syncs as well. since the pipeline load scheduler waits for all pipeline loads to finish before scheduling another load in `60s`, speeding up a single pipeline to be faster than `60s` also makes all other pipelines load more frequently. this is not really that impactful, as the Devcon pipeline runs on a separate self-hosted Podbox, but it may be impactful later.
- finally, due to the increased loading frequency scheduling change in `startPipelineLoadLoop`, the Devcon pipeline will end up loading once every `~1m` (given that it takes `1m` to load, causing there to be a delay of `0` until the next load is scheduled, rather than the previously static `60s` delay), rather than once every `~1m + ~6m = ~7m`, meaning that a new order placed through the Pretix shop will end up in the Devcon pipeline in at most `~1m` (on avg. `~30s`) rather than in at most `~7m` (on avg. `3m 30s`)
- (unmeasured) `handleGetTicketPreview` should now be more performant

#### Devcon pipeline load before
<img width="549" alt="Screenshot 2024-10-29 at 5 25 35 PM" src="https://github.com/user-attachments/assets/70f99f95-f36b-466f-b01d-6c328941861e">

#### Devcon pipeline load after
<img width="544" alt="Screenshot 2024-10-29 at 5 02 17 PM" src="https://github.com/user-attachments/assets/c421d2cf-6b8f-4240-9ebe-9b9e2b921216">
