### PR TITLE
Zapp Screen changes

### DIFF
--- a/apps/passport-client/components/screens/EmbeddedScreens/EmbeddedGPCProofScreen.tsx
+++ b/apps/passport-client/components/screens/EmbeddedScreens/EmbeddedGPCProofScreen.tsx
@@ -21,6 +21,7 @@ import {
   usePCDCollection,
   useZappOrigin
 } from "../../../src/appHooks";
+import { BANNER_HEIGHT } from "../../../src/sharedConstants";
 import { useSyncE2EEStorage } from "../../../src/useSyncE2EEStorage";
 import { getGPCArtifactsURL } from "../../../src/util";
 import { getPODsForCollections } from "../../../src/zapp/collections";
@@ -463,7 +464,7 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  height: 100vh;
+  height: calc(100vh - ${BANNER_HEIGHT}px);
   padding: 24px 24px 20px 24px;
   width: 100%;
   gap: 16px;

--- a/apps/passport-client/components/screens/ZappScreens/ApprovePermissionsScreen.tsx
+++ b/apps/passport-client/components/screens/ZappScreens/ApprovePermissionsScreen.tsx
@@ -1,15 +1,16 @@
 import { Zapp } from "@parcnet-js/client-rpc";
-import { ReactNode, useLayoutEffect, useRef } from "react";
+import { ReactNode, useRef } from "react";
 import styled from "styled-components";
-import { useDispatch, useZapp, useZappOrigin } from "../../../src/appHooks";
-import { AppContainer } from "../../shared/AppContainer";
-import { BottomModalHeader } from "../../../new-components/shared/BottomModal";
 import {
   DescriptiveAccordion,
   DescriptiveAccordionRef,
   DescriptiveAccrodionChild
 } from "../../../new-components/shared/Accordion";
+import { BottomModalHeader } from "../../../new-components/shared/BottomModal";
 import { Button2 } from "../../../new-components/shared/Button";
+import { useDispatch, useZapp, useZappOrigin } from "../../../src/appHooks";
+import { BANNER_HEIGHT } from "../../../src/sharedConstants";
+import { AppContainer } from "../../shared/AppContainer";
 
 /**
  * This screen is only ever shown in a popup modal. It is used when Zupass is
@@ -56,61 +57,43 @@ function Permissions({ zapp }: { zapp: Zapp }): ReactNode {
     });
   }
   if (zapp.permissions.REQUEST_PROOF) {
+    const collections = zapp.permissions.REQUEST_PROOF.collections.join(", ");
     chidren.push({
-      title: "Request proof",
-      description: `This will allow ${
-        zapp.name
-      } to request zero-knowldge proofs using data from these collections: ${zapp.permissions.REQUEST_PROOF.collections.join(
-        ","
-      )}`
+      title: `Request ZK proofs from ${collections}`,
+      description: `This will allow ${zapp.name} to request zero-knowldge proofs using data from these collections: ${collections}`
     });
   }
   if (zapp.permissions.READ_POD) {
+    const collections = zapp.permissions.READ_POD.collections.join(", ");
     chidren.push({
-      title: "Read PODs",
-      description: `This will allow ${
-        zapp.name
-      } to read PODs from these collections: ${zapp.permissions.READ_POD.collections.join(
-        ","
-      )}`
+      title: `Read PODs from ${collections}`,
+      description: `This will allow ${zapp.name} to read PODs from these collections: ${collections}`
     });
   }
   if (zapp.permissions.INSERT_POD) {
+    const collections = zapp.permissions.INSERT_POD.collections.join(", ");
     chidren.push({
-      title: "Insert PODs",
-      description: `This will allow ${
-        zapp.name
-      } to insert PODs from these collections: ${zapp.permissions.INSERT_POD.collections.join(
-        ","
-      )}`
+      title: `Insert PODs to ${collections}`,
+      description: `This will allow ${zapp.name} to insert PODs to these collections: ${collections}`
     });
   }
   if (zapp.permissions.DELETE_POD) {
+    const collections = zapp.permissions.DELETE_POD.collections.join(", ");
     chidren.push({
-      title: "Delete PODs",
-      description: `This will allow ${
-        zapp.name
-      } to delete PODs from these collections: ${zapp.permissions.DELETE_POD.collections.join(
-        ","
-      )}`,
+      title: `Delete PODs from ${collections}`,
+      description: `This will allow ${zapp.name} to delete PODs from these collections: ${collections}`,
       color: "var(--new-danger)"
     });
   }
 
   if (zapp.permissions.SUGGEST_PODS) {
+    const collections = zapp.permissions.SUGGEST_PODS.collections.join(", ");
     chidren.push({
-      title: "Suggest PODs",
-      description: `This will allow ${
-        zapp.name
-      } to suggest PODs from these collections: ${zapp.permissions.SUGGEST_PODS.collections.join(
-        ","
-      )}`
+      title: `Suggest PODs to ${collections}`,
+      description: `This will allow ${zapp.name} to suggest PODs to these collections: ${collections}`
     });
   }
 
-  useLayoutEffect(() => {
-    ref.current?.openAll();
-  }, []);
   return (
     <>
       <AccordionContainer>

--- a/apps/passport-client/components/screens/ZappScreens/ApprovePermissionsScreen.tsx
+++ b/apps/passport-client/components/screens/ZappScreens/ApprovePermissionsScreen.tsx
@@ -126,7 +126,7 @@ const Container = styled.div`
   align-items: center;
   justify-content: center;
   gap: 16px;
-  height: 100vh;
+  height: calc(100vh - ${BANNER_HEIGHT}px);
   padding: 24px 24px 20px 24px;
 `;
 

--- a/apps/passport-client/components/screens/ZappScreens/ConnectPopupScreen.tsx
+++ b/apps/passport-client/components/screens/ZappScreens/ConnectPopupScreen.tsx
@@ -3,14 +3,15 @@ import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import urljoin from "url-join";
 import * as v from "valibot";
-import { appConfig } from "../../../src/appConfig";
-import { useDispatch } from "../../../src/appHooks";
-import { useSelector } from "../../../src/subscribe";
-import { AppContainer } from "../../shared/AppContainer";
 import { BottomModalHeader } from "../../../new-components/shared/BottomModal";
+import { Button2 } from "../../../new-components/shared/Button";
 import { NewLoader } from "../../../new-components/shared/NewLoader";
 import { Typography } from "../../../new-components/shared/Typography";
-import { Button2 } from "../../../new-components/shared/Button";
+import { appConfig } from "../../../src/appConfig";
+import { useDispatch } from "../../../src/appHooks";
+import { BANNER_HEIGHT } from "../../../src/sharedConstants";
+import { useSelector } from "../../../src/subscribe";
+import { AppContainer } from "../../shared/AppContainer";
 
 const IFrameAuthenticationMessageSchema = v.object({
   type: v.literal("auth"),
@@ -230,7 +231,7 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  height: 100vh;
+  height: calc(100vh - ${BANNER_HEIGHT}px);
   padding: 24px 24px 20px 24px;
 `;
 


### PR DESCRIPTION
This pull request does two things

- auto-collapses sections and display more descriptive names on the connect screen
- fixes the iframe heights since now we have the banner at the top

<img width="416" alt="Screenshot 2024-11-03 at 1 23 03 PM" src="https://github.com/user-attachments/assets/5df2e556-8710-4b59-93ed-aaa2eb70f5f5">

<img width="422" alt="Screenshot 2024-11-03 at 1 23 12 PM" src="https://github.com/user-attachments/assets/fbceae77-3a24-467b-aafe-22888c9b5b83">
