### PR TITLE
Allow POD card display if at least one of title/description/image is set

### DIFF
--- a/packages/ui/pod-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/pod-pcd-ui/src/CardBody.tsx
@@ -1,6 +1,12 @@
 import { ErrorContainer, SlidingTabs, styled, VIcon } from "@pcd/passport-ui";
 import { PCDUI } from "@pcd/pcd-types";
-import { getImageUrlEntry, PODPCD, PODPCDPackage } from "@pcd/pod-pcd";
+import {
+  getDescriptionEntry,
+  getImageUrlEntry,
+  getTitleEntry,
+  PODPCD,
+  PODPCDPackage
+} from "@pcd/pod-pcd";
 import { getErrorMessage } from "@pcd/util";
 import { useMemo, useState } from "react";
 import { CollectablePODPCDCardBody } from "./renderers/CollectablePODPCDCardBody";
@@ -41,7 +47,13 @@ function PODPCDCardBody({
 
   const hasCollectableContent = useMemo(() => {
     const imageUrlEntry = getImageUrlEntry(pcd);
-    return imageUrlEntry?.type === "string" && imageUrlEntry.value !== "";
+    const titleEntry = getTitleEntry(pcd);
+    const descriptionEntry = getDescriptionEntry(pcd);
+    return (
+      (imageUrlEntry?.type === "string" && imageUrlEntry.value !== "") ||
+      (titleEntry?.type === "string" && titleEntry.value !== "") ||
+      (descriptionEntry?.type === "string" && descriptionEntry.value !== "")
+    );
   }, [pcd]);
 
   const availableDisplayFormat = getPreferredDisplayFormat(pcd);


### PR DESCRIPTION
Logic changed since the original version of the POD card display so I've been misinforming devs that they can make a collectable POD without an image.

I tested and the UI code seems to work fine for text-only PODs, so this PR loosens the check so that the collectable display can trigger if at least one of the title/description/image entries are set to a non-empty value.
