### PR TITLE
Clear Confirmation & Email Field [0XP-1492][0XP-1290]

### DIFF
--- a/apps/passport-client/new-components/shared/Modals/ManageEmailsModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/ManageEmailsModal.tsx
@@ -196,6 +196,8 @@ export const ManageEmailModal = (): JSX.Element => {
         stateContext.update({
           extraSubscriptionFetchRequested: true
         });
+        setConfirmationCode("");
+        setNewEmail("");
       } else {
         setError(
           `Couldn't add '${newEmail}', please wait and try again later.`


### PR DESCRIPTION
During the “Add Email” flow, the email and confirmation code fields are now reset to empty (””) after submission.

In staging-richard
