### PR TITLE
0XP-1605: One-click QR fixes

### DIFF
--- a/apps/passport-server/resources/one-click-page/index.html
+++ b/apps/passport-server/resources/one-click-page/index.html
@@ -75,6 +75,9 @@
     align-self: stretch;
     border-radius: 16px;
     background: var(--white);
+    &:not(:last-child) {
+      margin-bottom: 25px;
+    }
 
     /* shadow-sm */
     box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.05);
@@ -492,6 +495,8 @@
               d="M20.7908 18.8751C17.9001 18.8751 15.5488 16.6925 15.5488 14.0098C15.5488 13.6068 15.8746 13.2803 16.2766 13.2803C16.6787 13.2803 17.0045 13.6068 17.0045 14.0098C17.0045 15.8878 18.7029 17.4154 20.7901 17.4154C22.8774 17.4154 24.5758 15.8878 24.5758 14.0098C24.5758 13.6068 24.9023 13.2803 25.3037 13.2803C25.705 13.2803 26.0315 13.6068 26.0315 14.0098C26.0315 16.6925 23.6802 18.8751 20.7895 18.8751H20.7908Z"
               fill="#154133" />
           </svg></button>
+        
+        {{#tickets}}
         <div class="ticket">
           <img class="ticket__qr-code" src="{{qr}}" draggable="false" />
           <div class="ticket__text-container">
@@ -502,7 +507,7 @@
               <span class="ticket__subtitle--text">{{ticketName}}</span>
             </div>
           </div>
-          {{#addonsCount}}
+          {{#showAddons}}
           <button id="addons-btn" type="button" class="ticket__addons-btn">
             {{#moreThanOneAddon}}
             <span class="ticket__subtitle--text" style="font-size: 16px;">View {{addonsCount}}
@@ -529,12 +534,13 @@
                 d="M8.5 9.417a.917.917 0 1 1 1.833 0 .917.917 0 0 1-1.833 0ZM8.5 13.083a.917.917 0 1 1 1.833 0 .917.917 0 0 1-1.833 0ZM13.083 8.5a.917.917 0 1 0 0 1.833.917.917 0 0 0 0-1.833ZM12.166 13.084a.917.917 0 1 1 1.833 0 .917.917 0 0 1-1.833 0ZM11.25 10.333a.917.917 0 1 0 0 1.833.917.917 0 0 0 0-1.833Z" />
             </svg>
           </button>
-          {{/addonsCount}}
-          {{^addonsCount}}
+          {{/showAddons}}
+          {{^showAddons}}
           <!-- spacer when we dont have any addon -->
           <div style="height:16px;" />
-          {{/addonsCount}}
+          {{/showAddons}}
         </div>
+        {{/tickets}}
       </div>
     </div>
   </main>

--- a/apps/passport-server/resources/one-click-page/index.html
+++ b/apps/passport-server/resources/one-click-page/index.html
@@ -493,7 +493,7 @@
               fill="#154133" />
           </svg></button>
         <div class="ticket">
-          <img class="ticket__qr-code" src="{{qr}}" />
+          <img class="ticket__qr-code" src="{{qr}}" draggable="false" />
           <div class="ticket__text-container">
             <span class="ticket__title">{{attendeeName}}</span>
             <div class="ticket__subtitle--container">
@@ -576,7 +576,7 @@
           <div class="swiper-slide">
             <div class="modal__qr--container">
               <div class="modal__qr">
-                <img class="modal__qr--image" src="{{image}}" />
+                <img class="modal__qr--image" src="{{image}}" draggable="false" />
               </div>
               <span class="modal__qr--text">{{name}}</span>
             </div>

--- a/apps/passport-server/src/routing/routes/genericIssuanceRoutes.ts
+++ b/apps/passport-server/src/routing/routes/genericIssuanceRoutes.ts
@@ -826,15 +826,21 @@ export function initGenericIssuanceRoutes(
       );
 
       const rendered = Mustache.render(file, {
+        tickets: await Promise.all(
+          main.map(async (ticket, i) => ({
+            // only show add-ons for the first ticket, and if we have 1 or more add-on
+            showAddons: i === 0 && addOnsQrs.length > 0,
+            attendeeName:
+              ticket.attendeeName !== ""
+                ? ticket.attendeeName.toUpperCase()
+                : ticket.eventName.toUpperCase(),
+            attendeeEmail: ticket.attendeeEmail,
+            ticketName: ticket.ticketName,
+            qr: await getTicketImage(ticket)
+          }))
+        ),
         eventName: ticket.eventName.toUpperCase(),
-        attendeeName:
-          ticket.attendeeName !== ""
-            ? ticket.attendeeName.toUpperCase()
-            : ticket.eventName.toUpperCase(),
-        attendeeEmail: ticket.attendeeEmail,
-        ticketName: ticket.ticketName,
         eventLocation: ticket.eventLocation,
-        qr: await getTicketImage(ticket),
         backgroundImage: ticket.imageUrl,
         count: ticketsCount,
         isMoreThanOne: ticketsCount > 1,

--- a/apps/passport-server/src/services/generic-issuance/GenericIssuanceService.ts
+++ b/apps/passport-server/src/services/generic-issuance/GenericIssuanceService.ts
@@ -65,9 +65,9 @@ import {
 import { PCDHTTPError } from "../../routing/pcdHttpError";
 import { ApplicationContext } from "../../types";
 import { logger } from "../../util/logger";
+import { LocalFileService } from "../LocalFileService";
 import { DiscordService } from "../discordService";
 import { EmailService } from "../emailService";
-import { LocalFileService } from "../LocalFileService";
 import { PagerDutyService } from "../pagerDutyService";
 import { PersistentCacheService } from "../persistentCacheService";
 import { InMemoryPipelineAtomDB } from "./InMemoryPipelineAtomDB";
@@ -440,8 +440,19 @@ export class GenericIssuanceService {
 
     const tickets = await pipeline.getAllTickets();
 
+    // Check that a valid atom exists with the given orderCode and email
+    const validAtom = tickets.atoms.find(
+      (atom) => atom.orderCode === orderCode && atom.email === email
+    );
+    if (!validAtom) {
+      throw new PCDHTTPError(
+        400,
+        `No ticket found with order code ${orderCode} and email ${email}`
+      );
+    }
+
     const matchingTickets = tickets.atoms.filter(
-      (atom) => atom.email === email && atom.orderCode === orderCode
+      (atom) => atom.email === email
     );
 
     const ticketDatas = matchingTickets.map(


### PR DESCRIPTION
This PR does a few things that make the one-click preview page better:

- It fetches all tickets under a given email, rather than just those under the given order. It still checks that the (email, order) pair corresponds to a valid Pretix order.
- If there are multiple non-addon tickets, show them all. Show all add-ons under the first non-addon ticket by default (this isn't ideal, but unfortunately mustache is a bit hard to configure dynamic modal rendering).
- Minor styling fixes, such as adding padding between tickets and making images not draggable

**Example (one order that has 2 non-add ons and 5 add-ons)**

Before (in current prod):

<img width="500" alt="Screenshot 2024-11-01 at 12 02 44 AM" src="https://github.com/user-attachments/assets/2e3f9b58-6063-4254-8a47-dd58af389c04">


After (on local):

https://github.com/user-attachments/assets/5f4a0f94-9fea-42cf-89e8-5bffc6ca2807

