### PR TITLE
Detect when we can't post between tabs and show error message

### DIFF
--- a/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
+++ b/apps/passport-client/components/screens/ProveScreen/GenericProveScreen.tsx
@@ -41,7 +41,7 @@ const Header = styled.div`
  */
 function throwNoOpenerError(): never {
   throw new Error(
-    "Zupass was unable to send your proof to the opening window. This may be because your browser settings do not allow this, or because your browser does not support messaging between tabs."
+    "Zupass was unable to send your proof. Please retry this on a different browser or device."
   );
 }
 


### PR DESCRIPTION
Closes https://linear.app/0xparc-pcd/issue/0XP-1685/replace-cannot-be-parsed-as-url-with-a-nicer-error-message