### PR TITLE
Allow forcing of new session

### DIFF
--- a/apps/passport-client/pages/index.tsx
+++ b/apps/passport-client/pages/index.tsx
@@ -82,6 +82,21 @@ import { ListenMode, useZappServer } from "../src/zapp/useZappServer";
 
 enableLiveReload();
 
+// Delete local storage and reload if forceNewSession is set
+if (typeof window !== "undefined") {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has("forceNewSession")) {
+    localStorage.clear();
+    const newParams = new URLSearchParams(window.location.search);
+    newParams.delete("forceNewSession");
+    const newSearch = newParams.toString();
+    const newPath = `${window.location.pathname}${
+      newSearch ? `?${newSearch}` : ""
+    }${window.location.hash}`;
+    window.location.replace(newPath);
+  }
+}
+
 function App(): JSX.Element {
   useBackgroundJobs();
   useZappServer(ListenMode.LISTEN_IF_EMBEDDED);

--- a/apps/passport-client/src/zapp/useZappServer.ts
+++ b/apps/passport-client/src/zapp/useZappServer.ts
@@ -43,6 +43,13 @@ async function waitForFirstSync(context: StateContextValue): Promise<void> {
       return;
     }
     const unlisten = context.stateEmitter.listen((state) => {
+      if (
+        context.getState().downloadedPCDs &&
+        context.getState().pcds.getAllPCDsInFolder("Devcon SEA").length > 0
+      ) {
+        resolve();
+        return;
+      }
       if (state.completedFirstSync) {
         unlisten();
         resolve();


### PR DESCRIPTION
This PR adds two tweaks:

1) A query param to force Zupass to initialize a new session, only for use with the Z API embedded use-case on shared devices (Frog Zone)

2) Cover a race condition for the "faster session creation" for Z API, which meant that sometimes the slower path was being taken