### PR TITLE
Doc/repo links for POD/GPC packages

### DIFF
--- a/.changeset/rich-rivers-hear.md
+++ b/.changeset/rich-rivers-hear.md
@@ -1,0 +1,11 @@
+---
+"@pcd/gpcircuits": patch
+"@pcd/gpc-pcd-ui": patch
+"@pcd/pod-pcd-ui": patch
+"@pcd/gpc-pcd": patch
+"@pcd/pod-pcd": patch
+"@pcd/gpc": patch
+"@pcd/pod": patch
+---
+
+Update links in README and NPM metadata

--- a/packages/lib/gpc/README.md
+++ b/packages/lib/gpc/README.md
@@ -18,7 +18,7 @@
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/gpc.svg?style=flat-square" />
     </a>
 <br>
-    <a href="https://zupass.org/pod">
+    <a href="https://pod.org/gpc/introduction">
         <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
     </a>
     <a href="https://github.com/proofcarryingdata/zupass/blob/main/examples/pod-gpc-example/src/gpcExample.ts#L88">
@@ -34,7 +34,7 @@
 
 A library for creating and verifying zero-knowledge proofs using General Purpose
 Circuits. For a full introduction, see the
-[Developer Site](https://zupass.org/pod).
+[Developer Site](https://pod.org/gpc/introduction).
 
 **POD** libraries enable any app to create zero-knowledge proofs of cryptographic data. A POD could represent your ticket to an event, a secure
 message, a collectible badge, or an item in a role-playing game. Using PODs,

--- a/packages/lib/gpc/package.json
+++ b/packages/lib/gpc/package.json
@@ -2,6 +2,11 @@
   "name": "@pcd/gpc",
   "version": "0.4.0",
   "license": "GPL-3.0-or-later",
+  "repository": "git@github.com:proofcarryingdata/zupass",
+  "homepage": "https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/gpc",
+  "bugs": {
+    "url": "https://github.com/proofcarryingdata/zupass/issues"
+  },
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",

--- a/packages/lib/gpcircuits/README.md
+++ b/packages/lib/gpcircuits/README.md
@@ -18,7 +18,7 @@
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/gpcircuits.svg?style=flat-square" />
     </a>
 <br>
-    <a href="https://zupass.org/pod">
+    <a href="https://pod.org/gpc/introduction">
         <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
     </a>
     <a href="https://docs.pcd.team/modules/_pcd_gpcircuits.html">
@@ -32,7 +32,7 @@
 A collection of circom circuits and supporting code for zero-knowledge proofs on
 PODs (Provable Object Data) via the GPC (General Purpose Circuits) framework.
 For a full introduction, see the
-[Developer Site](https://zupass.org/pod).
+[Developer Site](https://pod.org/gpc/introduction).
 
 **POD** libraries enable any app to create zero-knowledge proofs of cryptographic data. A POD could represent your ticket to an event, a secure
 message, a collectible badge, or an item in a role-playing game. Using PODs,

--- a/packages/lib/gpcircuits/package.json
+++ b/packages/lib/gpcircuits/package.json
@@ -2,6 +2,11 @@
   "name": "@pcd/gpcircuits",
   "version": "0.5.0",
   "license": "GPL-3.0-or-later",
+  "repository": "git@github.com:proofcarryingdata/zupass",
+  "homepage": "https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/gpcircuits",
+  "bugs": {
+    "url": "https://github.com/proofcarryingdata/zupass/issues"
+  },
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",

--- a/packages/lib/pod/README.md
+++ b/packages/lib/pod/README.md
@@ -18,7 +18,7 @@
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/pod.svg?style=flat-square" />
     </a>
 <br>
-    <a href="https://zupass.org/pod">
+    <a href="https://pod.org/pod/introduction">
         <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
     </a>
     <a href="https://github.com/proofcarryingdata/zupass/blob/main/examples/pod-gpc-example/src/podExample.ts#L57">
@@ -34,7 +34,7 @@
 
 A library for creating and manipulating objects in the Provable Object Data
 format. For a full introduction, see the
-[Developer Site](https://zupass.org/pod).
+[Developer Site](https://pod.org/pod/introduction).
 
 **POD** libraries enable any app to create zero-knowledge proofs of cryptographic data. A POD could represent your ticket to an event, a secure
 message, a collectible badge, or an item in a role-playing game. Using PODs,

--- a/packages/lib/pod/package.json
+++ b/packages/lib/pod/package.json
@@ -2,6 +2,11 @@
   "name": "@pcd/pod",
   "version": "0.5.0",
   "license": "MIT",
+  "repository": "git@github.com:proofcarryingdata/zupass",
+  "homepage": "https://github.com/proofcarryingdata/zupass/tree/main/packages/lib/pod",
+  "bugs": {
+    "url": "https://github.com/proofcarryingdata/zupass/issues"
+  },
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",

--- a/packages/pcd/gpc-pcd/README.md
+++ b/packages/pcd/gpc-pcd/README.md
@@ -18,7 +18,7 @@
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/gpc-pcd.svg?style=flat-square" />
     </a>
 <br>
-    <a href="https://zupass.org/pod">
+    <a href="https://pod.org/gpc/introduction">
         <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
     </a>
     <a href="https://github.com/proofcarryingdata/zupass/blob/main/examples/pod-gpc-example/src/gpcExample.ts#L376">
@@ -34,7 +34,7 @@
 
 A PCD representating a ZK proof about one or more POD (Provable Object Data)
 objects using a GPC (General Purpose Circuit). For a full introduction, see the
-[Developer Site](https://zupass.org/pod).
+[Developer Site](https://pod.org/gpc/introduction).
 
 **POD** libraries enable any app to create zero-knowledge proofs of cryptographic data. A POD could represent your ticket to an event, a secure
 message, a collectible badge, or an item in a role-playing game. Using PODs,

--- a/packages/pcd/gpc-pcd/package.json
+++ b/packages/pcd/gpc-pcd/package.json
@@ -2,6 +2,11 @@
   "name": "@pcd/gpc-pcd",
   "version": "0.4.0",
   "license": "GPL-3.0-or-later",
+  "repository": "git@github.com:proofcarryingdata/zupass",
+  "homepage": "https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/gpc-pcd",
+  "bugs": {
+    "url": "https://github.com/proofcarryingdata/zupass/issues"
+  },
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",

--- a/packages/pcd/pod-pcd/README.md
+++ b/packages/pcd/pod-pcd/README.md
@@ -18,7 +18,7 @@
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/pod-pcd.svg?style=flat-square" />
     </a>
 <br>
-    <a href="https://zupass.org/pod">
+    <a href="https://pod.org/pod/introduction">
         <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
     </a>
     <a href="https://github.com/proofcarryingdata/zupass/blob/main/examples/pod-gpc-example/src/podExample.ts#L214">
@@ -35,7 +35,7 @@
 A PCD representating an object in the **POD** (Provable Object Data) format,
 allowing it to be manipulated by generic apps like Zupass.
 For a full introduction, see the
-[Developer Site](https://zupass.org/pod).
+[Developer Site](https://pod.org/pod/introduction).
 
 **POD** libraries enable any app to create zero-knowledge proofs of cryptographic data. A POD could represent your ticket to an event, a secure
 message, a collectible badge, or an item in a role-playing game. Using PODs,

--- a/packages/pcd/pod-pcd/package.json
+++ b/packages/pcd/pod-pcd/package.json
@@ -2,6 +2,11 @@
   "name": "@pcd/pod-pcd",
   "version": "0.5.0",
   "license": "GPL-3.0-or-later",
+  "repository": "git@github.com:proofcarryingdata/zupass",
+  "homepage": "https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/pod-pcd",
+  "bugs": {
+    "url": "https://github.com/proofcarryingdata/zupass/issues"
+  },
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",

--- a/packages/ui/gpc-pcd-ui/README.md
+++ b/packages/ui/gpc-pcd-ui/README.md
@@ -18,7 +18,7 @@
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/gpc-pcd-ui.svg?style=flat-square" />
     </a>
 <br>
-    <a href="https://zupass.org/pod">
+    <a href="https://pod.org/gpc/introduction">
         <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
     </a>
     <a href="https://docs.pcd.team/modules/_pcd_gpc_pcd_ui.html">
@@ -33,4 +33,4 @@ This package provides React UI for
 [`@pcd/gpc-pcd`](https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/gpc-pcd).
 See that package for more details on functionality.
 
-For a full introduction, see the [Developer Site](https://zupass.org/pod).
+For a full introduction, see the [Developer Site](https://pod.org/gpc/introduction).

--- a/packages/ui/gpc-pcd-ui/package.json
+++ b/packages/ui/gpc-pcd-ui/package.json
@@ -2,6 +2,11 @@
   "name": "@pcd/gpc-pcd-ui",
   "version": "0.4.0",
   "license": "GPL-3.0-or-later",
+  "repository": "git@github.com:proofcarryingdata/zupass",
+  "homepage": "https://github.com/proofcarryingdata/zupass/tree/main/packages/ui/gpc-pcd-ui",
+  "bugs": {
+    "url": "https://github.com/proofcarryingdata/zupass/issues"
+  },
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",

--- a/packages/ui/gpc-pcd-ui/src/CardBody.tsx
+++ b/packages/ui/gpc-pcd-ui/src/CardBody.tsx
@@ -41,7 +41,7 @@ function GPCCardBody({ pcd }: { pcd: GPCPCD }): JSX.Element {
       <p>
         This is a ZK proof of info about PODs using a General Purpose Circuit.
         You can learn more about PODs and GPCs{" "}
-        <a href="https://zupass.org/pod">here</a>.
+        <a href="https://pod.org/pod/introduction">here</a>.
       </p>
 
       <Separator />

--- a/packages/ui/pod-pcd-ui/README.md
+++ b/packages/ui/pod-pcd-ui/README.md
@@ -18,7 +18,7 @@
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@pcd/pod-pcd-ui.svg?style=flat-square" />
     </a>
 <br>
-    <a href="https://zupass.org/pod">
+    <a href="https://pod.org/pod/introduction">
         <img alt="Developer Site" src="https://img.shields.io/badge/Developer_Site-green.svg?style=flat-square">
     </a>
     <a href="https://docs.pcd.team/modules/_pcd_pod_pcd_ui.html">
@@ -33,4 +33,4 @@ This package provides React UI for
 [`@pcd/pod-pcd`](https://github.com/proofcarryingdata/zupass/tree/main/packages/pcd/pod-pcd).
 See that package for more details on functionality.
 
-For a full introduction, see the [Developer Site](https://zupass.org/pod).
+For a full introduction, see the [Developer Site](https://pod.org/pod/introduction).

--- a/packages/ui/pod-pcd-ui/package.json
+++ b/packages/ui/pod-pcd-ui/package.json
@@ -2,6 +2,11 @@
   "name": "@pcd/pod-pcd-ui",
   "version": "0.5.0",
   "license": "GPL-3.0-or-later",
+  "repository": "git@github.com:proofcarryingdata/zupass",
+  "homepage": "https://github.com/proofcarryingdata/zupass/tree/main/packages/ui/pod-pcd-ui",
+  "bugs": {
+    "url": "https://github.com/proofcarryingdata/zupass/issues"
+  },
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",


### PR DESCRIPTION
Cleanup in README to decouple docs from the old site, and reliance on zupass.org.  Also added github links to package.json for NPM metadata, useful to devs when viewing on npmjs.com
