### PR TITLE
[0XP-1481] investigate caching one-click-preview page

### DIFF
--- a/apps/passport-client/src/sharedConstants.ts
+++ b/apps/passport-client/src/sharedConstants.ts
@@ -4,7 +4,9 @@ import { ARTIFACTS_NPM_VERSION } from "@pcd/gpcircuits/constants";
  * Single constant shared between the service worker and the page code which
  * registers it.
  */
-export const SERVICE_WORKER_ENABLED = process.env.NODE_ENV !== "development";
+export const SERVICE_WORKER_ENABLED =
+  process.env.NODE_ENV !== "development" ||
+  process.env.ENABLE_LOCAL_DEV_SERVICE_WORKER === "true";
 
 /** Start time of Devconnect 2023, from https://devconnect.org/schedule */
 export const DEVCONNECT_2023_START = Date.parse(

--- a/apps/passport-client/src/worker/tsconfig.json
+++ b/apps/passport-client/src/worker/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "files": ["service-worker.ts", "../sharedConstants.ts"],
   "compilerOptions": {
-    "lib": ["ES2020", "DOM", "WebWorker"]
+    "lib": ["ES2020", "DOM", "WebWorker"],
+    "inlineSourceMap": true
   }
 }

--- a/apps/passport-server/resources/one-click-page/index.html
+++ b/apps/passport-server/resources/one-click-page/index.html
@@ -201,6 +201,51 @@
     function redirectToZupass() {
       window.location.replace(clientPath);
     }
+
+    async function registerServiceWorker() {
+      const SERVICE_WORKER_ENABLED = true;
+      if (!("serviceWorker" in navigator)) {
+        console.log(`[SERVICE_WORKER] service workers not supported`);
+        return;
+      }
+
+      if (!SERVICE_WORKER_ENABLED) {
+        console.log(
+          `[SERVICE_WORKER] not registering service worker in development mode`
+        );
+        return;
+      }
+
+      const serviceWorkerPath = "/service-worker.js";
+
+      console.log(
+        `[SERVICE_WORKER] attempting to register ${serviceWorkerPath}`
+      );
+
+      try {
+        await navigator.serviceWorker.register(serviceWorkerPath, {
+          scope: "/"
+        });
+
+        navigator.serviceWorker.ready.then((registration) => {
+          registration.active.postMessage(
+            JSON.stringify({
+              action: "cache",
+              url: window.location.href
+            })
+          );
+        });
+
+        console.log(`[SERVICE_WORKER] registered ${serviceWorkerPath}`);
+      } catch (e) {
+        console.log(
+          `[SERVICE_WORKER] error registering service worker ${serviceWorkerPath}`,
+          e
+        );
+      }
+    }
+
+    registerServiceWorker();
   </script>
 
   <body>

--- a/turbo.json
+++ b/turbo.json
@@ -241,6 +241,7 @@
     "LOCAL_FILE_SERVICE_ENABLED",
     "SELF_HOSTED_PODBOX_MODE",
     "GENERIC_ISSUANCE_TEST_MODE",
+    "ENABLE_LOCAL_DEV_SERVICE_WORKER",
     "//// add env vars above this line ////"
   ]
 }


### PR DESCRIPTION
#### summary
- I think this PR basically implements caching for the one-click preview page, as long as it's actually proxied through the same host that hosts the zupass client (since the way I've implemented this was on top of the existing service worker infra).
- I've tested this locally and am pretty sure it works.
- I'd like for this to be tested on a staging server, along with the pass-through proxy for one click pages, prior to being confident that this is implemented properly.
  - This probably means I'd like to hand this off to someone else to finish up.

#### details
- to facilitate local development, I edited `passport-client`'s [build script](https://github.com/proofcarryingdata/zupass/pull/2070/files#diff-03ee4e57fbf043d2e0657ba301c9b559a3b5dd6db2d5e1a60106a0b14752f5c8R209-R220) to not only serve the built zupass client's build artifacts, but also to forward requests to the generic-issuance backend for requests to `localhost:3000/one-click-preview/...`, similarly to how that forwarding will be done in production and currently is done on `staging-richard`
  - if you append `?slow` to a one-click preview URL (in local dev only), this build script will deliberately sleep for `30s` prior to returning a response. this can be used to test that the service worker actually did cache that preview page. the way that the caching works is that if the request to the one-click preview url takes longer than 5 seconds to load, it'll attempt to load the page from the cache. I've verified that this works locally - preview pages with the `?slow` suffix hang for 5 seconds, then render, despite the actual request taking `30s`.
- I edited the [one click preview html](https://github.com/proofcarryingdata/zupass/blob/ivan/cache-one-click-page/apps/passport-server/resources/one-click-page/index.html#L205) on the podbox backend to include a script that loads and registers the same service worker that the normal zupass client does.
- I edited the [service worker itself](https://github.com/proofcarryingdata/zupass/blob/ivan/cache-one-click-page/apps/passport-client/src/worker/service-worker.ts#L314) to be able to receive messages posted from the application's webpage. invoke that api on the one click preview page to cache itself, so that that particular preview page is cached in the service worker's ephemeral cache.