### PR TITLE
Retroactive changeset for PR #2199

### DIFF
--- a/.changeset/afraid-news-look.md
+++ b/.changeset/afraid-news-look.md
@@ -1,0 +1,14 @@
+---
+"@pcd/gpcircuits": patch
+"@pcd/passport-ui": patch
+"@pcd/pod": patch
+"@pcd/eddsa-ticket-pcd": patch
+"@pcd/ethereum-group-pcd": patch
+"@pcd/halo-nonce-pcd": patch
+"@pcd/message-pcd": patch
+"@pcd/rsa-pcd": patch
+"@pcd/semaphore-identity-pcd": patch
+"@pcd/pod-ticket-pcd-ui": patch
+---
+
+Add direct import of Buffer to avoid need for polyfill


### PR DESCRIPTION
Retroactive changeset for PR #2199 

Based on a review of diffs since our last NPM package release, this is the only change which affects POD/GPC packages, and deserves to be mentioned in release notes.  I'm trying to retroactively follow the right process so that `yarn changeset` can be used to do a release manual manipulation of version numbers.
