### PR TITLE
Should not expand in width when toggling items [0XP-1616] [0XP-1618]

### DIFF
--- a/apps/passport-client/components/shared/AppContainer.tsx
+++ b/apps/passport-client/components/shared/AppContainer.tsx
@@ -93,7 +93,7 @@ export const Background = styled.div<{ color: string }>`
 
 export const CenterColumn = styled.div<{
   defaultPadding: boolean;
-  $fullscreen: boolean;
+  $fullscreen?: boolean;
 }>`
   display: flex;
   justify-content: flex-start;

--- a/apps/passport-client/components/shared/AppContainer.tsx
+++ b/apps/passport-client/components/shared/AppContainer.tsx
@@ -8,7 +8,7 @@ import {
   useIOSOrientationFix,
   useUserShouldAgreeNewPrivacyNotice
 } from "../../src/appHooks";
-import { BANNER_HEIGHT } from "../../src/sharedConstants";
+import { BANNER_HEIGHT, MAX_WIDTH_SCREEN } from "../../src/sharedConstants";
 import { ScreenLoader } from "./ScreenLoader";
 import { ZupassSVG } from "./ZupassSVG";
 
@@ -65,7 +65,7 @@ export function AppContainer({
         <ZupassSVG />
       </Banner>
       <Background color={col}>
-        <CenterColumn defaultPadding={!noPadding}>
+        <CenterColumn defaultPadding={!noPadding} $fullscreen={!!fullscreen}>
           {children && (
             <Toaster
               toastOptions={{
@@ -91,7 +91,10 @@ export const Background = styled.div<{ color: string }>`
   background: ${(p): string => p.color};
 `;
 
-export const CenterColumn = styled.div<{ defaultPadding: boolean }>`
+export const CenterColumn = styled.div<{
+  defaultPadding: boolean;
+  $fullscreen: boolean;
+}>`
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -99,6 +102,8 @@ export const CenterColumn = styled.div<{ defaultPadding: boolean }>`
   min-height: 100%;
   margin: 0 auto;
   position: relative;
+  ${({ $fullscreen }): string =>
+    !$fullscreen ? `max-width: ${MAX_WIDTH_SCREEN}px` : ""};
   ${({ defaultPadding }): string => (defaultPadding ? "padding: 16px;" : "")}
   padding-top: ${BANNER_HEIGHT}px;
 `;

--- a/apps/passport-client/new-components/screens/Home/NewHomeScreen.tsx
+++ b/apps/passport-client/new-components/screens/Home/NewHomeScreen.tsx
@@ -45,6 +45,7 @@ import { NewLoader } from "../../shared/NewLoader";
 import { SwipeViewContainer } from "../../shared/SwipeViewContainer";
 import { Typography } from "../../shared/Typography";
 import {
+  hideScrollCSS,
   isMobile,
   replaceDotWithSlash,
   useOrientation
@@ -147,17 +148,12 @@ const BackgroundContainer = styled.div<{ image?: string }>`
 `;
 
 const ScrollContainer = styled.div`
-  padding: 0 20px;
   height: 100%;
   overflow: scroll;
-  -ms-overflow-style: none; /* Internet Explorer 10+ */
-  scrollbar-width: none; /* Firefox */
   width: 100%;
   max-width: ${MAX_WIDTH_SCREEN}px;
 
-  &::-webkit-scrollbar {
-    display: none; /* Safari and Chrome */
-  }
+  ${hideScrollCSS}
 `;
 
 export const NewHomeScreen = (): ReactElement => {

--- a/apps/passport-client/new-components/shared/SwipeViewContainer.tsx
+++ b/apps/passport-client/new-components/shared/SwipeViewContainer.tsx
@@ -5,5 +5,5 @@ export const SwipeViewContainer = styled.div<{ isZapp?: boolean }>`
   height: ${({ isZapp }): string => (isZapp ? "100vh" : "inherit")};
   display: flex;
   flex-direction: column-reverse;
-  align-items: center;
+  width: 100%;
 `;

--- a/apps/passport-client/src/sharedConstants.ts
+++ b/apps/passport-client/src/sharedConstants.ts
@@ -25,7 +25,7 @@ export const OUTDATED_BROWSER_ERROR_MESSAGE =
 
 export const OOM_ERROR_MESSAGE = "Out of memory";
 
-export const MAX_WIDTH_SCREEN = 420;
+export const MAX_WIDTH_SCREEN = 440;
 
 // Environment variable configure how we fetch GPC artifacts, however we
 // default to fetching from the Zupass server rather than jsdelivr.


### PR DESCRIPTION
- increasing to 440px to handle phones with wider screens
- fixing zapp issue to keep width of 440px
- fixing the alignment of the tickets
- fixes scroll issues on the home page

#### Zapp permissions screen
![Screenshot 2024-11-03 at 16 35 18](https://github.com/user-attachments/assets/61c9ca1d-bc01-4d9c-8ff9-0ba6ac9be919)

#### Desktop home page
![Screenshot 2024-11-03 at 16 36 29](https://github.com/user-attachments/assets/87fff284-cc53-4422-8344-630a78d8f3e8)

#### Mobile home page - one ticket
![Screenshot 2024-11-03 at 16 37 02](https://github.com/user-attachments/assets/f5a2fc71-7d78-4a14-b7e7-94e91c5f9ea1)

#### Mobile home page - multi-ticket
https://github.com/user-attachments/assets/a52e6ae7-bf38-457f-9c00-7fbfd68ee236

