### PR TITLE
Add support for React 19 as a peer dependency

### DIFF
--- a/.changeset/clever-berries-kiss.md
+++ b/.changeset/clever-berries-kiss.md
@@ -1,0 +1,25 @@
+---
+"@pcd/zk-eddsa-event-ticket-pcd-ui": patch
+"@pcd/semaphore-signature-pcd-ui": patch
+"@pcd/ethereum-ownership-pcd-ui": patch
+"@pcd/semaphore-identity-pcd-ui": patch
+"@pcd/semaphore-group-pcd-ui": patch
+"@pcd/ethereum-group-pcd-ui": patch
+"@pcd/zk-eddsa-frog-pcd-ui": patch
+"@pcd/passport-interface": patch
+"@pcd/eddsa-ticket-pcd-ui": patch
+"@pcd/eddsa-frog-pcd-ui": patch
+"@pcd/halo-nonce-pcd-ui": patch
+"@pcd/pod-ticket-pcd-ui": patch
+"@pcd/rsa-ticket-pcd-ui": patch
+"@pcd/rsa-image-pcd-ui": patch
+"@pcd/webauthn-pcd-ui": patch
+"@pcd/message-pcd-ui": patch
+"@pcd/passport-ui": patch
+"@pcd/eddsa-pcd-ui": patch
+"@pcd/email-pcd-ui": patch
+"@pcd/rsa-pcd-ui": patch
+"@pcd/zuauth": patch
+---
+
+Add support for React 19 as a peer dependency

--- a/packages/lib/passport-interface/package.json
+++ b/packages/lib/passport-interface/package.json
@@ -99,7 +99,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/lib/passport-ui/package.json
+++ b/packages/lib/passport-ui/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lib/zuauth/package.json
+++ b/packages/lib/zuauth/package.json
@@ -79,7 +79,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/eddsa-frog-pcd-ui/package.json
+++ b/packages/ui/eddsa-frog-pcd-ui/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/eddsa-pcd-ui/package.json
+++ b/packages/ui/eddsa-pcd-ui/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/eddsa-ticket-pcd-ui/package.json
+++ b/packages/ui/eddsa-ticket-pcd-ui/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/email-pcd-ui/package.json
+++ b/packages/ui/email-pcd-ui/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/ethereum-group-pcd-ui/package.json
+++ b/packages/ui/ethereum-group-pcd-ui/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/ethereum-ownership-pcd-ui/package.json
+++ b/packages/ui/ethereum-ownership-pcd-ui/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/halo-nonce-pcd-ui/package.json
+++ b/packages/ui/halo-nonce-pcd-ui/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/message-pcd-ui/package.json
+++ b/packages/ui/message-pcd-ui/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/pod-ticket-pcd-ui/package.json
+++ b/packages/ui/pod-ticket-pcd-ui/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/rsa-image-pcd-ui/package.json
+++ b/packages/ui/rsa-image-pcd-ui/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/rsa-pcd-ui/package.json
+++ b/packages/ui/rsa-pcd-ui/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/rsa-ticket-pcd-ui/package.json
+++ b/packages/ui/rsa-ticket-pcd-ui/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/semaphore-group-pcd-ui/package.json
+++ b/packages/ui/semaphore-group-pcd-ui/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/semaphore-identity-pcd-ui/package.json
+++ b/packages/ui/semaphore-identity-pcd-ui/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/semaphore-signature-pcd-ui/package.json
+++ b/packages/ui/semaphore-signature-pcd-ui/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/webauthn-pcd-ui/package.json
+++ b/packages/ui/webauthn-pcd-ui/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/zk-eddsa-event-ticket-pcd-ui/package.json
+++ b/packages/ui/zk-eddsa-event-ticket-pcd-ui/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/ui/zk-eddsa-frog-pcd-ui/package.json
+++ b/packages/ui/zk-eddsa-frog-pcd-ui/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }


### PR DESCRIPTION
[React 19 now has a stable release](https://react.dev/blog/2024/12/05/react-19) and so we can expect to see third-party apps using it.

Our packages specify that React ^18.2.0 is a supported peer dependency, but this excludes React 19. In initial testing it seems that our packages work with React 19, and so it should be listed as a valid peer dependency.

The effect on third-party developers is that they will be able to use our packages with React 19 without receiving warnings or errors from their package manager, and without having to override those warnings or errors (e.g. by using `--force` or `--legacy-peer-deps` with `npm`).

I've added a changeset for this, which can be used to version-bump the affected packages when this PR is accepted.