### PR TITLE
Re-enable disabled Podbox features

### DIFF
--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVPipeline/CSVPipeline.ts
@@ -169,12 +169,6 @@ export class CSVPipeline implements BasePipeline {
 
   private async issue(req: PollFeedRequest): Promise<PollFeedResponseValue> {
     return traced(LOG_NAME, "issue", async (span) => {
-      if (Math.random() < 1000) {
-        return {
-          actions: []
-        };
-      }
-
       logger(LOG_TAG, `issue`, req);
       tracePipeline(this.definition);
 

--- a/apps/passport-server/src/services/generic-issuance/pipelines/CSVTicketPipeline/CSVTicketPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/CSVTicketPipeline/CSVTicketPipeline.ts
@@ -193,12 +193,6 @@ export class CSVTicketPipeline implements BasePipeline {
 
   private async issue(req: PollFeedRequest): Promise<PollFeedResponseValue> {
     return traced(LOG_NAME, "issue", async (span) => {
-      if (Math.random() < 1000) {
-        return {
-          actions: []
-        };
-      }
-
       logger(LOG_TAG, `issue`, req);
       tracePipeline(this.definition);
 

--- a/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
+++ b/apps/passport-server/src/services/generic-issuance/pipelines/PretixPipeline.ts
@@ -1179,105 +1179,119 @@ export class PretixPipeline implements BasePipeline {
       span?.setAttribute("email", emails.map((e) => e.email).join(","));
       span?.setAttribute("semaphore_id", semaphoreId);
 
-      //let didUpdate = false;
-
-      return sqlQueryWithPool(this.context.dbPool, async (client) => {
-        // for (const e of emails) {
-        //   didUpdate =
-        //     didUpdate ||
-        //     (await this.consumerDB.save(
-        //       client,
-        //       this.id,
-        //       e.email,
-        //       semaphoreId,
-        //       new Date()
-        //     ));
-        // }
-
-        // const provider = this.autoIssuanceProvider;
-        // if (provider) {
-        //   const newManualTickets = (
-        //     await Promise.all(
-        //       emails.map(async (e) =>
-        //         provider.maybeIssueForUser(
-        //           e.email,
-        //           await this.getAllManualTickets(client),
-        //           await this.db.loadByEmail(this.id, e.email)
-        //         )
-        //       )
-        //     )
-        //   ).flat();
-
-        //   await Promise.allSettled(
-        //     newManualTickets.map((t) =>
-        //       this.manualTicketDB.save(client, this.id, t)
-        //     )
-        //   );
-        // }
+      await sqlQueryWithPool(this.context.dbPool, async (client) => {
+        let didUpdate = false;
+        for (const e of emails) {
+          didUpdate =
+            didUpdate ||
+            (await this.consumerDB.save(
+              client,
+              this.id,
+              e.email,
+              semaphoreId,
+              new Date()
+            ));
+        }
 
         // If the user's Semaphore commitment has changed, `didUpdate` will be
         // true, and we need to update the Semaphore groups
-        // if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
-        //   if (didUpdate) {
-        //     span?.setAttribute("semaphore_groups_updated", true);
-        //     await this.triggerSemaphoreGroupUpdate(client);
-        //   }
-        // }
-
-        const tickets = (
-          await Promise.all(
-            emails.map((e) =>
-              this.getEdDSATicketsForEmail(client, e.email, semaphoreId)
-            )
-          )
-        ).flat();
-
-        span?.setAttribute("pcds_issued", tickets.length);
-
-        const actions: PCDAction[] = [];
-
-        if (await this.db.hasLoaded(this.id)) {
-          actions.push({
-            type: PCDActionType.DeleteFolder,
-            folder: this.definition.options.feedOptions.feedFolder,
-            recursive: true
-          });
+        if ((this.definition.options.semaphoreGroups ?? []).length > 0) {
+          if (didUpdate) {
+            span?.setAttribute("semaphore_groups_updated", true);
+            await this.triggerSemaphoreGroupUpdate(client);
+          }
         }
+      });
 
-        const ticketPCDs = await Promise.all(
-          tickets.map((t) => EdDSATicketPCDPackage.serialize(t))
-        );
+      // Is this still needed?
+      // const provider = this.autoIssuanceProvider;
+      // if (provider) {
+      //   const newManualTickets = (
+      //     await Promise.all(
+      //       emails.map(async (e) =>
+      //         provider.maybeIssueForUser(
+      //           e.email,
+      //           await this.getAllManualTickets(client),
+      //           await this.db.loadByEmail(this.id, e.email)
+      //         )
+      //       )
+      //     )
+      //   ).flat();
 
-        if (this.definition.options.enablePODTickets) {
-          const podTickets = (
+      //   await Promise.allSettled(
+      //     newManualTickets.map((t) =>
+      //       this.manualTicketDB.save(client, this.id, t)
+      //     )
+      //   );
+      // }
+
+      const tickets = await sqlQueryWithPool(
+        this.context.dbPool,
+        async (client) => {
+          return (
             await Promise.all(
               emails.map((e) =>
-                e.semaphoreV4Id
-                  ? this.getPODTicketsForEmail(client, e.email, e.semaphoreV4Id)
-                  : undefined
+                this.getEdDSATicketsForEmail(client, e.email, semaphoreId)
               )
             )
-          )
-            .flat()
-            .filter((t) => t !== undefined) as PODTicketPCD[];
-
-          ticketPCDs.push(
-            ...(await Promise.all(
-              podTickets.map((t) => PODTicketPCDPackage.serialize(t))
-            ))
-          );
+          ).flat();
         }
+      );
 
+      span?.setAttribute("pcds_issued", tickets.length);
+
+      const actions: PCDAction[] = [];
+
+      if (await this.db.hasLoaded(this.id)) {
         actions.push({
-          type: PCDActionType.ReplaceInFolder,
+          type: PCDActionType.DeleteFolder,
           folder: this.definition.options.feedOptions.feedFolder,
-          pcds: ticketPCDs
+          recursive: true
         });
+      }
 
-        const result: PollFeedResponseValue = { actions };
+      const ticketPCDs = await Promise.all(
+        tickets.map((t) => EdDSATicketPCDPackage.serialize(t))
+      );
 
-        return result;
+      if (this.definition.options.enablePODTickets) {
+        const podTickets = await sqlQueryWithPool(
+          this.context.dbPool,
+          async (client) => {
+            return (
+              await Promise.all(
+                emails.map((e) =>
+                  e.semaphoreV4Id
+                    ? this.getPODTicketsForEmail(
+                        client,
+                        e.email,
+                        e.semaphoreV4Id
+                      )
+                    : undefined
+                )
+              )
+            )
+              .flat()
+              .filter((t) => t !== undefined) as PODTicketPCD[];
+          }
+        );
+
+        ticketPCDs.push(
+          ...(await Promise.all(
+            podTickets.map((t) => PODTicketPCDPackage.serialize(t))
+          ))
+        );
+      }
+
+      actions.push({
+        type: PCDActionType.ReplaceInFolder,
+        folder: this.definition.options.feedOptions.feedFolder,
+        pcds: ticketPCDs
       });
+
+      const result: PollFeedResponseValue = { actions };
+
+      return result;
     });
   }
 

--- a/apps/passport-server/test/generic-issuance/pipelines/csv-ticket/CSVTicketPipeline.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/csv-ticket/CSVTicketPipeline.spec.ts
@@ -26,7 +26,7 @@ import { setupTestCSVTicketPipelineDefinition } from "./setupTestCSVTicketPipeli
 /**
  * Tests for {@link GenericIssuanceService}, in particular the {@link CSVTicketPipeline}.
  */
-describe.skip("generic issuance - CSVTicketPipeline", function () {
+describe("generic issuance - CSVTicketPipeline", function () {
   const nowDate = new Date();
   const now = Date.now();
 

--- a/apps/passport-server/test/generic-issuance/pipelines/csv/csvPipeline.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/csv/csvPipeline.spec.ts
@@ -27,7 +27,7 @@ import { setupTestCSVPipelineDefinition } from "./setupTestCSVPipelineDefinition
 /**
  * Tests for {@link GenericIssuanceService}, in particular the {@link CSVPipeline}.
  */
-describe.skip("generic issuance - CSVPipeline", function () {
+describe("generic issuance - CSVPipeline", function () {
   const nowDate = new Date();
   const now = Date.now();
 

--- a/apps/passport-server/test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/lemonade/lemonadePipeline.spec.ts
@@ -5,9 +5,20 @@ import {
   PipelineLogLevel,
   PodboxTicketActionResponseValue,
   createCredentialPayload,
+  requestGenericIssuanceHistoricalSemaphoreGroup,
+  requestGenericIssuanceSemaphoreGroup,
+  requestGenericIssuanceSemaphoreGroupRoot,
+  requestGenericIssuanceValidSemaphoreGroup,
   requestPodboxTicketAction
 } from "@pcd/passport-interface";
-import { ONE_DAY_MS } from "@pcd/util";
+import { ArgumentTypeName } from "@pcd/pcd-types";
+import {
+  SemaphoreGroupPCDPackage,
+  deserializeSemaphoreGroup,
+  serializeSemaphoreGroup
+} from "@pcd/semaphore-group-pcd";
+import { SemaphoreIdentityPCDPackage } from "@pcd/semaphore-identity-pcd";
+import { ONE_DAY_MS, ONE_MINUTE_MS } from "@pcd/util";
 import { Identity } from "@semaphore-protocol/identity";
 import { expect } from "chai";
 import { randomUUID } from "crypto";
@@ -20,6 +31,7 @@ import urljoin from "url-join";
 import { LemonadeOAuthCredentials } from "../../../../src/apis/lemonade/auth";
 import { LemonadeTicket } from "../../../../src/apis/lemonade/types";
 import { stopApplication } from "../../../../src/application";
+import { PipelineConsumerDB } from "../../../../src/database/queries/pipelineConsumerDB";
 import { PipelineDefinitionDB } from "../../../../src/database/queries/pipelineDefinitionDB";
 import { PipelineUserDB } from "../../../../src/database/queries/pipelineUserDB";
 import { GenericIssuanceService } from "../../../../src/services/generic-issuance/GenericIssuanceService";
@@ -77,9 +89,9 @@ describe("generic issuance - LemonadePipeline", function () {
     edgeCityPipeline,
     edgeCityGIUserID,
     edgeCityGIUserEmail,
-    //   EdgeCityLemonadeAccount,
+    EdgeCityLemonadeAccount,
     EdgeCityDenver,
-    //   EdgeCityAttendeeTicketType,
+    EdgeCityAttendeeTicketType,
     EdgeCityDenverAttendee,
     EdgeCityDenverAttendeeIdentity,
     EdgeCityAttendeeTicket,
@@ -95,7 +107,7 @@ describe("generic issuance - LemonadePipeline", function () {
     EdgeCityManualBouncerEmail,
     lemonadeTokenSource,
     lemonadeAPI,
-    // edgeCitySemaphoreGroupIds,
+    edgeCitySemaphoreGroupIds,
     lemonadeBackendUrl,
     lemonadeBackend,
     lemonadeOAuthClientId,
@@ -441,389 +453,389 @@ describe("generic issuance - LemonadePipeline", function () {
       // backend, will be implemented with the pipeline as the check-in backend
 
       // Verify that consumers were saved for each user who requested tickets
-      // const consumerDB = new PipelineConsumerDB();
-      // const consumers = await consumerDB.loadByEmails(
-      //   client,
-      //   edgeCityDenverPipeline.id,
-      //   [
-      //     EdgeCityManualAttendeeEmail,
-      //     EdgeCityManualBouncerEmail,
-      //     EdgeCityDenverAttendee.email,
-      //     EdgeCityDenverBouncer.email,
-      //     EdgeCityDenverBouncer2.email
-      //   ]
-      // );
-      // expectLength(consumers, 5);
-      // const edgeCityIssuanceDateTime = new Date();
-      // expect(consumers).to.deep.include.members([
-      //   {
-      //     email: EdgeCityManualAttendeeEmail,
-      //     commitment: EdgeCityManualAttendeeIdentity.commitment.toString(),
-      //     timeCreated: edgeCityIssuanceDateTime,
-      //     timeUpdated: edgeCityIssuanceDateTime
-      //   },
-      //   {
-      //     email: EdgeCityManualBouncerEmail,
-      //     commitment: EdgeCityManualBouncerIdentity.commitment.toString(),
-      //     timeCreated: edgeCityIssuanceDateTime,
-      //     timeUpdated: edgeCityIssuanceDateTime
-      //   },
-      //   {
-      //     email: EdgeCityDenverAttendee.email,
-      //     commitment: EdgeCityDenverAttendeeIdentity.commitment.toString(),
-      //     timeCreated: edgeCityIssuanceDateTime,
-      //     timeUpdated: edgeCityIssuanceDateTime
-      //   },
-      //   {
-      //     email: EdgeCityDenverBouncer.email,
-      //     commitment: EdgeCityBouncerIdentity.commitment.toString(),
-      //     timeCreated: edgeCityIssuanceDateTime,
-      //     timeUpdated: edgeCityIssuanceDateTime
-      //   },
-      //   {
-      //     email: EdgeCityDenverBouncer2.email,
-      //     commitment: EdgeCityBouncer2Identity.commitment.toString(),
-      //     timeCreated: edgeCityIssuanceDateTime,
-      //     timeUpdated: edgeCityIssuanceDateTime
-      //   }
-      // ]);
+      const consumerDB = new PipelineConsumerDB();
+      const consumers = await consumerDB.loadByEmails(
+        client,
+        edgeCityDenverPipeline.id,
+        [
+          EdgeCityManualAttendeeEmail,
+          EdgeCityManualBouncerEmail,
+          EdgeCityDenverAttendee.email,
+          EdgeCityDenverBouncer.email,
+          EdgeCityDenverBouncer2.email
+        ]
+      );
+      expectLength(consumers, 5);
+      const edgeCityIssuanceDateTime = new Date();
+      expect(consumers).to.deep.include.members([
+        {
+          email: EdgeCityManualAttendeeEmail,
+          commitment: EdgeCityManualAttendeeIdentity.commitment.toString(),
+          timeCreated: edgeCityIssuanceDateTime,
+          timeUpdated: edgeCityIssuanceDateTime
+        },
+        {
+          email: EdgeCityManualBouncerEmail,
+          commitment: EdgeCityManualBouncerIdentity.commitment.toString(),
+          timeCreated: edgeCityIssuanceDateTime,
+          timeUpdated: edgeCityIssuanceDateTime
+        },
+        {
+          email: EdgeCityDenverAttendee.email,
+          commitment: EdgeCityDenverAttendeeIdentity.commitment.toString(),
+          timeCreated: edgeCityIssuanceDateTime,
+          timeUpdated: edgeCityIssuanceDateTime
+        },
+        {
+          email: EdgeCityDenverBouncer.email,
+          commitment: EdgeCityBouncerIdentity.commitment.toString(),
+          timeCreated: edgeCityIssuanceDateTime,
+          timeUpdated: edgeCityIssuanceDateTime
+        },
+        {
+          email: EdgeCityDenverBouncer2.email,
+          commitment: EdgeCityBouncer2Identity.commitment.toString(),
+          timeCreated: edgeCityIssuanceDateTime,
+          timeUpdated: edgeCityIssuanceDateTime
+        }
+      ]);
 
       await checkPipelineInfoEndpoint(giBackend, edgeCityDenverPipeline);
     }
   );
 
-  // step(
-  //   "Lemonade pipeline Semaphore groups contain correct members",
-  //   async function () {
-  //     expectToExist(giService);
-  //     const pipelines = await giService.getAllPipelineInstances();
-  //     expectToExist(pipelines);
-  //     expectLength(pipelines, 1);
-  //     const edgeCityDenverPipeline = pipelines.find(LemonadePipeline.is);
-  //     expectToExist(edgeCityDenverPipeline);
+  step(
+    "Lemonade pipeline Semaphore groups contain correct members",
+    async function () {
+      expectToExist(giService);
+      const pipelines = await giService.getAllPipelineInstances();
+      expectToExist(pipelines);
+      expectLength(pipelines, 1);
+      const edgeCityDenverPipeline = pipelines.find(LemonadePipeline.is);
+      expectToExist(edgeCityDenverPipeline);
 
-  //     await giService.performPipelineLoad(edgeCityDenverPipeline.id);
+      await giService.performPipelineLoad(edgeCityDenverPipeline.id);
 
-  //     const semaphoreGroupAll = await requestGenericIssuanceSemaphoreGroup(
-  //       process.env.PASSPORT_SERVER_URL as string,
-  //       edgeCityDenverPipeline.id,
-  //       edgeCitySemaphoreGroupIds.all
-  //     );
+      const semaphoreGroupAll = await requestGenericIssuanceSemaphoreGroup(
+        process.env.PASSPORT_SERVER_URL as string,
+        edgeCityDenverPipeline.id,
+        edgeCitySemaphoreGroupIds.all
+      );
 
-  //     expectTrue(semaphoreGroupAll.success);
-  //     expectLength(semaphoreGroupAll.value.members, 5);
-  //     expect(semaphoreGroupAll.value.members).to.deep.include.members([
-  //       EdgeCityBouncerIdentity.commitment.toString(),
-  //       EdgeCityBouncer2Identity.commitment.toString(),
-  //       EdgeCityDenverAttendeeIdentity.commitment.toString(),
-  //       EdgeCityManualAttendeeIdentity.commitment.toString(),
-  //       EdgeCityManualBouncerIdentity.commitment.toString()
-  //     ]);
+      expectTrue(semaphoreGroupAll.success);
+      expectLength(semaphoreGroupAll.value.members, 5);
+      expect(semaphoreGroupAll.value.members).to.deep.include.members([
+        EdgeCityBouncerIdentity.commitment.toString(),
+        EdgeCityBouncer2Identity.commitment.toString(),
+        EdgeCityDenverAttendeeIdentity.commitment.toString(),
+        EdgeCityManualAttendeeIdentity.commitment.toString(),
+        EdgeCityManualBouncerIdentity.commitment.toString()
+      ]);
 
-  //     const semaphoreGroupBouncers = await requestGenericIssuanceSemaphoreGroup(
-  //       process.env.PASSPORT_SERVER_URL as string,
-  //       edgeCityDenverPipeline.id,
-  //       edgeCitySemaphoreGroupIds.bouncers
-  //     );
+      const semaphoreGroupBouncers = await requestGenericIssuanceSemaphoreGroup(
+        process.env.PASSPORT_SERVER_URL as string,
+        edgeCityDenverPipeline.id,
+        edgeCitySemaphoreGroupIds.bouncers
+      );
 
-  //     expectTrue(semaphoreGroupBouncers.success);
-  //     expectLength(semaphoreGroupBouncers.value.members, 2);
-  //     expect(semaphoreGroupBouncers.value.members).to.deep.include.members([
-  //       EdgeCityBouncerIdentity.commitment.toString(),
-  //       EdgeCityManualBouncerIdentity.commitment.toString()
-  //     ]);
+      expectTrue(semaphoreGroupBouncers.success);
+      expectLength(semaphoreGroupBouncers.value.members, 2);
+      expect(semaphoreGroupBouncers.value.members).to.deep.include.members([
+        EdgeCityBouncerIdentity.commitment.toString(),
+        EdgeCityManualBouncerIdentity.commitment.toString()
+      ]);
 
-  //     const semaphoreGroupAttendees =
-  //       await requestGenericIssuanceSemaphoreGroup(
-  //         process.env.PASSPORT_SERVER_URL as string,
-  //         edgeCityDenverPipeline.id,
-  //         edgeCitySemaphoreGroupIds.attendees
-  //       );
+      const semaphoreGroupAttendees =
+        await requestGenericIssuanceSemaphoreGroup(
+          process.env.PASSPORT_SERVER_URL as string,
+          edgeCityDenverPipeline.id,
+          edgeCitySemaphoreGroupIds.attendees
+        );
 
-  //     expectTrue(semaphoreGroupAttendees.success);
-  //     expectLength(semaphoreGroupAttendees.value.members, 3);
-  //     expect(semaphoreGroupAttendees.value.members).to.deep.include.members([
-  //       EdgeCityDenverAttendeeIdentity.commitment.toString(),
-  //       EdgeCityManualAttendeeIdentity.commitment.toString(),
-  //       // Bouncer2 has a specially configured "superuser email", but is not
-  //       // a holder of a bouncer-tier ticket. Having a "superuser email" allows
-  //       // a user to perform check-ins, but does not change the product type of
-  //       // their ticket, and so does not change their Semaphore group
-  //       // memberships.
-  //       EdgeCityBouncer2Identity.commitment.toString()
-  //     ]);
+      expectTrue(semaphoreGroupAttendees.success);
+      expectLength(semaphoreGroupAttendees.value.members, 3);
+      expect(semaphoreGroupAttendees.value.members).to.deep.include.members([
+        EdgeCityDenverAttendeeIdentity.commitment.toString(),
+        EdgeCityManualAttendeeIdentity.commitment.toString(),
+        // Bouncer2 has a specially configured "superuser email", but is not
+        // a holder of a bouncer-tier ticket. Having a "superuser email" allows
+        // a user to perform check-ins, but does not change the product type of
+        // their ticket, and so does not change their Semaphore group
+        // memberships.
+        EdgeCityBouncer2Identity.commitment.toString()
+      ]);
 
-  //     const semaphoreGroupAttendeesAndBouncers =
-  //       await requestGenericIssuanceSemaphoreGroup(
-  //         process.env.PASSPORT_SERVER_URL as string,
-  //         edgeCityDenverPipeline.id,
-  //         edgeCitySemaphoreGroupIds.attendeesAndBouncers
-  //       );
+      const semaphoreGroupAttendeesAndBouncers =
+        await requestGenericIssuanceSemaphoreGroup(
+          process.env.PASSPORT_SERVER_URL as string,
+          edgeCityDenverPipeline.id,
+          edgeCitySemaphoreGroupIds.attendeesAndBouncers
+        );
 
-  //     expectTrue(semaphoreGroupAttendeesAndBouncers.success);
-  //     expectLength(semaphoreGroupAttendeesAndBouncers.value.members, 5);
-  //     expect(
-  //       semaphoreGroupAttendeesAndBouncers.value.members
-  //     ).to.deep.include.members([
-  //       EdgeCityBouncerIdentity.commitment.toString(),
-  //       EdgeCityBouncer2Identity.commitment.toString(),
-  //       EdgeCityDenverAttendeeIdentity.commitment.toString(),
-  //       EdgeCityManualAttendeeIdentity.commitment.toString(),
-  //       EdgeCityManualBouncerIdentity.commitment.toString()
-  //     ]);
-  //   }
-  // );
+      expectTrue(semaphoreGroupAttendeesAndBouncers.success);
+      expectLength(semaphoreGroupAttendeesAndBouncers.value.members, 5);
+      expect(
+        semaphoreGroupAttendeesAndBouncers.value.members
+      ).to.deep.include.members([
+        EdgeCityBouncerIdentity.commitment.toString(),
+        EdgeCityBouncer2Identity.commitment.toString(),
+        EdgeCityDenverAttendeeIdentity.commitment.toString(),
+        EdgeCityManualAttendeeIdentity.commitment.toString(),
+        EdgeCityManualBouncerIdentity.commitment.toString()
+      ]);
+    }
+  );
 
-  // step(
-  //   "New users can sign up, get added to group, prove group membership for Lemonade Pipeline",
-  //   async function () {
-  //     expectToExist(giService);
-  //     const pipelines = await giService.getAllPipelineInstances();
-  //     expectToExist(pipelines);
-  //     expectLength(pipelines, 1);
-  //     const edgeCityDenverPipeline = pipelines.find(LemonadePipeline.is);
-  //     expectToExist(edgeCityDenverPipeline);
+  step(
+    "New users can sign up, get added to group, prove group membership for Lemonade Pipeline",
+    async function () {
+      expectToExist(giService);
+      const pipelines = await giService.getAllPipelineInstances();
+      expectToExist(pipelines);
+      expectLength(pipelines, 1);
+      const edgeCityDenverPipeline = pipelines.find(LemonadePipeline.is);
+      expectToExist(edgeCityDenverPipeline);
 
-  //     // Test that a new user is added to the attendee group
-  //     const newUser = lemonadeBackend.addUser(
-  //       "newuser@example.com",
-  //       "New",
-  //       "User"
-  //     );
-  //     const newUserIdentity = new Identity();
-  //     EdgeCityLemonadeAccount.addUserTicket(
-  //       EdgeCityDenver._id,
-  //       EdgeCityAttendeeTicketType._id,
-  //       newUser._id,
-  //       newUser.name
-  //     );
-  //     await giService.performPipelineLoad(edgeCityDenverPipeline.id);
-  //     const edgeCityDenverTicketFeedUrl =
-  //       edgeCityDenverPipeline.issuanceCapability.feedUrl;
-  //     // The pipeline doesn't know that the user exists until they hit the feed
-  //     const NewUserTickets = await requestTicketsFromPipeline(
-  //       edgeCityDenverPipeline.issuanceCapability.options.feedFolder,
-  //       edgeCityDenverTicketFeedUrl,
-  //       edgeCityDenverPipeline.issuanceCapability.options.feedId,
-  //       ZUPASS_EDDSA_PRIVATE_KEY,
-  //       newUser.email,
-  //       newUserIdentity
-  //     );
-  //     expectLength(NewUserTickets, 1);
+      // Test that a new user is added to the attendee group
+      const newUser = lemonadeBackend.addUser(
+        "newuser@example.com",
+        "New",
+        "User"
+      );
+      const newUserIdentity = new Identity();
+      EdgeCityLemonadeAccount.addUserTicket(
+        EdgeCityDenver._id,
+        EdgeCityAttendeeTicketType._id,
+        newUser._id,
+        newUser.name
+      );
+      await giService.performPipelineLoad(edgeCityDenverPipeline.id);
+      const edgeCityDenverTicketFeedUrl =
+        edgeCityDenverPipeline.issuanceCapability.feedUrl;
+      // The pipeline doesn't know that the user exists until they hit the feed
+      const NewUserTickets = await requestTicketsFromPipeline(
+        edgeCityDenverPipeline.issuanceCapability.options.feedFolder,
+        edgeCityDenverTicketFeedUrl,
+        edgeCityDenverPipeline.issuanceCapability.options.feedId,
+        ZUPASS_EDDSA_PRIVATE_KEY,
+        newUser.email,
+        newUserIdentity
+      );
+      expectLength(NewUserTickets, 1);
 
-  //     const attendeeGroupResponse = await requestGenericIssuanceSemaphoreGroup(
-  //       process.env.PASSPORT_SERVER_URL as string,
-  //       edgeCityDenverPipeline.id,
-  //       edgeCitySemaphoreGroupIds.attendees
-  //     );
+      const attendeeGroupResponse = await requestGenericIssuanceSemaphoreGroup(
+        process.env.PASSPORT_SERVER_URL as string,
+        edgeCityDenverPipeline.id,
+        edgeCitySemaphoreGroupIds.attendees
+      );
 
-  //     expectTrue(attendeeGroupResponse.success);
-  //     expectLength(attendeeGroupResponse.value.members, 4);
-  //     expect(attendeeGroupResponse.value.members).to.deep.include.members([
-  //       EdgeCityDenverAttendeeIdentity.commitment.toString(),
-  //       EdgeCityManualAttendeeIdentity.commitment.toString(),
-  //       EdgeCityBouncer2Identity.commitment.toString(),
-  //       newUserIdentity.commitment.toString()
-  //     ]);
-  //     const attendeeGroup = await deserializeSemaphoreGroup(
-  //       attendeeGroupResponse.value
-  //     );
+      expectTrue(attendeeGroupResponse.success);
+      expectLength(attendeeGroupResponse.value.members, 4);
+      expect(attendeeGroupResponse.value.members).to.deep.include.members([
+        EdgeCityDenverAttendeeIdentity.commitment.toString(),
+        EdgeCityManualAttendeeIdentity.commitment.toString(),
+        EdgeCityBouncer2Identity.commitment.toString(),
+        newUserIdentity.commitment.toString()
+      ]);
+      const attendeeGroup = await deserializeSemaphoreGroup(
+        attendeeGroupResponse.value
+      );
 
-  //     const attendeesGroupRootResponse =
-  //       await requestGenericIssuanceSemaphoreGroupRoot(
-  //         process.env.PASSPORT_SERVER_URL as string,
-  //         edgeCityDenverPipeline.id,
-  //         edgeCitySemaphoreGroupIds.attendees
-  //       );
-  //     expectTrue(attendeesGroupRootResponse.success);
-  //     expect(attendeesGroupRootResponse.value).to.eq(
-  //       (
-  //         await deserializeSemaphoreGroup(attendeeGroupResponse.value)
-  //       ).root.toString()
-  //     );
+      const attendeesGroupRootResponse =
+        await requestGenericIssuanceSemaphoreGroupRoot(
+          process.env.PASSPORT_SERVER_URL as string,
+          edgeCityDenverPipeline.id,
+          edgeCitySemaphoreGroupIds.attendees
+        );
+      expectTrue(attendeesGroupRootResponse.success);
+      expect(attendeesGroupRootResponse.value).to.eq(
+        (
+          await deserializeSemaphoreGroup(attendeeGroupResponse.value)
+        ).root.toString()
+      );
 
-  //     const attendeeGroupValidResponse =
-  //       await requestGenericIssuanceValidSemaphoreGroup(
-  //         process.env.PASSPORT_SERVER_URL as string,
-  //         edgeCityDenverPipeline.id,
-  //         edgeCitySemaphoreGroupIds.attendees,
-  //         attendeeGroup.root.toString()
-  //       );
+      const attendeeGroupValidResponse =
+        await requestGenericIssuanceValidSemaphoreGroup(
+          process.env.PASSPORT_SERVER_URL as string,
+          edgeCityDenverPipeline.id,
+          edgeCitySemaphoreGroupIds.attendees,
+          attendeeGroup.root.toString()
+        );
 
-  //     expectTrue(attendeeGroupValidResponse.success);
-  //     expectTrue(attendeeGroupValidResponse.value.valid);
+      expectTrue(attendeeGroupValidResponse.success);
+      expectTrue(attendeeGroupValidResponse.value.valid);
 
-  //     const newUserIdentityPCD = await SemaphoreIdentityPCDPackage.prove({
-  //       identityV3: newUserIdentity
-  //     });
+      const newUserIdentityPCD = await SemaphoreIdentityPCDPackage.prove({
+        identityV3: newUserIdentity
+      });
 
-  //     const groupPCD = await SemaphoreGroupPCDPackage.prove({
-  //       externalNullifier: {
-  //         argumentType: ArgumentTypeName.BigInt,
-  //         value: attendeeGroup.root.toString()
-  //       },
-  //       signal: {
-  //         argumentType: ArgumentTypeName.BigInt,
-  //         value: "1"
-  //       },
-  //       group: {
-  //         argumentType: ArgumentTypeName.Object,
-  //         value: serializeSemaphoreGroup(
-  //           attendeeGroup,
-  //           attendeeGroupResponse.value.name
-  //         )
-  //       },
-  //       identity: {
-  //         argumentType: ArgumentTypeName.PCD,
-  //         pcdType: SemaphoreIdentityPCDPackage.name,
-  //         value: await SemaphoreIdentityPCDPackage.serialize(newUserIdentityPCD)
-  //       }
-  //     });
+      const groupPCD = await SemaphoreGroupPCDPackage.prove({
+        externalNullifier: {
+          argumentType: ArgumentTypeName.BigInt,
+          value: attendeeGroup.root.toString()
+        },
+        signal: {
+          argumentType: ArgumentTypeName.BigInt,
+          value: "1"
+        },
+        group: {
+          argumentType: ArgumentTypeName.Object,
+          value: serializeSemaphoreGroup(
+            attendeeGroup,
+            attendeeGroupResponse.value.name
+          )
+        },
+        identity: {
+          argumentType: ArgumentTypeName.PCD,
+          pcdType: SemaphoreIdentityPCDPackage.name,
+          value: await SemaphoreIdentityPCDPackage.serialize(newUserIdentityPCD)
+        }
+      });
 
-  //     expectTrue(await SemaphoreGroupPCDPackage.verify(groupPCD));
+      expectTrue(await SemaphoreGroupPCDPackage.verify(groupPCD));
 
-  //     const consumerDB = new PipelineConsumerDB();
-  //     const consumer = (
-  //       await consumerDB.loadByEmails(client, edgeCityPipeline.id, [
-  //         newUser.email
-  //       ])
-  //     )[0];
-  //     expectToExist(consumer);
-  //     const consumerUpdated = consumer.timeUpdated;
-  //     const consumerCreated = consumer.timeCreated;
-  //     expect(consumerCreated.getTime()).to.eq(consumerUpdated.getTime());
-  //     MockDate.set(Date.now() + ONE_MINUTE_MS);
+      const consumerDB = new PipelineConsumerDB();
+      const consumer = (
+        await consumerDB.loadByEmails(client, edgeCityPipeline.id, [
+          newUser.email
+        ])
+      )[0];
+      expectToExist(consumer);
+      const consumerUpdated = consumer.timeUpdated;
+      const consumerCreated = consumer.timeCreated;
+      expect(consumerCreated.getTime()).to.eq(consumerUpdated.getTime());
+      MockDate.set(Date.now() + ONE_MINUTE_MS);
 
-  //     const changedIdentity = new Identity();
-  //     await requestTicketsFromPipeline(
-  //       edgeCityDenverPipeline.issuanceCapability.options.feedFolder,
-  //       edgeCityDenverTicketFeedUrl,
-  //       edgeCityDenverPipeline.issuanceCapability.options.feedId,
-  //       ZUPASS_EDDSA_PRIVATE_KEY,
-  //       newUser.email,
-  //       // The user has a new identity, which might occur if they reset their
-  //       // Zupass account
-  //       changedIdentity
-  //     );
+      const changedIdentity = new Identity();
+      await requestTicketsFromPipeline(
+        edgeCityDenverPipeline.issuanceCapability.options.feedFolder,
+        edgeCityDenverTicketFeedUrl,
+        edgeCityDenverPipeline.issuanceCapability.options.feedId,
+        ZUPASS_EDDSA_PRIVATE_KEY,
+        newUser.email,
+        // The user has a new identity, which might occur if they reset their
+        // Zupass account
+        changedIdentity
+      );
 
-  //     {
-  //       const newAttendeeGroupResponse =
-  //         await requestGenericIssuanceSemaphoreGroup(
-  //           process.env.PASSPORT_SERVER_URL as string,
-  //           edgeCityDenverPipeline.id,
-  //           edgeCitySemaphoreGroupIds.attendees
-  //         );
+      {
+        const newAttendeeGroupResponse =
+          await requestGenericIssuanceSemaphoreGroup(
+            process.env.PASSPORT_SERVER_URL as string,
+            edgeCityDenverPipeline.id,
+            edgeCitySemaphoreGroupIds.attendees
+          );
 
-  //       expectTrue(newAttendeeGroupResponse.success);
-  //       expectLength(newAttendeeGroupResponse.value.members, 5);
-  //       expect(newAttendeeGroupResponse.value.members).to.deep.include.members([
-  //         EdgeCityDenverAttendeeIdentity.commitment.toString(),
-  //         EdgeCityManualAttendeeIdentity.commitment.toString(),
-  //         EdgeCityBouncer2Identity.commitment.toString(),
-  //         changedIdentity.commitment.toString(),
-  //         // The deleted entry is represented by a zeroValue
-  //         newAttendeeGroupResponse.value.zeroValue
-  //       ]);
+        expectTrue(newAttendeeGroupResponse.success);
+        expectLength(newAttendeeGroupResponse.value.members, 5);
+        expect(newAttendeeGroupResponse.value.members).to.deep.include.members([
+          EdgeCityDenverAttendeeIdentity.commitment.toString(),
+          EdgeCityManualAttendeeIdentity.commitment.toString(),
+          EdgeCityBouncer2Identity.commitment.toString(),
+          changedIdentity.commitment.toString(),
+          // The deleted entry is represented by a zeroValue
+          newAttendeeGroupResponse.value.zeroValue
+        ]);
 
-  //       const newAttendeeGroup = await deserializeSemaphoreGroup(
-  //         newAttendeeGroupResponse.value
-  //       );
-  //       expect(newAttendeeGroup.root).to.not.eq(attendeeGroup.root.toString());
+        const newAttendeeGroup = await deserializeSemaphoreGroup(
+          newAttendeeGroupResponse.value
+        );
+        expect(newAttendeeGroup.root).to.not.eq(attendeeGroup.root.toString());
 
-  //       // Requesting the root hash for the group should give us the new root
-  //       const newAttendeeGroupRootResponse =
-  //         await requestGenericIssuanceSemaphoreGroupRoot(
-  //           process.env.PASSPORT_SERVER_URL as string,
-  //           edgeCityDenverPipeline.id,
-  //           edgeCitySemaphoreGroupIds.attendees
-  //         );
+        // Requesting the root hash for the group should give us the new root
+        const newAttendeeGroupRootResponse =
+          await requestGenericIssuanceSemaphoreGroupRoot(
+            process.env.PASSPORT_SERVER_URL as string,
+            edgeCityDenverPipeline.id,
+            edgeCitySemaphoreGroupIds.attendees
+          );
 
-  //       expectTrue(newAttendeeGroupRootResponse.success);
-  //       expect(newAttendeeGroupRootResponse.value).to.eq(
-  //         newAttendeeGroup.root.toString()
-  //       );
+        expectTrue(newAttendeeGroupRootResponse.success);
+        expect(newAttendeeGroupRootResponse.value).to.eq(
+          newAttendeeGroup.root.toString()
+        );
 
-  //       const newAttendeeGroupValidResponse =
-  //         await requestGenericIssuanceValidSemaphoreGroup(
-  //           process.env.PASSPORT_SERVER_URL as string,
-  //           edgeCityDenverPipeline.id,
-  //           edgeCitySemaphoreGroupIds.attendees,
-  //           newAttendeeGroup.root.toString()
-  //         );
+        const newAttendeeGroupValidResponse =
+          await requestGenericIssuanceValidSemaphoreGroup(
+            process.env.PASSPORT_SERVER_URL as string,
+            edgeCityDenverPipeline.id,
+            edgeCitySemaphoreGroupIds.attendees,
+            newAttendeeGroup.root.toString()
+          );
 
-  //       expectTrue(newAttendeeGroupValidResponse.success);
-  //       expectTrue(newAttendeeGroupValidResponse.value.valid);
+        expectTrue(newAttendeeGroupValidResponse.success);
+        expectTrue(newAttendeeGroupValidResponse.value.valid);
 
-  //       // We should be able to get the old values for the group by providing
-  //       // the root hash.
-  //       const historicalGroupResponse =
-  //         await requestGenericIssuanceHistoricalSemaphoreGroup(
-  //           process.env.PASSPORT_SERVER_URL as string,
-  //           edgeCityDenverPipeline.id,
-  //           edgeCitySemaphoreGroupIds.attendees,
-  //           attendeeGroup.root.toString()
-  //         );
+        // We should be able to get the old values for the group by providing
+        // the root hash.
+        const historicalGroupResponse =
+          await requestGenericIssuanceHistoricalSemaphoreGroup(
+            process.env.PASSPORT_SERVER_URL as string,
+            edgeCityDenverPipeline.id,
+            edgeCitySemaphoreGroupIds.attendees,
+            attendeeGroup.root.toString()
+          );
 
-  //       expectTrue(historicalGroupResponse.success);
-  //       expect(historicalGroupResponse.value.members).to.deep.eq(
-  //         attendeeGroupResponse.value.members
-  //       );
+        expectTrue(historicalGroupResponse.success);
+        expect(historicalGroupResponse.value.members).to.deep.eq(
+          attendeeGroupResponse.value.members
+        );
 
-  //       const newUserIdentityPCD = await SemaphoreIdentityPCDPackage.prove({
-  //         identityV3: changedIdentity // Use the changed identity
-  //       });
+        const newUserIdentityPCD = await SemaphoreIdentityPCDPackage.prove({
+          identityV3: changedIdentity // Use the changed identity
+        });
 
-  //       const groupPCD = await SemaphoreGroupPCDPackage.prove({
-  //         externalNullifier: {
-  //           argumentType: ArgumentTypeName.BigInt,
-  //           value: newAttendeeGroup.root.toString()
-  //         },
-  //         signal: {
-  //           argumentType: ArgumentTypeName.BigInt,
-  //           value: "1"
-  //         },
-  //         group: {
-  //           argumentType: ArgumentTypeName.Object,
-  //           value: serializeSemaphoreGroup(
-  //             newAttendeeGroup,
-  //             newAttendeeGroupResponse.value.name
-  //           )
-  //         },
-  //         identity: {
-  //           argumentType: ArgumentTypeName.PCD,
-  //           pcdType: SemaphoreIdentityPCDPackage.name,
-  //           value:
-  //             await SemaphoreIdentityPCDPackage.serialize(newUserIdentityPCD)
-  //         }
-  //       });
+        const groupPCD = await SemaphoreGroupPCDPackage.prove({
+          externalNullifier: {
+            argumentType: ArgumentTypeName.BigInt,
+            value: newAttendeeGroup.root.toString()
+          },
+          signal: {
+            argumentType: ArgumentTypeName.BigInt,
+            value: "1"
+          },
+          group: {
+            argumentType: ArgumentTypeName.Object,
+            value: serializeSemaphoreGroup(
+              newAttendeeGroup,
+              newAttendeeGroupResponse.value.name
+            )
+          },
+          identity: {
+            argumentType: ArgumentTypeName.PCD,
+            pcdType: SemaphoreIdentityPCDPackage.name,
+            value:
+              await SemaphoreIdentityPCDPackage.serialize(newUserIdentityPCD)
+          }
+        });
 
-  //       expectTrue(await SemaphoreGroupPCDPackage.verify(groupPCD));
-  //     }
+        expectTrue(await SemaphoreGroupPCDPackage.verify(groupPCD));
+      }
 
-  //     const consumerAfterChange = (
-  //       await consumerDB.loadByEmails(client, edgeCityDenverPipeline.id, [
-  //         newUser.email
-  //       ])
-  //     )[0];
-  //     const consumerUpdatedAfterChange = consumerAfterChange.timeUpdated;
-  //     const consumerCreatedAfterChange = consumerAfterChange.timeCreated;
+      const consumerAfterChange = (
+        await consumerDB.loadByEmails(client, edgeCityDenverPipeline.id, [
+          newUser.email
+        ])
+      )[0];
+      const consumerUpdatedAfterChange = consumerAfterChange.timeUpdated;
+      const consumerCreatedAfterChange = consumerAfterChange.timeCreated;
 
-  //     // Consumer update occurred now
-  //     expect(consumerUpdatedAfterChange.getTime()).to.eq(Date.now());
-  //     // Creation time should never change
-  //     expect(consumerCreatedAfterChange.getTime()).to.eq(
-  //       consumerCreated.getTime()
-  //     );
-  //     // Update time should be later than creation time now
-  //     expect(consumerUpdatedAfterChange.getTime()).to.be.greaterThan(
-  //       consumerCreated.getTime()
-  //     );
-  //     // Update time should be later than original update time
-  //     expect(consumerUpdatedAfterChange.getTime()).to.be.greaterThan(
-  //       consumerUpdated.getTime()
-  //     );
-  //   }
-  // );
+      // Consumer update occurred now
+      expect(consumerUpdatedAfterChange.getTime()).to.eq(Date.now());
+      // Creation time should never change
+      expect(consumerCreatedAfterChange.getTime()).to.eq(
+        consumerCreated.getTime()
+      );
+      // Update time should be later than creation time now
+      expect(consumerUpdatedAfterChange.getTime()).to.be.greaterThan(
+        consumerCreated.getTime()
+      );
+      // Update time should be later than original update time
+      expect(consumerUpdatedAfterChange.getTime()).to.be.greaterThan(
+        consumerUpdated.getTime()
+      );
+    }
+  );
 
   step(
     "Lemonade API will request new token when old one expires",

--- a/apps/passport-server/test/generic-issuance/pipelines/pretix/pretixPipeline-with-v4.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/pretix/pretixPipeline-with-v4.spec.ts
@@ -4,7 +4,9 @@ import { EmailPCDPackage } from "@pcd/email-pcd";
 import {
   PipelineLogLevel,
   PodboxTicketActionResponseValue,
+  PretixPipelineDefinition,
   createCredentialPayload,
+  requestGenericIssuanceSemaphoreGroup,
   requestPodboxTicketAction
 } from "@pcd/passport-interface";
 import { expectIsPODTicketPCD } from "@pcd/pod-ticket-pcd";
@@ -16,6 +18,8 @@ import { step } from "mocha-steps";
 import * as MockDate from "mockdate";
 import { Pool, PoolClient } from "postgres-pool";
 import { stopApplication } from "../../../../src/application";
+import { PipelineCheckinDB } from "../../../../src/database/queries/pipelineCheckinDB";
+import { PipelineConsumerDB } from "../../../../src/database/queries/pipelineConsumerDB";
 import { PipelineDefinitionDB } from "../../../../src/database/queries/pipelineDefinitionDB";
 import { PipelineUserDB } from "../../../../src/database/queries/pipelineUserDB";
 import { GenericIssuanceService } from "../../../../src/services/generic-issuance/GenericIssuanceService";
@@ -73,8 +77,8 @@ describe("generic issuance - PretixPipeline with semaphore v4 enabled", function
     pretixBackend,
     ethLatAmPretixOrganizer,
     ethLatAmEvent,
-    ethLatAmPipeline
-    // ethLatAmSemaphoreGroupIds
+    ethLatAmPipeline,
+    ethLatAmSemaphoreGroupIds
   } = setupTestPretixPipeline(true);
 
   const pipelineDefinitions = [ethLatAmPipeline];
@@ -204,7 +208,7 @@ describe("generic issuance - PretixPipeline with semaphore v4 enabled", function
       expectToExist(pipeline);
       expect(pipeline.id).to.eq(ethLatAmPipeline.id);
       const ethLatAmTicketFeedUrl = pipeline.issuanceCapability.feedUrl;
-      //  const ethLatAmIssuanceDateTime = new Date();
+      const ethLatAmIssuanceDateTime = new Date();
       const attendeeTickets = await requestTicketsFromPipeline(
         pipeline.issuanceCapability.options.feedFolder,
         ethLatAmTicketFeedUrl,
@@ -452,392 +456,392 @@ describe("generic issuance - PretixPipeline with semaphore v4 enabled", function
       } satisfies PodboxTicketActionResponseValue);
 
       // Verify that consumers were saved for each user who requested tickets
-      // const consumerDB = new PipelineConsumerDB();
-      // const consumers = await consumerDB.loadByEmails(
-      //   client,
-      //   ethLatAmPipeline.id,
-      //   [
-      //     EthLatAmManualAttendeeEmail,
-      //     EthLatAmManualBouncerEmail,
-      //     pretixBackend.get().ethLatAmOrganizer.ethLatAmAttendeeEmail,
-      //     pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-      //   ]
-      // );
-      // expectLength(consumers, 4);
-      // expect(consumers).to.deep.include.members([
-      //   {
-      //     email: EthLatAmManualAttendeeEmail,
-      //     commitment: EthLatAmManualAttendeeIdentity.commitment.toString(),
-      //     timeCreated: ethLatAmIssuanceDateTime,
-      //     timeUpdated: ethLatAmIssuanceDateTime
-      //   },
-      //   {
-      //     email: EthLatAmManualBouncerEmail,
-      //     commitment: EthLatAmManualBouncerIdentity.commitment.toString(),
-      //     timeCreated: ethLatAmIssuanceDateTime,
-      //     timeUpdated: ethLatAmIssuanceDateTime
-      //   },
-      //   {
-      //     email: pretixBackend.get().ethLatAmOrganizer.ethLatAmAttendeeEmail,
-      //     commitment: EthLatAmAttendeeIdentity.commitment.toString(),
-      //     timeCreated: ethLatAmIssuanceDateTime,
-      //     timeUpdated: ethLatAmIssuanceDateTime
-      //   },
-      //   {
-      //     email: pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
-      //     commitment: EthLatAmBouncerIdentity.commitment.toString(),
-      //     timeCreated: ethLatAmIssuanceDateTime,
-      //     timeUpdated: ethLatAmIssuanceDateTime
-      //   }
-      // ]);
+      const consumerDB = new PipelineConsumerDB();
+      const consumers = await consumerDB.loadByEmails(
+        client,
+        ethLatAmPipeline.id,
+        [
+          EthLatAmManualAttendeeEmail,
+          EthLatAmManualBouncerEmail,
+          pretixBackend.get().ethLatAmOrganizer.ethLatAmAttendeeEmail,
+          pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+        ]
+      );
+      expectLength(consumers, 4);
+      expect(consumers).to.deep.include.members([
+        {
+          email: EthLatAmManualAttendeeEmail,
+          commitment: EthLatAmManualAttendeeIdentity.commitment.toString(),
+          timeCreated: ethLatAmIssuanceDateTime,
+          timeUpdated: ethLatAmIssuanceDateTime
+        },
+        {
+          email: EthLatAmManualBouncerEmail,
+          commitment: EthLatAmManualBouncerIdentity.commitment.toString(),
+          timeCreated: ethLatAmIssuanceDateTime,
+          timeUpdated: ethLatAmIssuanceDateTime
+        },
+        {
+          email: pretixBackend.get().ethLatAmOrganizer.ethLatAmAttendeeEmail,
+          commitment: EthLatAmAttendeeIdentity.commitment.toString(),
+          timeCreated: ethLatAmIssuanceDateTime,
+          timeUpdated: ethLatAmIssuanceDateTime
+        },
+        {
+          email: pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
+          commitment: EthLatAmBouncerIdentity.commitment.toString(),
+          timeCreated: ethLatAmIssuanceDateTime,
+          timeUpdated: ethLatAmIssuanceDateTime
+        }
+      ]);
 
       await checkPipelineInfoEndpoint(giBackend, pipeline);
     }
   );
 
-  // step(
-  //   "Pretix pipeline Semaphore groups contain correct members",
-  //   async function () {
-  //     expectToExist(giService);
-  //     const pipelines = await giService.getAllPipelineInstances();
-  //     expectToExist(pipelines);
-  //     expectLength(pipelines, 1);
-  //     const ethLatAmPipeline = pipelines.find(PretixPipeline.is);
-  //     expectToExist(ethLatAmPipeline);
+  step(
+    "Pretix pipeline Semaphore groups contain correct members",
+    async function () {
+      expectToExist(giService);
+      const pipelines = await giService.getAllPipelineInstances();
+      expectToExist(pipelines);
+      expectLength(pipelines, 1);
+      const ethLatAmPipeline = pipelines.find(PretixPipeline.is);
+      expectToExist(ethLatAmPipeline);
 
-  //     await giService.performPipelineLoad(ethLatAmPipeline.id);
+      await giService.performPipelineLoad(ethLatAmPipeline.id);
 
-  //     const semaphoreGroupAll = await requestGenericIssuanceSemaphoreGroup(
-  //       process.env.PASSPORT_SERVER_URL as string,
-  //       ethLatAmPipeline.id,
-  //       ethLatAmSemaphoreGroupIds.all
-  //     );
-  //     expectTrue(semaphoreGroupAll.success);
-  //     expectLength(semaphoreGroupAll.value.members, 4);
-  //     expect(semaphoreGroupAll.value.members).to.deep.include.members([
-  //       EthLatAmBouncerIdentity.commitment.toString(),
-  //       EthLatAmAttendeeIdentity.commitment.toString(),
-  //       EthLatAmManualAttendeeIdentity.commitment.toString(),
-  //       EthLatAmManualBouncerIdentity.commitment.toString()
-  //     ]);
+      const semaphoreGroupAll = await requestGenericIssuanceSemaphoreGroup(
+        process.env.PASSPORT_SERVER_URL as string,
+        ethLatAmPipeline.id,
+        ethLatAmSemaphoreGroupIds.all
+      );
+      expectTrue(semaphoreGroupAll.success);
+      expectLength(semaphoreGroupAll.value.members, 4);
+      expect(semaphoreGroupAll.value.members).to.deep.include.members([
+        EthLatAmBouncerIdentity.commitment.toString(),
+        EthLatAmAttendeeIdentity.commitment.toString(),
+        EthLatAmManualAttendeeIdentity.commitment.toString(),
+        EthLatAmManualBouncerIdentity.commitment.toString()
+      ]);
 
-  //     const semaphoreGroupBouncers = await requestGenericIssuanceSemaphoreGroup(
-  //       process.env.PASSPORT_SERVER_URL as string,
-  //       ethLatAmPipeline.id,
-  //       ethLatAmSemaphoreGroupIds.bouncers
-  //     );
+      const semaphoreGroupBouncers = await requestGenericIssuanceSemaphoreGroup(
+        process.env.PASSPORT_SERVER_URL as string,
+        ethLatAmPipeline.id,
+        ethLatAmSemaphoreGroupIds.bouncers
+      );
 
-  //     expectTrue(semaphoreGroupBouncers.success);
-  //     expectLength(semaphoreGroupBouncers.value.members, 2);
-  //     expect(semaphoreGroupBouncers.value.members).to.deep.include.members([
-  //       EthLatAmBouncerIdentity.commitment.toString(),
-  //       EthLatAmManualBouncerIdentity.commitment.toString()
-  //     ]);
+      expectTrue(semaphoreGroupBouncers.success);
+      expectLength(semaphoreGroupBouncers.value.members, 2);
+      expect(semaphoreGroupBouncers.value.members).to.deep.include.members([
+        EthLatAmBouncerIdentity.commitment.toString(),
+        EthLatAmManualBouncerIdentity.commitment.toString()
+      ]);
 
-  //     const semaphoreGroupAttendees =
-  //       await requestGenericIssuanceSemaphoreGroup(
-  //         process.env.PASSPORT_SERVER_URL as string,
-  //         ethLatAmPipeline.id,
-  //         ethLatAmSemaphoreGroupIds.attendees
-  //       );
+      const semaphoreGroupAttendees =
+        await requestGenericIssuanceSemaphoreGroup(
+          process.env.PASSPORT_SERVER_URL as string,
+          ethLatAmPipeline.id,
+          ethLatAmSemaphoreGroupIds.attendees
+        );
 
-  //     expectTrue(semaphoreGroupAttendees.success);
-  //     expectLength(semaphoreGroupAttendees.value.members, 2);
-  //     expect(semaphoreGroupAttendees.value.members).to.deep.include.members([
-  //       EthLatAmAttendeeIdentity.commitment.toString(),
-  //       EthLatAmManualAttendeeIdentity.commitment.toString()
-  //     ]);
+      expectTrue(semaphoreGroupAttendees.success);
+      expectLength(semaphoreGroupAttendees.value.members, 2);
+      expect(semaphoreGroupAttendees.value.members).to.deep.include.members([
+        EthLatAmAttendeeIdentity.commitment.toString(),
+        EthLatAmManualAttendeeIdentity.commitment.toString()
+      ]);
 
-  //     const semaphoreGroupAttendeesAndBouncers =
-  //       await requestGenericIssuanceSemaphoreGroup(
-  //         process.env.PASSPORT_SERVER_URL as string,
-  //         ethLatAmPipeline.id,
-  //         ethLatAmSemaphoreGroupIds.attendeesAndBouncers
-  //       );
+      const semaphoreGroupAttendeesAndBouncers =
+        await requestGenericIssuanceSemaphoreGroup(
+          process.env.PASSPORT_SERVER_URL as string,
+          ethLatAmPipeline.id,
+          ethLatAmSemaphoreGroupIds.attendeesAndBouncers
+        );
 
-  //     expectTrue(semaphoreGroupAttendeesAndBouncers.success);
-  //     expectLength(semaphoreGroupAttendeesAndBouncers.value.members, 4);
-  //     expect(
-  //       semaphoreGroupAttendeesAndBouncers.value.members
-  //     ).to.deep.include.members([
-  //       EthLatAmBouncerIdentity.commitment.toString(),
-  //       EthLatAmAttendeeIdentity.commitment.toString(),
-  //       EthLatAmManualAttendeeIdentity.commitment.toString(),
-  //       EthLatAmManualBouncerIdentity.commitment.toString()
-  //     ]);
-  //   }
-  // );
+      expectTrue(semaphoreGroupAttendeesAndBouncers.success);
+      expectLength(semaphoreGroupAttendeesAndBouncers.value.members, 4);
+      expect(
+        semaphoreGroupAttendeesAndBouncers.value.members
+      ).to.deep.include.members([
+        EthLatAmBouncerIdentity.commitment.toString(),
+        EthLatAmAttendeeIdentity.commitment.toString(),
+        EthLatAmManualAttendeeIdentity.commitment.toString(),
+        EthLatAmManualBouncerIdentity.commitment.toString()
+      ]);
+    }
+  );
 
-  // step("check-ins for deleted manual tickets are removed", async function () {
-  //   expectToExist(giService);
+  step("check-ins for deleted manual tickets are removed", async function () {
+    expectToExist(giService);
 
-  //   const checkinDB = new PipelineCheckinDB();
-  //   const checkins = await checkinDB.getByPipelineId(
-  //     client,
-  //     ethLatAmPipeline.id
-  //   );
-  //   // Manual attendee ticket was checked in
-  //   expectLength(checkins, 1);
+    const checkinDB = new PipelineCheckinDB();
+    const checkins = await checkinDB.getByPipelineId(
+      client,
+      ethLatAmPipeline.id
+    );
+    // Manual attendee ticket was checked in
+    expectLength(checkins, 1);
 
-  //   const userDB = new PipelineUserDB();
-  //   const adminUser = await userDB.getUserById(client, adminGIUserId);
-  //   expectToExist(adminUser);
+    const userDB = new PipelineUserDB();
+    const adminUser = await userDB.getUserById(client, adminGIUserId);
+    expectToExist(adminUser);
 
-  //   // Delete the manual tickets from the definition
-  //   const latestPipeline = (await giService.getPipeline(
-  //     client,
-  //     ethLatAmPipeline.id
-  //   )) as PretixPipelineDefinition;
-  //   const newPipelineDefinition = structuredClone(latestPipeline);
-  //   newPipelineDefinition.options.manualTickets = [];
-  //   // Update the definition
-  //   const { restartPromise } = await giService.upsertPipelineDefinition(
-  //     client,
-  //     adminUser,
-  //     newPipelineDefinition
-  //   );
-  //   // On restart, the pipeline will delete the orphaned checkins
-  //   await restartPromise;
+    // Delete the manual tickets from the definition
+    const latestPipeline = (await giService.getPipeline(
+      client,
+      ethLatAmPipeline.id
+    )) as PretixPipelineDefinition;
+    const newPipelineDefinition = structuredClone(latestPipeline);
+    newPipelineDefinition.options.manualTickets = [];
+    // Update the definition
+    const { restartPromise } = await giService.upsertPipelineDefinition(
+      client,
+      adminUser,
+      newPipelineDefinition
+    );
+    // On restart, the pipeline will delete the orphaned checkins
+    await restartPromise;
 
-  //   // Find the running pipeline
-  //   const pipelines = await giService.getAllPipelineInstances();
-  //   expectToExist(pipelines);
-  //   expectLength(pipelines, 1);
-  //   const pipeline = pipelines.find(PretixPipeline.is);
-  //   expectToExist(pipeline);
-  //   expect(pipeline.id).to.eq(newPipelineDefinition.id);
-  //   // Verify that there are no checkins in the DB now
-  //   {
-  //     const checkins = await checkinDB.getByPipelineId(
-  //       client,
-  //       ethLatAmPipeline.id
-  //     );
-  //     // no checkins are found as the tickets have been deleted
-  //     expectLength(checkins, 0);
-  //   }
-  // });
+    // Find the running pipeline
+    const pipelines = await giService.getAllPipelineInstances();
+    expectToExist(pipelines);
+    expectLength(pipelines, 1);
+    const pipeline = pipelines.find(PretixPipeline.is);
+    expectToExist(pipeline);
+    expect(pipeline.id).to.eq(newPipelineDefinition.id);
+    // Verify that there are no checkins in the DB now
+    {
+      const checkins = await checkinDB.getByPipelineId(
+        client,
+        ethLatAmPipeline.id
+      );
+      // no checkins are found as the tickets have been deleted
+      expectLength(checkins, 0);
+    }
+  });
 
-  // step("check-in and remote check-out works in Pretix", async function () {
-  //   expectToExist(giService);
-  //   const pipelines = await giService.getAllPipelineInstances();
-  //   const pipeline = pipelines.find(PretixPipeline.is);
-  //   expectToExist(pipeline);
-  //   expect(pipeline.id).to.eq(ethLatAmPipeline.id);
-  //   const ethLatAmTicketFeedUrl = pipeline.issuanceCapability.feedUrl;
+  step("check-in and remote check-out works in Pretix", async function () {
+    expectToExist(giService);
+    const pipelines = await giService.getAllPipelineInstances();
+    const pipeline = pipelines.find(PretixPipeline.is);
+    expectToExist(pipeline);
+    expect(pipeline.id).to.eq(ethLatAmPipeline.id);
+    const ethLatAmTicketFeedUrl = pipeline.issuanceCapability.feedUrl;
 
-  //   // Ensure that bouncer is checked out
-  //   pretixBackend.checkOut(
-  //     ethLatAmPretixOrganizer.orgUrl,
-  //     "eth-lat-am",
-  //     pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-  //   );
-  //   MockDate.set(Date.now() + ONE_SECOND_MS);
-  //   // Verify that bouncer is checked out in backend
-  //   await giService.performPipelineLoad(pipeline.id);
+    // Ensure that bouncer is checked out
+    pretixBackend.checkOut(
+      ethLatAmPretixOrganizer.orgUrl,
+      "eth-lat-am",
+      pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+    );
+    MockDate.set(Date.now() + ONE_SECOND_MS);
+    // Verify that bouncer is checked out in backend
+    await giService.performPipelineLoad(pipeline.id);
 
-  //   const bouncerTickets = await requestTicketsFromPipeline(
-  //     pipeline.issuanceCapability.options.feedFolder,
-  //     ethLatAmTicketFeedUrl,
-  //     pipeline.issuanceCapability.options.feedId,
-  //     ZUPASS_EDDSA_PRIVATE_KEY,
-  //     pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
-  //     EthLatAmBouncerIdentity,
-  //     true
-  //   );
-  //   expectLength(bouncerTickets, 2);
-  //   const bouncerTicket = bouncerTickets[0];
-  //   expectToExist(bouncerTicket);
-  //   expectIsEdDSATicketPCD(bouncerTicket);
-  //   expect(bouncerTicket.claim.ticket.attendeeEmail).to.eq(
-  //     pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-  //   );
-  //   // Bouncer ticket is checked out
-  //   expect(bouncerTicket.claim.ticket.isConsumed).to.eq(false);
-  //   expect(bouncerTicket.claim.ticket.imageUrl).to.be.undefined;
+    const bouncerTickets = await requestTicketsFromPipeline(
+      pipeline.issuanceCapability.options.feedFolder,
+      ethLatAmTicketFeedUrl,
+      pipeline.issuanceCapability.options.feedId,
+      ZUPASS_EDDSA_PRIVATE_KEY,
+      pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
+      EthLatAmBouncerIdentity,
+      true
+    );
+    expectLength(bouncerTickets, 2);
+    const bouncerTicket = bouncerTickets[0];
+    expectToExist(bouncerTicket);
+    expectIsEdDSATicketPCD(bouncerTicket);
+    expect(bouncerTicket.claim.ticket.attendeeEmail).to.eq(
+      pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+    );
+    // Bouncer ticket is checked out
+    expect(bouncerTicket.claim.ticket.isConsumed).to.eq(false);
+    expect(bouncerTicket.claim.ticket.imageUrl).to.be.undefined;
 
-  //   const bouncerPODTicket = bouncerTickets[1];
-  //   expectToExist(bouncerPODTicket);
-  //   expectIsPODTicketPCD(bouncerPODTicket);
-  //   expect(bouncerPODTicket.claim.ticket.attendeeEmail).to.eq(
-  //     pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-  //   );
-  //   // Bouncer ticket is checked out
-  //   expect(bouncerPODTicket.claim.ticket.isConsumed).to.eq(false);
-  //   expect(bouncerPODTicket.claim.ticket.imageUrl).to.be.undefined;
+    const bouncerPODTicket = bouncerTickets[1];
+    expectToExist(bouncerPODTicket);
+    expectIsPODTicketPCD(bouncerPODTicket);
+    expect(bouncerPODTicket.claim.ticket.attendeeEmail).to.eq(
+      pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+    );
+    // Bouncer ticket is checked out
+    expect(bouncerPODTicket.claim.ticket.isConsumed).to.eq(false);
+    expect(bouncerPODTicket.claim.ticket.imageUrl).to.be.undefined;
 
-  //   // Now check the bouncer in
-  //   const ethLatAmCheckinRoute = pipeline.checkinCapability.getCheckinUrl();
+    // Now check the bouncer in
+    const ethLatAmCheckinRoute = pipeline.checkinCapability.getCheckinUrl();
 
-  //   const bouncerCheckInBouncer = await requestCheckInPipelineTicket(
-  //     ethLatAmCheckinRoute,
-  //     ZUPASS_EDDSA_PRIVATE_KEY,
-  //     bouncerTicket.claim.ticket.attendeeEmail,
-  //     EthLatAmBouncerIdentity,
-  //     bouncerTicket
-  //   );
-  //   expect(bouncerCheckInBouncer.value).to.deep.eq({ success: true });
-  //   const checkinTimestamp = Date.now();
-  //   MockDate.set(Date.now() + ONE_SECOND_MS);
+    const bouncerCheckInBouncer = await requestCheckInPipelineTicket(
+      ethLatAmCheckinRoute,
+      ZUPASS_EDDSA_PRIVATE_KEY,
+      bouncerTicket.claim.ticket.attendeeEmail,
+      EthLatAmBouncerIdentity,
+      bouncerTicket
+    );
+    expect(bouncerCheckInBouncer.value).to.deep.eq({ success: true });
+    const checkinTimestamp = Date.now();
+    MockDate.set(Date.now() + ONE_SECOND_MS);
 
-  //   // Reload the pipeline
-  //   await giService.performPipelineLoad(pipeline.id);
+    // Reload the pipeline
+    await giService.performPipelineLoad(pipeline.id);
 
-  //   {
-  //     // Get updated tickets from feed
-  //     const bouncerTickets = await requestTicketsFromPipeline(
-  //       pipeline.issuanceCapability.options.feedFolder,
-  //       ethLatAmTicketFeedUrl,
-  //       pipeline.issuanceCapability.options.feedId,
-  //       ZUPASS_EDDSA_PRIVATE_KEY,
-  //       pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
-  //       EthLatAmBouncerIdentity,
-  //       true
-  //     );
-  //     expectLength(bouncerTickets, 2);
-  //     const bouncerTicket = bouncerTickets[0];
-  //     expectToExist(bouncerTicket);
-  //     expectIsEdDSATicketPCD(bouncerTicket);
-  //     expect(bouncerTicket.claim.ticket.attendeeEmail).to.eq(
-  //       pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-  //     );
-  //     // User is now checked in
-  //     expect(bouncerTicket.claim.ticket.isConsumed).to.eq(true);
+    {
+      // Get updated tickets from feed
+      const bouncerTickets = await requestTicketsFromPipeline(
+        pipeline.issuanceCapability.options.feedFolder,
+        ethLatAmTicketFeedUrl,
+        pipeline.issuanceCapability.options.feedId,
+        ZUPASS_EDDSA_PRIVATE_KEY,
+        pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
+        EthLatAmBouncerIdentity,
+        true
+      );
+      expectLength(bouncerTickets, 2);
+      const bouncerTicket = bouncerTickets[0];
+      expectToExist(bouncerTicket);
+      expectIsEdDSATicketPCD(bouncerTicket);
+      expect(bouncerTicket.claim.ticket.attendeeEmail).to.eq(
+        pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+      );
+      // User is now checked in
+      expect(bouncerTicket.claim.ticket.isConsumed).to.eq(true);
 
-  //     const bouncerPODTicket = bouncerTickets[1];
-  //     expectToExist(bouncerPODTicket);
-  //     expectIsPODTicketPCD(bouncerPODTicket);
-  //     expect(bouncerPODTicket.claim.ticket.attendeeEmail).to.eq(
-  //       pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-  //     );
-  //     // User is now checked in
-  //     expect(bouncerPODTicket.claim.ticket.isConsumed).to.eq(true);
-  //   }
-  //   {
-  //     // Trying to check in again should fail
-  //     const bouncerCheckInBouncer = await requestCheckInPipelineTicket(
-  //       ethLatAmCheckinRoute,
-  //       ZUPASS_EDDSA_PRIVATE_KEY,
-  //       bouncerTicket.claim.ticket.attendeeEmail,
-  //       EthLatAmBouncerIdentity,
-  //       bouncerTicket
-  //     );
-  //     expect(bouncerCheckInBouncer.value).to.deep.eq({
-  //       success: false,
-  //       error: {
-  //         name: "AlreadyCheckedIn",
-  //         checkinTimestamp: new Date(checkinTimestamp).toISOString(),
-  //         checker: "Pretix"
-  //       }
-  //     } as PodboxTicketActionResponseValue);
-  //   }
-  //   {
-  //     // Check the bouncer out again
-  //     // Simulates the effect of check-in being deleted in Pretix
-  //     pretixBackend.checkOut(
-  //       ethLatAmPretixOrganizer.orgUrl,
-  //       "eth-lat-am",
-  //       pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-  //     );
-  //   }
-  //   {
-  //     // Trying to check in again should fail because we have not yet reloaded
-  //     // data from Pretix.
-  //     const bouncerCheckInBouncer = await requestCheckInPipelineTicket(
-  //       ethLatAmCheckinRoute,
-  //       ZUPASS_EDDSA_PRIVATE_KEY,
-  //       bouncerTicket.claim.ticket.attendeeEmail,
-  //       EthLatAmBouncerIdentity,
-  //       bouncerTicket
-  //     );
-  //     expect(bouncerCheckInBouncer.value).to.deep.eq({
-  //       success: false,
-  //       error: {
-  //         name: "AlreadyCheckedIn",
-  //         checkinTimestamp: new Date(checkinTimestamp).toISOString(),
-  //         checker: "Pretix"
-  //       }
-  //     } as PodboxTicketActionResponseValue);
-  //   }
-  //   // Verify that bouncer is checked out in backend
-  //   await giService.performPipelineLoad(pipeline.id);
+      const bouncerPODTicket = bouncerTickets[1];
+      expectToExist(bouncerPODTicket);
+      expectIsPODTicketPCD(bouncerPODTicket);
+      expect(bouncerPODTicket.claim.ticket.attendeeEmail).to.eq(
+        pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+      );
+      // User is now checked in
+      expect(bouncerPODTicket.claim.ticket.isConsumed).to.eq(true);
+    }
+    {
+      // Trying to check in again should fail
+      const bouncerCheckInBouncer = await requestCheckInPipelineTicket(
+        ethLatAmCheckinRoute,
+        ZUPASS_EDDSA_PRIVATE_KEY,
+        bouncerTicket.claim.ticket.attendeeEmail,
+        EthLatAmBouncerIdentity,
+        bouncerTicket
+      );
+      expect(bouncerCheckInBouncer.value).to.deep.eq({
+        success: false,
+        error: {
+          name: "AlreadyCheckedIn",
+          checkinTimestamp: new Date(checkinTimestamp).toISOString(),
+          checker: "Pretix"
+        }
+      } as PodboxTicketActionResponseValue);
+    }
+    {
+      // Check the bouncer out again
+      // Simulates the effect of check-in being deleted in Pretix
+      pretixBackend.checkOut(
+        ethLatAmPretixOrganizer.orgUrl,
+        "eth-lat-am",
+        pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+      );
+    }
+    {
+      // Trying to check in again should fail because we have not yet reloaded
+      // data from Pretix.
+      const bouncerCheckInBouncer = await requestCheckInPipelineTicket(
+        ethLatAmCheckinRoute,
+        ZUPASS_EDDSA_PRIVATE_KEY,
+        bouncerTicket.claim.ticket.attendeeEmail,
+        EthLatAmBouncerIdentity,
+        bouncerTicket
+      );
+      expect(bouncerCheckInBouncer.value).to.deep.eq({
+        success: false,
+        error: {
+          name: "AlreadyCheckedIn",
+          checkinTimestamp: new Date(checkinTimestamp).toISOString(),
+          checker: "Pretix"
+        }
+      } as PodboxTicketActionResponseValue);
+    }
+    // Verify that bouncer is checked out in backend
+    await giService.performPipelineLoad(pipeline.id);
 
-  //   {
-  //     const bouncerTickets = await requestTicketsFromPipeline(
-  //       pipeline.issuanceCapability.options.feedFolder,
-  //       ethLatAmTicketFeedUrl,
-  //       pipeline.issuanceCapability.options.feedId,
-  //       ZUPASS_EDDSA_PRIVATE_KEY,
-  //       pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
-  //       EthLatAmBouncerIdentity,
-  //       true
-  //     );
-  //     expectLength(bouncerTickets, 2);
-  //     const bouncerTicket = bouncerTickets[0];
-  //     expectToExist(bouncerTicket);
-  //     expectIsEdDSATicketPCD(bouncerTicket);
-  //     expect(bouncerTicket.claim.ticket.attendeeEmail).to.eq(
-  //       pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-  //     );
-  //     // Bouncer ticket is checked out
-  //     expect(bouncerTicket.claim.ticket.isConsumed).to.eq(false);
+    {
+      const bouncerTickets = await requestTicketsFromPipeline(
+        pipeline.issuanceCapability.options.feedFolder,
+        ethLatAmTicketFeedUrl,
+        pipeline.issuanceCapability.options.feedId,
+        ZUPASS_EDDSA_PRIVATE_KEY,
+        pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
+        EthLatAmBouncerIdentity,
+        true
+      );
+      expectLength(bouncerTickets, 2);
+      const bouncerTicket = bouncerTickets[0];
+      expectToExist(bouncerTicket);
+      expectIsEdDSATicketPCD(bouncerTicket);
+      expect(bouncerTicket.claim.ticket.attendeeEmail).to.eq(
+        pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+      );
+      // Bouncer ticket is checked out
+      expect(bouncerTicket.claim.ticket.isConsumed).to.eq(false);
 
-  //     const bouncerPODTicket = bouncerTickets[1];
-  //     expectToExist(bouncerPODTicket);
-  //     expectIsPODTicketPCD(bouncerPODTicket);
-  //     expect(bouncerPODTicket.claim.ticket.attendeeEmail).to.eq(
-  //       pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-  //     );
-  //     // Bouncer ticket is checked out
-  //     expect(bouncerPODTicket.claim.ticket.isConsumed).to.eq(false);
-  //   }
-  //   {
-  //     // Now check the bouncer in
-  //     const ethLatAmCheckinRoute = pipeline.checkinCapability.getCheckinUrl();
+      const bouncerPODTicket = bouncerTickets[1];
+      expectToExist(bouncerPODTicket);
+      expectIsPODTicketPCD(bouncerPODTicket);
+      expect(bouncerPODTicket.claim.ticket.attendeeEmail).to.eq(
+        pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+      );
+      // Bouncer ticket is checked out
+      expect(bouncerPODTicket.claim.ticket.isConsumed).to.eq(false);
+    }
+    {
+      // Now check the bouncer in
+      const ethLatAmCheckinRoute = pipeline.checkinCapability.getCheckinUrl();
 
-  //     const bouncerCheckInBouncer = await requestCheckInPipelineTicket(
-  //       ethLatAmCheckinRoute,
-  //       ZUPASS_EDDSA_PRIVATE_KEY,
-  //       bouncerTicket.claim.ticket.attendeeEmail,
-  //       EthLatAmBouncerIdentity,
-  //       bouncerTicket
-  //     );
-  //     expect(bouncerCheckInBouncer.value).to.deep.eq({ success: true });
-  //     MockDate.set(Date.now() + ONE_SECOND_MS);
+      const bouncerCheckInBouncer = await requestCheckInPipelineTicket(
+        ethLatAmCheckinRoute,
+        ZUPASS_EDDSA_PRIVATE_KEY,
+        bouncerTicket.claim.ticket.attendeeEmail,
+        EthLatAmBouncerIdentity,
+        bouncerTicket
+      );
+      expect(bouncerCheckInBouncer.value).to.deep.eq({ success: true });
+      MockDate.set(Date.now() + ONE_SECOND_MS);
 
-  //     // Reload the pipeline
-  //     await giService.performPipelineLoad(pipeline.id);
+      // Reload the pipeline
+      await giService.performPipelineLoad(pipeline.id);
 
-  //     {
-  //       const bouncerTickets = await requestTicketsFromPipeline(
-  //         pipeline.issuanceCapability.options.feedFolder,
-  //         ethLatAmTicketFeedUrl,
-  //         pipeline.issuanceCapability.options.feedId,
-  //         ZUPASS_EDDSA_PRIVATE_KEY,
-  //         pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
-  //         EthLatAmBouncerIdentity,
-  //         true
-  //       );
-  //       expectLength(bouncerTickets, 2);
-  //       const bouncerTicket = bouncerTickets[0];
-  //       expectToExist(bouncerTicket);
-  //       expectIsEdDSATicketPCD(bouncerTicket);
-  //       expect(bouncerTicket.claim.ticket.attendeeEmail).to.eq(
-  //         pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-  //       );
-  //       // User is now checked in
-  //       expect(bouncerTicket.claim.ticket.isConsumed).to.eq(true);
+      {
+        const bouncerTickets = await requestTicketsFromPipeline(
+          pipeline.issuanceCapability.options.feedFolder,
+          ethLatAmTicketFeedUrl,
+          pipeline.issuanceCapability.options.feedId,
+          ZUPASS_EDDSA_PRIVATE_KEY,
+          pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
+          EthLatAmBouncerIdentity,
+          true
+        );
+        expectLength(bouncerTickets, 2);
+        const bouncerTicket = bouncerTickets[0];
+        expectToExist(bouncerTicket);
+        expectIsEdDSATicketPCD(bouncerTicket);
+        expect(bouncerTicket.claim.ticket.attendeeEmail).to.eq(
+          pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+        );
+        // User is now checked in
+        expect(bouncerTicket.claim.ticket.isConsumed).to.eq(true);
 
-  //       const bouncerPODTicket = bouncerTickets[1];
-  //       expectToExist(bouncerPODTicket);
-  //       expectIsPODTicketPCD(bouncerPODTicket);
-  //       expect(bouncerPODTicket.claim.ticket.attendeeEmail).to.eq(
-  //         pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-  //       );
-  //       // User is now checked in
-  //       expect(bouncerPODTicket.claim.ticket.isConsumed).to.eq(true);
-  //     }
-  //   }
-  // });
+        const bouncerPODTicket = bouncerTickets[1];
+        expectToExist(bouncerPODTicket);
+        expectIsPODTicketPCD(bouncerPODTicket);
+        expect(bouncerPODTicket.claim.ticket.attendeeEmail).to.eq(
+          pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+        );
+        // User is now checked in
+        expect(bouncerPODTicket.claim.ticket.isConsumed).to.eq(true);
+      }
+    }
+  });
 
   step(
     "Pretix should not load tickets for an event with invalid settings",

--- a/apps/passport-server/test/generic-issuance/pipelines/pretix/pretixPipeline-without-v4.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/pretix/pretixPipeline-without-v4.spec.ts
@@ -6,6 +6,7 @@ import {
   PodboxTicketActionResponseValue,
   PretixPipelineDefinition,
   createCredentialPayload,
+  requestGenericIssuanceSemaphoreGroup,
   requestPodboxTicketAction
 } from "@pcd/passport-interface";
 import { ONE_DAY_MS, ONE_SECOND_MS } from "@pcd/util";
@@ -17,6 +18,7 @@ import * as MockDate from "mockdate";
 import { Pool, PoolClient } from "postgres-pool";
 import { stopApplication } from "../../../../src/application";
 import { PipelineCheckinDB } from "../../../../src/database/queries/pipelineCheckinDB";
+import { PipelineConsumerDB } from "../../../../src/database/queries/pipelineConsumerDB";
 import { PipelineDefinitionDB } from "../../../../src/database/queries/pipelineDefinitionDB";
 import { PipelineUserDB } from "../../../../src/database/queries/pipelineUserDB";
 import { GenericIssuanceService } from "../../../../src/services/generic-issuance/GenericIssuanceService";
@@ -74,8 +76,8 @@ describe("generic issuance - PretixPipeline without semaphore v4 enabled", funct
     pretixBackend,
     ethLatAmPretixOrganizer,
     ethLatAmEvent,
-    ethLatAmPipeline
-    //  ethLatAmSemaphoreGroupIds
+    ethLatAmPipeline,
+    ethLatAmSemaphoreGroupIds
   } = setupTestPretixPipeline(false);
 
   const pipelineDefinitions = [ethLatAmPipeline];
@@ -205,7 +207,7 @@ describe("generic issuance - PretixPipeline without semaphore v4 enabled", funct
       expectToExist(pipeline);
       expect(pipeline.id).to.eq(ethLatAmPipeline.id);
       const ethLatAmTicketFeedUrl = pipeline.issuanceCapability.feedUrl;
-      //  const ethLatAmIssuanceDateTime = new Date();
+      const ethLatAmIssuanceDateTime = new Date();
       const attendeeTickets = await requestTicketsFromPipeline(
         pipeline.issuanceCapability.options.feedFolder,
         ethLatAmTicketFeedUrl,
@@ -405,121 +407,121 @@ describe("generic issuance - PretixPipeline without semaphore v4 enabled", funct
       } satisfies PodboxTicketActionResponseValue);
 
       // Verify that consumers were saved for each user who requested tickets
-      // const consumerDB = new PipelineConsumerDB();
-      // const consumers = await consumerDB.loadByEmails(
-      //   client,
-      //   ethLatAmPipeline.id,
-      //   [
-      //     EthLatAmManualAttendeeEmail,
-      //     EthLatAmManualBouncerEmail,
-      //     pretixBackend.get().ethLatAmOrganizer.ethLatAmAttendeeEmail,
-      //     pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
-      //   ]
-      // );
-      // expectLength(consumers, 4);
-      // expect(consumers).to.deep.include.members([
-      //   {
-      //     email: EthLatAmManualAttendeeEmail,
-      //     commitment: EthLatAmManualAttendeeIdentity.commitment.toString(),
-      //     timeCreated: ethLatAmIssuanceDateTime,
-      //     timeUpdated: ethLatAmIssuanceDateTime
-      //   },
-      //   {
-      //     email: EthLatAmManualBouncerEmail,
-      //     commitment: EthLatAmManualBouncerIdentity.commitment.toString(),
-      //     timeCreated: ethLatAmIssuanceDateTime,
-      //     timeUpdated: ethLatAmIssuanceDateTime
-      //   },
-      //   {
-      //     email: pretixBackend.get().ethLatAmOrganizer.ethLatAmAttendeeEmail,
-      //     commitment: EthLatAmAttendeeIdentity.commitment.toString(),
-      //     timeCreated: ethLatAmIssuanceDateTime,
-      //     timeUpdated: ethLatAmIssuanceDateTime
-      //   },
-      //   {
-      //     email: pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
-      //     commitment: EthLatAmBouncerIdentity.commitment.toString(),
-      //     timeCreated: ethLatAmIssuanceDateTime,
-      //     timeUpdated: ethLatAmIssuanceDateTime
-      //   }
-      // ]);
+      const consumerDB = new PipelineConsumerDB();
+      const consumers = await consumerDB.loadByEmails(
+        client,
+        ethLatAmPipeline.id,
+        [
+          EthLatAmManualAttendeeEmail,
+          EthLatAmManualBouncerEmail,
+          pretixBackend.get().ethLatAmOrganizer.ethLatAmAttendeeEmail,
+          pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail
+        ]
+      );
+      expectLength(consumers, 4);
+      expect(consumers).to.deep.include.members([
+        {
+          email: EthLatAmManualAttendeeEmail,
+          commitment: EthLatAmManualAttendeeIdentity.commitment.toString(),
+          timeCreated: ethLatAmIssuanceDateTime,
+          timeUpdated: ethLatAmIssuanceDateTime
+        },
+        {
+          email: EthLatAmManualBouncerEmail,
+          commitment: EthLatAmManualBouncerIdentity.commitment.toString(),
+          timeCreated: ethLatAmIssuanceDateTime,
+          timeUpdated: ethLatAmIssuanceDateTime
+        },
+        {
+          email: pretixBackend.get().ethLatAmOrganizer.ethLatAmAttendeeEmail,
+          commitment: EthLatAmAttendeeIdentity.commitment.toString(),
+          timeCreated: ethLatAmIssuanceDateTime,
+          timeUpdated: ethLatAmIssuanceDateTime
+        },
+        {
+          email: pretixBackend.get().ethLatAmOrganizer.ethLatAmBouncerEmail,
+          commitment: EthLatAmBouncerIdentity.commitment.toString(),
+          timeCreated: ethLatAmIssuanceDateTime,
+          timeUpdated: ethLatAmIssuanceDateTime
+        }
+      ]);
 
       await checkPipelineInfoEndpoint(giBackend, pipeline);
     }
   );
 
-  // step(
-  //   "Pretix pipeline Semaphore groups contain correct members",
-  //   async function () {
-  //     expectToExist(giService);
-  //     const pipelines = await giService.getAllPipelineInstances();
-  //     expectToExist(pipelines);
-  //     expectLength(pipelines, 1);
-  //     const ethLatAmPipeline = pipelines.find(PretixPipeline.is);
-  //     expectToExist(ethLatAmPipeline);
+  step(
+    "Pretix pipeline Semaphore groups contain correct members",
+    async function () {
+      expectToExist(giService);
+      const pipelines = await giService.getAllPipelineInstances();
+      expectToExist(pipelines);
+      expectLength(pipelines, 1);
+      const ethLatAmPipeline = pipelines.find(PretixPipeline.is);
+      expectToExist(ethLatAmPipeline);
 
-  //     await giService.performPipelineLoad(ethLatAmPipeline.id);
+      await giService.performPipelineLoad(ethLatAmPipeline.id);
 
-  //     const semaphoreGroupAll = await requestGenericIssuanceSemaphoreGroup(
-  //       process.env.PASSPORT_SERVER_URL as string,
-  //       ethLatAmPipeline.id,
-  //       ethLatAmSemaphoreGroupIds.all
-  //     );
-  //     expectTrue(semaphoreGroupAll.success);
-  //     expectLength(semaphoreGroupAll.value.members, 4);
-  //     expect(semaphoreGroupAll.value.members).to.deep.include.members([
-  //       EthLatAmBouncerIdentity.commitment.toString(),
-  //       EthLatAmAttendeeIdentity.commitment.toString(),
-  //       EthLatAmManualAttendeeIdentity.commitment.toString(),
-  //       EthLatAmManualBouncerIdentity.commitment.toString()
-  //     ]);
+      const semaphoreGroupAll = await requestGenericIssuanceSemaphoreGroup(
+        process.env.PASSPORT_SERVER_URL as string,
+        ethLatAmPipeline.id,
+        ethLatAmSemaphoreGroupIds.all
+      );
+      expectTrue(semaphoreGroupAll.success);
+      expectLength(semaphoreGroupAll.value.members, 4);
+      expect(semaphoreGroupAll.value.members).to.deep.include.members([
+        EthLatAmBouncerIdentity.commitment.toString(),
+        EthLatAmAttendeeIdentity.commitment.toString(),
+        EthLatAmManualAttendeeIdentity.commitment.toString(),
+        EthLatAmManualBouncerIdentity.commitment.toString()
+      ]);
 
-  //     const semaphoreGroupBouncers = await requestGenericIssuanceSemaphoreGroup(
-  //       process.env.PASSPORT_SERVER_URL as string,
-  //       ethLatAmPipeline.id,
-  //       ethLatAmSemaphoreGroupIds.bouncers
-  //     );
+      const semaphoreGroupBouncers = await requestGenericIssuanceSemaphoreGroup(
+        process.env.PASSPORT_SERVER_URL as string,
+        ethLatAmPipeline.id,
+        ethLatAmSemaphoreGroupIds.bouncers
+      );
 
-  //     expectTrue(semaphoreGroupBouncers.success);
-  //     expectLength(semaphoreGroupBouncers.value.members, 2);
-  //     expect(semaphoreGroupBouncers.value.members).to.deep.include.members([
-  //       EthLatAmBouncerIdentity.commitment.toString(),
-  //       EthLatAmManualBouncerIdentity.commitment.toString()
-  //     ]);
+      expectTrue(semaphoreGroupBouncers.success);
+      expectLength(semaphoreGroupBouncers.value.members, 2);
+      expect(semaphoreGroupBouncers.value.members).to.deep.include.members([
+        EthLatAmBouncerIdentity.commitment.toString(),
+        EthLatAmManualBouncerIdentity.commitment.toString()
+      ]);
 
-  //     const semaphoreGroupAttendees =
-  //       await requestGenericIssuanceSemaphoreGroup(
-  //         process.env.PASSPORT_SERVER_URL as string,
-  //         ethLatAmPipeline.id,
-  //         ethLatAmSemaphoreGroupIds.attendees
-  //       );
+      const semaphoreGroupAttendees =
+        await requestGenericIssuanceSemaphoreGroup(
+          process.env.PASSPORT_SERVER_URL as string,
+          ethLatAmPipeline.id,
+          ethLatAmSemaphoreGroupIds.attendees
+        );
 
-  //     expectTrue(semaphoreGroupAttendees.success);
-  //     expectLength(semaphoreGroupAttendees.value.members, 2);
-  //     expect(semaphoreGroupAttendees.value.members).to.deep.include.members([
-  //       EthLatAmAttendeeIdentity.commitment.toString(),
-  //       EthLatAmManualAttendeeIdentity.commitment.toString()
-  //     ]);
+      expectTrue(semaphoreGroupAttendees.success);
+      expectLength(semaphoreGroupAttendees.value.members, 2);
+      expect(semaphoreGroupAttendees.value.members).to.deep.include.members([
+        EthLatAmAttendeeIdentity.commitment.toString(),
+        EthLatAmManualAttendeeIdentity.commitment.toString()
+      ]);
 
-  //     const semaphoreGroupAttendeesAndBouncers =
-  //       await requestGenericIssuanceSemaphoreGroup(
-  //         process.env.PASSPORT_SERVER_URL as string,
-  //         ethLatAmPipeline.id,
-  //         ethLatAmSemaphoreGroupIds.attendeesAndBouncers
-  //       );
+      const semaphoreGroupAttendeesAndBouncers =
+        await requestGenericIssuanceSemaphoreGroup(
+          process.env.PASSPORT_SERVER_URL as string,
+          ethLatAmPipeline.id,
+          ethLatAmSemaphoreGroupIds.attendeesAndBouncers
+        );
 
-  //     expectTrue(semaphoreGroupAttendeesAndBouncers.success);
-  //     expectLength(semaphoreGroupAttendeesAndBouncers.value.members, 4);
-  //     expect(
-  //       semaphoreGroupAttendeesAndBouncers.value.members
-  //     ).to.deep.include.members([
-  //       EthLatAmBouncerIdentity.commitment.toString(),
-  //       EthLatAmAttendeeIdentity.commitment.toString(),
-  //       EthLatAmManualAttendeeIdentity.commitment.toString(),
-  //       EthLatAmManualBouncerIdentity.commitment.toString()
-  //     ]);
-  //   }
-  // );
+      expectTrue(semaphoreGroupAttendeesAndBouncers.success);
+      expectLength(semaphoreGroupAttendeesAndBouncers.value.members, 4);
+      expect(
+        semaphoreGroupAttendeesAndBouncers.value.members
+      ).to.deep.include.members([
+        EthLatAmBouncerIdentity.commitment.toString(),
+        EthLatAmAttendeeIdentity.commitment.toString(),
+        EthLatAmManualAttendeeIdentity.commitment.toString(),
+        EthLatAmManualBouncerIdentity.commitment.toString()
+      ]);
+    }
+  );
 
   step("check-ins for deleted manual tickets are removed", async function () {
     expectToExist(giService);

--- a/apps/passport-server/test/generic-issuance/pipelines/pretix/pretixPipelineMultiEmail.spec.ts
+++ b/apps/passport-server/test/generic-issuance/pipelines/pretix/pretixPipelineMultiEmail.spec.ts
@@ -2,14 +2,14 @@ import { getEdDSAPublicKey } from "@pcd/eddsa-pcd";
 import { EmailPCD, EmailPCDPackage, EmailPCDTypeName } from "@pcd/email-pcd";
 import {
   EmailUpdateError,
+  ZUPASS_CREDENTIAL_REQUEST,
+  ZupassFeedIds,
   requestAddUserEmail,
   requestChangeUserEmail,
   requestPollFeed,
-  requestRemoveUserEmail,
-  ZUPASS_CREDENTIAL_REQUEST,
-  ZupassFeedIds
+  requestRemoveUserEmail
 } from "@pcd/passport-interface";
-import { isReplaceInFolderAction, PCDActionType } from "@pcd/pcd-collection";
+import { PCDActionType, isReplaceInFolderAction } from "@pcd/pcd-collection";
 import { Identity } from "@semaphore-protocol/identity";
 import { expect } from "chai";
 import "mocha";


### PR DESCRIPTION
Re-enables features turned off during Devcon:

- CSV pipeline issuance
- CSV ticket pipeline issuance
- Pretix pipeline consumer DB and Semaphore groups
- Lemonade pipeline consumer DB and Semaphore groups