### PR TITLE
Constrain entry proofs to Merkle proofs only of names, not values

### DIFF
--- a/packages/lib/gpcircuits/circuits/entry.circom
+++ b/packages/lib/gpcircuits/circuits/entry.circom
@@ -44,6 +44,11 @@ template EntryModule (
     );
     objectContentID === proofRoot;
 
+    // Constrain entry proofs to always refer to the name leaf (even index) not
+    // the value leaf (odd index).  This relies on issuer to ownly sign a
+    // validly constructed POD, with alternating names and values.
+    proofIndices[0] === 0;
+
     // Revealed value hash output gets hash or -1 depending on configuration.
     signal output revealedValueHash <== ValueOrNegativeOne()(proofSiblings[0], isValueHashRevealed);
 }


### PR DESCRIPTION
This adds an extra constraint to prevent a buggy or malicious prover from proving an "entry" based on the Merkle proof of its value rather than its name.  In practice this would have the impact of swapping the role of the name and value hashes in the GPC proof.

Expected Behavior: POD Merkle trees contain leaves containing alternating name hashes (even indices) and value hashes (odd indices).  In normal use, the EntryModule always receives a Merkle proof of the leaf corresponding to the name, and the index is always even.  The corresponding value hash appears as the first sibling in the Merkle proof.

Incorrect Behavior: If a prover instead presents the Merkle proof of the leaf containing the value hash, its index will be odd, and the name hash will appear as the first sibling instead.  The current EntryModule allows this, resulting in swapping the role of name and value hashes as they flow into other modules and constraints.  Since entry names use the same hash algorithm as string/bytes values, this swap won't be rejected by the circuit.  A verifier could accept the resulting proof if the config and revealed claims are similarly altered.

Fix: Add a constraint to EntryModule ensuring that the index is always even (low bit is 0).  Since trust of POD issuers is implicit to the POD+GPC security model, this is sufficient to rule out the swap and accept only Merkle proofs of names.

Security Risk: It is possible to construct POD schemas for which this bug presents an exploitable security risk, particularly if verifiers use the presence of named entries as evidence of some important security property, without revealing or constraining the entry value.  Based on our analysis, no existing use cases in Zupass or known ZApps are subject to that risk.  Since issuers can be assumed to only sign valid data, an exploit would require a value (string or bytes) which collides with an expected name, attached to a name which collides with an expected value, along with semantics where swapping the two results in increased capabilities.
