### PR TITLE
add more padding to the pods modal

### DIFF
--- a/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
+++ b/apps/passport-client/new-components/shared/Modals/PodsCollectionBottomModal.tsx
@@ -411,7 +411,7 @@ const Container = styled.div<{ isLandscape: boolean }>`
   flex-direction: column;
   // 50px comes from 24px padding we have on the bottom modal
   max-height: calc(
-    100vh - ${({ isLandscape }): number => (isLandscape ? 50 : 120)}px
+    100vh - ${({ isLandscape }): number => (isLandscape ? 80 : 150)}px
   );
 `;
 const ContainerWithPadding = styled.div`


### PR DESCRIPTION
fix for chrome and safari landscape:

<img width="890" alt="image" src="https://github.com/user-attachments/assets/d0e15fe7-04c3-461b-b148-5541743229e4">
