### PR TITLE
Allow for larger PODs in single-object GPC config

### DIFF
--- a/packages/lib/gpcircuits/circuits.json
+++ b/packages/lib/gpcircuits/circuits.json
@@ -128,13 +128,13 @@
       "globalWatermark"
     ]
   },
-  "proto-pod-gpc_1o-11e-5md-0nv-0ei-0x0l-0x0t-0ov3-1ov4": {
+  "proto-pod-gpc_1o-11e-6md-0nv-0ei-0x0l-0x0t-0ov3-1ov4": {
     "file": "proto-pod-gpc",
     "template": "ProtoPODGPC",
     "params": [
       1,
       11,
-      5,
+      6,
       0,
       0,
       0,

--- a/packages/lib/gpcircuits/scripts/parameters/paramGen.ts
+++ b/packages/lib/gpcircuits/scripts/parameters/paramGen.ts
@@ -107,11 +107,11 @@ export const PARAMS: ProtoPODGPCCircuitParams[] = [
   //   includeOwnerV4: true
   // },
   // 11 entries
-  // Minimal POD ticket configuration.
+  // Minimal POD ticket/frog POD configuration.
   {
     maxObjects: 1,
     maxEntries: 11,
-    merkleMaxDepth: 5,
+    merkleMaxDepth: 6,
     maxNumericValues: 0,
     maxEntryInequalities: 0,
     maxLists: 0,

--- a/packages/lib/gpcircuits/src/circuitParameters.json
+++ b/packages/lib/gpcircuits/src/circuitParameters.json
@@ -51,7 +51,7 @@
     {
       "maxObjects": 1,
       "maxEntries": 11,
-      "merkleMaxDepth": 5,
+      "merkleMaxDepth": 6,
       "maxNumericValues": 0,
       "maxEntryInequalities": 0,
       "maxLists": 0,
@@ -61,7 +61,7 @@
       "includeOwnerV3": false,
       "includeOwnerV4": true
     },
-    20176
+    22882
   ],
   [
     {


### PR DESCRIPTION
This PR increments the max Merkle depth in one of the single-object GPC configurations.