### PR TITLE
Fix package dependencies

### DIFF
--- a/.changeset/olive-seas-bow.md
+++ b/.changeset/olive-seas-bow.md
@@ -1,0 +1,7 @@
+---
+"@pcd/gpcircuits": patch
+"@pcd/gpc": patch
+"@pcd/pod": patch
+---
+
+Update package dependencies to match code

--- a/packages/lib/gpc/package.json
+++ b/packages/lib/gpc/package.json
@@ -34,7 +34,6 @@
     "@pcd/util": "0.9.0",
     "@semaphore-protocol/core": "^4.5.0",
     "lodash": "^4.17.21",
-    "json-bigint": "^1.0.0",
     "snarkjs": "^0.7.4",
     "url-join": "^4.0.1",
     "valibot": "^0.42.1"

--- a/packages/lib/gpcircuits/package.json
+++ b/packages/lib/gpcircuits/package.json
@@ -45,8 +45,10 @@
   },
   "dependencies": {
     "@pcd/pod": "0.5.0",
+    "@pcd/util": "^0.9.0",
     "buffer": "^6.0.3",
     "fastfile": "0.0.20",
+    "poseidon-lite": "^0.3.0",
     "snarkjs": "^0.7.4",
     "url-join": "4.0.1"
   },
@@ -54,7 +56,6 @@
     "@pcd/eslint-config-custom": "0.15.0",
     "@pcd/semaphore-identity-v3-wrapper": "0.1.0",
     "@pcd/tsconfig": "0.15.0",
-    "@pcd/util": "^0.9.0",
     "@semaphore-protocol/core": "^4.5.0",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
@@ -66,7 +67,6 @@
     "fix-esm-import-path": "^1.10.0",
     "lodash": "^4.17.21",
     "mocha": "^10.2.0",
-    "poseidon-lite": "^0.3.0",
     "ts-mocha": "^10.0.0",
     "typescript": "^5.3.3"
   },

--- a/packages/lib/gpcircuits/tsconfig.cjs.json
+++ b/packages/lib/gpcircuits/tsconfig.cjs.json
@@ -14,10 +14,10 @@
       "path": "../pod/tsconfig.cjs.json"
     },
     {
-      "path": "../semaphore-identity-v3-wrapper/tsconfig.cjs.json"
+      "path": "../util/tsconfig.cjs.json"
     },
     {
-      "path": "../util/tsconfig.cjs.json"
+      "path": "../semaphore-identity-v3-wrapper/tsconfig.cjs.json"
     }
   ]
 }

--- a/packages/lib/gpcircuits/tsconfig.esm.json
+++ b/packages/lib/gpcircuits/tsconfig.esm.json
@@ -14,10 +14,10 @@
       "path": "../pod/tsconfig.esm.json"
     },
     {
-      "path": "../semaphore-identity-v3-wrapper/tsconfig.esm.json"
+      "path": "../util/tsconfig.esm.json"
     },
     {
-      "path": "../util/tsconfig.esm.json"
+      "path": "../semaphore-identity-v3-wrapper/tsconfig.esm.json"
     }
   ]
 }

--- a/packages/lib/gpcircuits/tsconfig.json
+++ b/packages/lib/gpcircuits/tsconfig.json
@@ -8,8 +8,18 @@
     "rootDir": "."
   },
   // Some artifact-including packages need to import a JSON file
-  "include": ["src", "test", "src/*.json", "scripts", "circomkit.json"],
-  "exclude": ["dist", "build", "node_modules"],
+  "include": [
+    "src",
+    "test",
+    "src/*.json",
+    "scripts",
+    "circomkit.json"
+  ],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules"
+  ],
   // DO NOT MODIFY MANUALLY BEYOND THIS POINT
   // References are automatically maintained by `yarn fix-references`
   "references": [
@@ -17,10 +27,10 @@
       "path": "../pod"
     },
     {
-      "path": "../semaphore-identity-v3-wrapper"
+      "path": "../util"
     },
     {
-      "path": "../util"
+      "path": "../semaphore-identity-v3-wrapper"
     }
   ]
 }

--- a/packages/lib/passport-interface/tsconfig.cjs.json
+++ b/packages/lib/passport-interface/tsconfig.cjs.json
@@ -35,6 +35,9 @@
       "path": "../pod/tsconfig.cjs.json"
     },
     {
+      "path": "../../pcd/pod-pcd/tsconfig.cjs.json"
+    },
+    {
       "path": "../../pcd/pod-ticket-pcd/tsconfig.cjs.json"
     },
     {
@@ -42,9 +45,6 @@
     },
     {
       "path": "../../pcd/semaphore-identity-pcd/tsconfig.cjs.json"
-    },
-    {
-      "path": "../../pcd/pod-pcd/tsconfig.cjs.json"
     },
     {
       "path": "../semaphore-identity-v3-wrapper/tsconfig.cjs.json"

--- a/packages/lib/passport-interface/tsconfig.esm.json
+++ b/packages/lib/passport-interface/tsconfig.esm.json
@@ -35,6 +35,9 @@
       "path": "../pod/tsconfig.esm.json"
     },
     {
+      "path": "../../pcd/pod-pcd/tsconfig.esm.json"
+    },
+    {
       "path": "../../pcd/pod-ticket-pcd/tsconfig.esm.json"
     },
     {
@@ -42,9 +45,6 @@
     },
     {
       "path": "../../pcd/semaphore-identity-pcd/tsconfig.esm.json"
-    },
-    {
-      "path": "../../pcd/pod-pcd/tsconfig.esm.json"
     },
     {
       "path": "../semaphore-identity-v3-wrapper/tsconfig.esm.json"

--- a/packages/lib/passport-interface/tsconfig.json
+++ b/packages/lib/passport-interface/tsconfig.json
@@ -46,6 +46,9 @@
       "path": "../pod"
     },
     {
+      "path": "../../pcd/pod-pcd"
+    },
+    {
       "path": "../../pcd/pod-ticket-pcd"
     },
     {
@@ -53,9 +56,6 @@
     },
     {
       "path": "../../pcd/semaphore-identity-pcd"
-    },
-    {
-      "path": "../../pcd/pod-pcd"
     },
     {
       "path": "../semaphore-identity-v3-wrapper"

--- a/packages/lib/pod/package.json
+++ b/packages/lib/pod/package.json
@@ -38,8 +38,8 @@
     "clean": "rm -rf dist node_modules *.tsbuildinfo"
   },
   "dependencies": {
-    "@pcd/util": "0.9.0",
     "@zk-kit/eddsa-poseidon": "^1.1.0",
+    "@zk-kit/baby-jubjub": "^1.0.3",
     "@zk-kit/lean-imt": "^2.2.2",
     "@zk-kit/utils": "^1.2.1",
     "buffer": "^6.0.3",
@@ -52,10 +52,10 @@
     "@pcd/pcd-types": "0.15.0",
     "@pcd/semaphore-identity-v3-wrapper": "0.1.0",
     "@pcd/tsconfig": "0.15.0",
+    "@pcd/util": "0.9.0",
     "@types/chai": "^4.3.5",
     "@types/circomlibjs": "^0.1.6",
     "@types/mocha": "^10.0.1",
-    "@zk-kit/baby-jubjub": "^1.0.3",
     "circomlibjs": "^0.1.7",
     "eslint": "^8.57.0",
     "fix-esm-import-path": "^1.10.0",

--- a/packages/lib/pod/tsconfig.cjs.json
+++ b/packages/lib/pod/tsconfig.cjs.json
@@ -11,9 +11,6 @@
   // References are automatically maintained by `yarn fix-references`
   "references": [
     {
-      "path": "../util/tsconfig.cjs.json"
-    },
-    {
       "path": "../../pcd/eddsa-pcd/tsconfig.cjs.json"
     },
     {
@@ -21,6 +18,9 @@
     },
     {
       "path": "../semaphore-identity-v3-wrapper/tsconfig.cjs.json"
+    },
+    {
+      "path": "../util/tsconfig.cjs.json"
     }
   ]
 }

--- a/packages/lib/pod/tsconfig.esm.json
+++ b/packages/lib/pod/tsconfig.esm.json
@@ -11,9 +11,6 @@
   // References are automatically maintained by `yarn fix-references`
   "references": [
     {
-      "path": "../util/tsconfig.esm.json"
-    },
-    {
       "path": "../../pcd/eddsa-pcd/tsconfig.esm.json"
     },
     {
@@ -21,6 +18,9 @@
     },
     {
       "path": "../semaphore-identity-v3-wrapper/tsconfig.esm.json"
+    },
+    {
+      "path": "../util/tsconfig.esm.json"
     }
   ]
 }

--- a/packages/lib/pod/tsconfig.json
+++ b/packages/lib/pod/tsconfig.json
@@ -22,9 +22,6 @@
   // References are automatically maintained by `yarn fix-references`
   "references": [
     {
-      "path": "../util"
-    },
-    {
       "path": "../../pcd/eddsa-pcd"
     },
     {
@@ -32,6 +29,9 @@
     },
     {
       "path": "../semaphore-identity-v3-wrapper"
+    },
+    {
+      "path": "../util"
     }
   ]
 }


### PR DESCRIPTION
The active fix here is the missing dependency of @pcd/gpcircuits on @pcd/util.  It was listed as a devDependency but used in production code.  At least in some packaging scenario (seen at a hackathon) this lead to the BABY_JUBJUB_PRIME constant being undefined, leading to a type error.  I suspect in most packaging scenarios it is hidden because that same dependency is pulled in by other packages.

I reviewed all the questionable dependencies of @pcd/pod, @pcd/gpcircuits, and @pcd/gpc to see if they matched what was imported in the src directory.  That lead to another missing dependencies being added, and to a few unnecessary dependencies being removed.

With this change I'm also starting to experiment with use of changesets for version management.  These changes are all marked as "patch".

Note that the tsconfig changes in other packages were auto-generated by `yarn fix-references`.
