### PR TITLE
set perms on zapp screen iframe

### DIFF
--- a/apps/passport-client/components/screens/ZappScreens/ZappScreen.tsx
+++ b/apps/passport-client/components/screens/ZappScreens/ZappScreen.tsx
@@ -26,6 +26,7 @@ export function ZappScreen({ url }: { url: string }): ReactNode {
           height: "100%"
         }}
         src={urlWithOptionalParameter.toString()}
+        allow="camera;microphone;clipboard-read;clipboard-write"
         sandbox="allow-downloads allow-same-origin allow-scripts allow-popups allow-modals allow-forms allow-storage-access-by-user-activation allow-popups-to-escape-sandbox"
       />
     </>


### PR DESCRIPTION
@rrrliu can you help me test this?

1/ "scan" should allow requesting camera access
2/ "share" should allow write url to clipboard

<img width="434" alt="image" src="https://github.com/user-attachments/assets/b53b866d-cf81-4ad0-a11e-779fd72463e6">
