### PR TITLE
Add verifySignature to example

### DIFF
--- a/examples/pod-gpc-example/src/podExample.ts
+++ b/examples/pod-gpc-example/src/podExample.ts
@@ -182,6 +182,9 @@ export async function podDemo(): Promise<boolean> {
   // recreate it without signing again.
   const loadedPOD = POD.load(sampleEntries, signature, signerPublicKey);
   console.log("Loaded POD content ID", loadedPOD.contentID);
+  if (!loadedPOD.verifySignature()) {
+    throw new Error("Bad POD!");
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   // POD contents can be serialized to/from a JSON-compatible format, which can


### PR DESCRIPTION
Clearing out an old branch of code changes I made migrating example to  pod.org docs.
I realized the example code didn't include any calls to verifySignature(), so added one here.
